### PR TITLE
Add release profile

### DIFF
--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -6,6 +6,11 @@ license = "UPL-1.0"
 edition = "2018"
 links = "app"
 
+[profile.release]
+lto = true
+strip = "debuginfo"
+codegen-units = 1
+
 [lib]
 name = "host"
 path = "src/lib.rs"


### PR DESCRIPTION
This PR
- Add a release profile for cargo so that optimised builds are significantly smaller

### Before change
```
17:16:21 ~/Documents/GitHub/basic-webserver release-profile $ roc build --optimize examples/echo.roc 
🔨 Rebuilding platform...
0 errors and 0 warnings found in 21972 ms while successfully building:

    examples/echo
17:17:22 ~/Documents/GitHub/basic-webserver release-profile $ ls -hl examples/echo 
-rwxr-xr-x  1 luke  staff   9.3M 18 Nov 17:20 examples/echo
```

### After change (with `--optimize`)
```
17:17:31 ~/Documents/GitHub/basic-webserver release-profile $ roc build --optimize examples/echo.roc
🔨 Rebuilding platform...
0 errors and 0 warnings found in 5589 ms while successfully building:

    examples/echo
17:17:44 ~/Documents/GitHub/basic-webserver release-profile $ ls -hl examples/echo                  
-rwxr-xr-x  1 luke  staff   7.2M 18 Nov 17:17 examples/echo
```