### PR TITLE
Sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ examples/file
 examples/dir
 examples/env
 examples/command
+examples/sqlite3

--- a/examples/command.roc
+++ b/examples/command.roc
@@ -13,16 +13,16 @@ main = \req ->
 
     # Log request date, method and url using echo program
     date <- Utc.now |> Task.map Utc.toIso8601Str |> Task.await
-    result <- 
+    result <-
         Command.new "echo"
         |> Command.arg "\(date) \(Http.methodToStr req.method) \(req.url)"
         |> Command.status
         |> Task.attempt
 
-    when result is 
+    when result is
         Ok {} -> respond "Command succeeded\n"
         Err (ExitCode code) -> respond "Command exited with code \(Num.toStr code)\n"
-        Err (KilledBySignal) -> respond "Command was killed by signal\n"
+        Err KilledBySignal -> respond "Command was killed by signal\n"
         Err (IOError str) -> respond "IO Error: \(str)\n"
 
 respond = \str -> Task.ok { status: 200, headers: [], body: Str.toUtf8 str }

--- a/examples/http.roc
+++ b/examples/http.roc
@@ -42,13 +42,13 @@ logRequest = \req ->
 
 readUrlEnv : Str -> Task Str AppError
 readUrlEnv = \target ->
-    Env.var target 
+    Env.var target
     |> Task.mapErr \_ -> EnvURLNotFound
 
 fetchContent : Str -> Task Str AppError
 fetchContent = \url ->
-    Http.getUtf8 url 
-    |> Task.mapErr \err -> (HttpError err)
+    Http.getUtf8 url
+    |> Task.mapErr \err -> HttpError err
 
 handleErr : AppError -> Task Response []
 handleErr = \err ->

--- a/examples/sleep.roc
+++ b/examples/sleep.roc
@@ -18,7 +18,7 @@ main = \_ ->
     # Sleep for 1 second
     {} <- Sleep.millis 1000 |> Task.await
 
-    # Deplayed Http response 
+    # Deplayed Http response
     body = Str.toUtf8 "Response delayed by 1 second\n"
     headers = []
     status = 200

--- a/examples/sqlite3.roc
+++ b/examples/sqlite3.roc
@@ -19,8 +19,8 @@ main = \_ ->
     result <-
         SQLite3.execute {
             path: maybeDbPath |> Result.withDefault "<DB_PATH> not set on environment",
-            query: "SELECT * FROM todos;",
-            bindings: [],
+            query: "SELECT * FROM todos WHERE status = :status;",
+            bindings: [{name : ":status", value : "completed"}],
         }
         |> Task.attempt
 

--- a/examples/sqlite3.roc
+++ b/examples/sqlite3.roc
@@ -1,0 +1,34 @@
+app "echo"
+    packages { pf: "../platform/main.roc" }
+    imports [
+        pf.Stdout,
+        pf.Task.{ Task },
+        pf.Http.{ Request, Response },
+        pf.SQLite3,
+    ]
+    provides [main] to pf
+
+main : Request -> Task Response []
+main = \_ ->
+
+    query = 
+        """
+        CREATE TABLE things (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL
+        );
+        """
+
+    result <- SQLite3.execute "test.db" query |> Task.attempt
+
+    body = when result is 
+        Ok {} -> "Success!!"
+        Err err -> "Error!! $(SQLite3.errToStr err)" 
+
+    {} <- Stdout.line body |> Task.await
+
+    Task.ok {
+        status: 200, 
+        headers: [{ name: "Content-Type", value: Str.toUtf8 "text/html; charset=utf-8" }], 
+        body: Str.toUtf8 body,
+    }

--- a/examples/sqlite3.roc
+++ b/examples/sqlite3.roc
@@ -19,15 +19,15 @@ main = \_ ->
     result <-
         SQLite3.execute {
             path: maybeDbPath |> Result.withDefault "<DB_PATH> not set on environment",
-            query: "SELECT * FROM todos WHERE status = :status;",
-            bindings: [{name : ":status", value : "completed"}],
+            query: "SELECT id, task FROM todos WHERE status = :status;",
+            bindings: [{ name: ":status", value: "completed" }],
         }
         |> Task.attempt
 
     # Print out the results
     body =
         when result is
-            Ok rows -> "$(Inspect.toStr rows)"
+            Ok rows -> parseCompletedTodos rows |> Str.joinWith "\n"
             Err err -> crash "$(SQLite3.errToStr err)"
 
     {} <- Stdout.line body |> Task.await
@@ -37,3 +37,11 @@ main = \_ ->
         headers: [{ name: "Content-Type", value: Str.toUtf8 "text/html; charset=utf-8" }],
         body: Str.toUtf8 body,
     }
+
+parseCompletedTodos : List (List SQLite3.Value) -> List Str
+parseCompletedTodos = \rows ->
+    rows
+    |> List.map \cols ->
+        when cols is
+            [Integer id, String task] -> "row $(Num.toStr id), task: $(task)"
+            _ -> crash "unexpected values returned, expected Integer and String got $(Inspect.toStr cols)"

--- a/platform/Cargo.lock
+++ b/platform/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "roc_app",
  "roc_fn",
  "roc_std",
+ "sqlite",
  "tokio",
 ]
 
@@ -486,6 +487,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "pretty_assertions"
@@ -799,6 +806,36 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "sqlite"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78a97f6ee5b054b7cfddc3b6613fdea4c77af2ef8f8aac3048c7d0be31e605e3"
+dependencies = [
+ "libc",
+ "sqlite3-sys",
+]
+
+[[package]]
+name = "sqlite3-src"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9448d45899495acd1a46b0b888ae9747c13551fb0d8f4a60ab485da52b040503"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "sqlite3-sys"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aed0b61828382e1103930d2d5df1972d493173319730b481192e63d929097321"
+dependencies = [
+ "libc",
+ "sqlite3-src",
+]
 
 [[package]]
 name = "static_assertions"

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -43,5 +43,6 @@ reqwest = { version = "0.11.11", default-features = false, features = [
 futures = "0.3"
 backtrace = "0.3.68"
 bytes = "1.0"
+sqlite = "0.33.0"
 
 [workspace]

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -43,6 +43,6 @@ reqwest = { version = "0.11.11", default-features = false, features = [
 futures = "0.3"
 backtrace = "0.3.68"
 bytes = "1.0"
-sqlite = "0.33.0"
+sqlite = { version = "0.33.0", features = ["bundled"] }
 
 [workspace]

--- a/platform/Command.roc
+++ b/platform/Command.roc
@@ -148,13 +148,13 @@ clearEnvs = \@Command cmd ->
 ##     |> Command.arg "SELECT id, task, status FROM todos;"
 ##     |> Command.output
 ##     |> Task.await
-## 
+##
 ## when output.status is
 ##     Ok {} -> jsonResponse output.stdout
 ##     Err _ -> byteResponse 500 output.stderr
 ## ```
 output : Command -> Task Output *
-output = \@Command cmd -> 
+output = \@Command cmd ->
     Effect.commandOutput (Box.box cmd)
     |> Effect.map (\out -> Ok out)
     |> InternalTask.fromEffect
@@ -163,13 +163,13 @@ output = \@Command cmd ->
 ## ```
 ## # Log request date, method and url using echo program
 ## date <- Utc.now |> Task.map Utc.toIso8601Str |> Task.await
-## result <- 
+## result <-
 ##     Command.new "echo"
 ##     |> Command.arg "\(date) \(Http.methodToStr req.method) \(req.url)"
 ##     |> Command.status
 ##     |> Task.attempt
-## 
-## when result is 
+##
+## when result is
 ##     Ok {} -> respond "Command succeeded\n"
 ##     Err (ExitCode code) -> respond "Command exited with code \(Num.toStr code)\n"
 ##     Err (KilledBySignal) -> respond "Command was killed by signal\n"

--- a/platform/Effect.roc
+++ b/platform/Effect.roc
@@ -41,6 +41,7 @@ hosted Effect
         InternalTcp,
         InternalCommand,
         InternalError,
+        InternalSQL,
     ]
     generates Effect with [after, map, always, forever, loop]
 
@@ -54,7 +55,7 @@ stderrLine : Str -> Effect {}
 stderrWrite : Str -> Effect {}
 stderrFlush : Effect {}
 
-# File 
+# File
 fileWriteBytes : List U8, List U8 -> Effect (Result {} InternalFile.WriteErr)
 fileWriteUtf8 : List U8, Str -> Effect (Result {} InternalFile.WriteErr)
 fileDelete : List U8 -> Effect (Result {} InternalFile.WriteErr)
@@ -89,4 +90,4 @@ commandStatus : Box InternalCommand.InternalCommand -> Effect (Result {} Interna
 commandOutput : Box InternalCommand.InternalCommand -> Effect InternalCommand.InternalOutput
 
 # SQLite3
-sqliteExecute : Str, Str -> Effect (Result {} InternalError.SQLiteError)
+sqliteExecute : Str, Str, List InternalSQL.SQLiteBindings -> Effect (Result (List (List InternalSQL.SQLiteValue)) InternalSQL.SQLiteError)

--- a/platform/Effect.roc
+++ b/platform/Effect.roc
@@ -33,6 +33,7 @@ hosted Effect
         sleepMillis,
         commandStatus,
         commandOutput,
+        sqliteExecute,
     ]
     imports [
         InternalHttp,
@@ -86,3 +87,6 @@ sleepMillis : U64 -> Effect {}
 
 commandStatus : Box InternalCommand.InternalCommand -> Effect (Result {} InternalCommand.InternalCommandErr)
 commandOutput : Box InternalCommand.InternalCommand -> Effect InternalCommand.InternalOutput
+
+# SQLite3
+sqliteExecute : Str, Str -> Effect (Result {} InternalError.SQLiteError)

--- a/platform/EnvDecoding.roc
+++ b/platform/EnvDecoding.roc
@@ -1,27 +1,27 @@
 interface EnvDecoding exposes [EnvFormat, format] imports []
 
 EnvFormat := {} implements [
-    DecoderFormatting {
-        u8: envU8,
-        u16: envU16,
-        u32: envU32,
-        u64: envU64,
-        u128: envU128,
-        i8: envI8,
-        i16: envI16,
-        i32: envI32,
-        i64: envI64,
-        i128: envI128,
-        f32: envF32,
-        f64: envF64,
-        dec: envDec,
-        bool: envBool,
-        string: envString,
-        list: envList,
-        record: envRecord,
-        tuple: envTuple,
-    },
-]
+        DecoderFormatting {
+            u8: envU8,
+            u16: envU16,
+            u32: envU32,
+            u64: envU64,
+            u128: envU128,
+            i8: envI8,
+            i16: envI16,
+            i32: envI32,
+            i64: envI64,
+            i128: envI128,
+            f32: envF32,
+            f64: envF64,
+            dec: envDec,
+            bool: envBool,
+            string: envString,
+            list: envList,
+            record: envRecord,
+            tuple: envTuple,
+        },
+    ]
 
 format : {} -> EnvFormat
 format = \{} -> @EnvFormat {}

--- a/platform/Http.roc
+++ b/platform/Http.roc
@@ -68,7 +68,7 @@ defaultRequest = {
 ## See common headers [here](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields).
 ##
 header : Str, Str -> Header
-header = \name, value -> { name, value : Str.toUtf8 value }
+header = \name, value -> { name, value: Str.toUtf8 value }
 
 ## An empty HTTP request [Body].
 emptyBody : Body
@@ -84,7 +84,7 @@ emptyBody =
 ##     [123, 125]
 ## ```
 bytesBody : Str, List U8 -> Body
-bytesBody = \mimeType, body -> Body { mimeType, body}
+bytesBody = \mimeType, body -> Body { mimeType, body }
 
 ## A request [Body] with a string.
 ##
@@ -94,7 +94,7 @@ bytesBody = \mimeType, body -> Body { mimeType, body}
 ##     "{\"name\": \"Louis\",\"age\": 22}"
 ## ```
 stringBody : Str, Str -> Body
-stringBody = \mimeType, str -> Body {mimeType, body: (Str.toUtf8 str)}
+stringBody = \mimeType, str -> Body { mimeType, body: Str.toUtf8 str }
 
 # jsonBody : a -> Body where a implements Encoding
 # jsonBody = \val ->
@@ -120,26 +120,25 @@ stringBody = \mimeType, str -> Body {mimeType, body: (Str.toUtf8 str)}
 # stringPart = \name, str ->
 #     Part name (Str.toUtf8 str)
 
-
 ## Map a [Response] body to a [Str] or return an [Error].
 handleStringResponse : Response -> Result Str Error
 handleStringResponse = \response ->
-    response.body 
-    |> Str.fromUtf8 
-    |> Result.mapErr \_ -> BadBody "" #TODO FIX THIS FUNCTION
+    response.body
+    |> Str.fromUtf8
+    |> Result.mapErr \_ -> BadBody "" # TODO FIX THIS FUNCTION
 
-    # when response is
-    #     BadRequest err -> Err (BadRequest err)
-    #     Timeout -> Err Timeout
-    #     NetworkError -> Err NetworkError
-    #     BadStatus metadata _ -> Err (BadStatus metadata.statusCode)
-    #     GoodStatus _ bodyBytes ->
-    #         Str.fromUtf8 bodyBytes
-    #         |> Result.mapErr
-    #             \BadUtf8 _ pos ->
-    #                 position = Num.toStr pos
+# when response is
+#     BadRequest err -> Err (BadRequest err)
+#     Timeout -> Err Timeout
+#     NetworkError -> Err NetworkError
+#     BadStatus metadata _ -> Err (BadStatus metadata.statusCode)
+#     GoodStatus _ bodyBytes ->
+#         Str.fromUtf8 bodyBytes
+#         |> Result.mapErr
+#             \BadUtf8 _ pos ->
+#                 position = Num.toStr pos
 
-    #                 BadBody "Invalid UTF-8 at byte offset \(position)"
+#                 BadBody "Invalid UTF-8 at byte offset \(position)"
 
 ## Convert an [Error] to a [Str].
 errorToString : Error -> Str

--- a/platform/InternalDateTime.roc
+++ b/platform/InternalDateTime.roc
@@ -114,45 +114,46 @@ epochMillisToDateTime = \millis ->
 epochMillisToDateTimeHelp : DateTime -> DateTime
 epochMillisToDateTimeHelp = \current ->
     countDaysInMonth = daysInMonth current.year current.month
-    countDaysInPrevMonth = 
-        if current.month == 1 then daysInMonth (current.year - 1) 12 
-        else daysInMonth current.year (current.month - 1)
+    countDaysInPrevMonth =
+        if current.month == 1 then
+            daysInMonth (current.year - 1) 12
+        else
+            daysInMonth current.year (current.month - 1)
 
-        if current.day < 1 then
-            epochMillisToDateTimeHelp {
-                current &
+    if current.day < 1 then
+        epochMillisToDateTimeHelp
+            { current &
                 year: if current.month == 1 then current.year - 1 else current.year,
                 month: if current.month == 1 then 12 else current.month - 1,
                 day: current.day + countDaysInPrevMonth,
             }
-        else if current.hours < 0 then
-            epochMillisToDateTimeHelp {
-                current &
+    else if current.hours < 0 then
+        epochMillisToDateTimeHelp
+            { current &
                 day: current.day - 1,
-                hours: current.hours + 24
+                hours: current.hours + 24,
             }
-        else if current.minutes < 0 then
-            epochMillisToDateTimeHelp {
-                current &
+    else if current.minutes < 0 then
+        epochMillisToDateTimeHelp
+            { current &
                 hours: current.hours - 1,
                 minutes: current.minutes + 60,
             }
-        else if current.seconds < 0 then
-            epochMillisToDateTimeHelp {
-                current &
+    else if current.seconds < 0 then
+        epochMillisToDateTimeHelp
+            { current &
                 minutes: current.minutes - 1,
                 seconds: current.seconds + 60,
             }
-        else if current.day > countDaysInMonth then
-            epochMillisToDateTimeHelp {
-                current &
+    else if current.day > countDaysInMonth then
+        epochMillisToDateTimeHelp
+            { current &
                 year: if current.month == 12 then current.year + 1 else current.year,
                 month: if current.month == 12 then 1 else current.month + 1,
                 day: current.day - countDaysInMonth,
             }
-        else
-            current
-
+    else
+        current
 
 # test 1000 ms before epoch
 expect
@@ -170,7 +171,7 @@ expect
     str == "1969-12-01T00:00:00Z"
 
 # test 1 year before epoch
-expect 
+expect
     str = (-1 * 365 * 24 * 60 * 60 * 1000) |> epochMillisToDateTime |> toIso8601Str
     str == "1969-01-01T00:00:00Z"
 
@@ -180,7 +181,7 @@ expect
     str == "1968-01-01T00:00:00Z"
 
 # test last day of 1st year after epoch
-expect 
+expect
     str = (364 * 24 * 60 * 60 * 1000) |> epochMillisToDateTime |> toIso8601Str
     str == "1970-12-31T00:00:00Z"
 

--- a/platform/InternalError.roc
+++ b/platform/InternalError.roc
@@ -1,5 +1,11 @@
 interface InternalError
-    exposes [InternalError, InternalDirReadErr, InternalDirDeleteErr]
+    exposes [
+        InternalError, 
+        InternalDirReadErr, 
+        InternalDirDeleteErr, 
+        SQLiteErrCode,
+        SQLiteError,
+    ]
     imports [Path.{ Path }]
 
 InternalError : [
@@ -10,3 +16,42 @@ InternalError : [
 InternalDirReadErr : [DirReadErr Path Str]
 
 InternalDirDeleteErr : [DirDeleteErr Path Str]
+
+SQLiteErrCode : [
+    ERROR,        # SQL error or missing database
+    INTERNAL,     # Internal logic error in SQLite
+    PERM,         # Access permission denied
+    ABORT,        # Callback routine requested an abort
+    BUSY,         # The database file is locked
+    LOCKED,       # A table in the database is locked
+    NOMEM,        # A malloc() failed
+    READONLY,     # Attempt to write a readonly database
+    INTERRUPT,    # Operation terminated by sqlite3_interrupt(
+    IOERR,        # Some kind of disk I/O error occurred
+    CORRUPT,      # The database disk image is malformed
+    NOTFOUND,     # Unknown opcode in sqlite3_file_control()
+    FULL,         # Insertion failed because database is full
+    CANTOPEN,     # Unable to open the database file
+    PROTOCOL,     # Database lock protocol error
+    EMPTY,        # Database is empty
+    SCHEMA,       # The database schema changed
+    TOOBIG,       # String or BLOB exceeds size limit
+    CONSTRAINT,   # Abort due to constraint violation
+    MISMATCH,     # Data type mismatch
+    MISUSE,       # Library used incorrectly
+    NOLFS,        # Uses OS features not supported on host
+    AUTH,         # Authorization denied
+    FORMAT,       # Auxiliary database format error
+    RANGE,        # 2nd parameter to sqlite3_bind out of range
+    NOTADB,       # File opened that is not a database file
+    NOTICE,       # Notifications from sqlite3_log()
+    WARNING,      # Warnings from sqlite3_log()
+    ROW,          # sqlite3_step() has another row ready
+    DONE,         # sqlite3_step() has finished executing
+]
+
+SQLiteError : {
+    code : I64,
+    message : Str,
+}
+

--- a/platform/InternalError.roc
+++ b/platform/InternalError.roc
@@ -1,57 +1,16 @@
 interface InternalError
     exposes [
-        InternalError, 
-        InternalDirReadErr, 
-        InternalDirDeleteErr, 
-        SQLiteErrCode,
-        SQLiteError,
+        InternalError,
+        InternalDirReadErr,
+        InternalDirDeleteErr,
     ]
     imports [Path.{ Path }]
 
 InternalError : [
-    IOError Str, 
+    IOError Str,
     EOF,
 ]
 
 InternalDirReadErr : [DirReadErr Path Str]
 
 InternalDirDeleteErr : [DirDeleteErr Path Str]
-
-SQLiteErrCode : [
-    ERROR,        # SQL error or missing database
-    INTERNAL,     # Internal logic error in SQLite
-    PERM,         # Access permission denied
-    ABORT,        # Callback routine requested an abort
-    BUSY,         # The database file is locked
-    LOCKED,       # A table in the database is locked
-    NOMEM,        # A malloc() failed
-    READONLY,     # Attempt to write a readonly database
-    INTERRUPT,    # Operation terminated by sqlite3_interrupt(
-    IOERR,        # Some kind of disk I/O error occurred
-    CORRUPT,      # The database disk image is malformed
-    NOTFOUND,     # Unknown opcode in sqlite3_file_control()
-    FULL,         # Insertion failed because database is full
-    CANTOPEN,     # Unable to open the database file
-    PROTOCOL,     # Database lock protocol error
-    EMPTY,        # Database is empty
-    SCHEMA,       # The database schema changed
-    TOOBIG,       # String or BLOB exceeds size limit
-    CONSTRAINT,   # Abort due to constraint violation
-    MISMATCH,     # Data type mismatch
-    MISUSE,       # Library used incorrectly
-    NOLFS,        # Uses OS features not supported on host
-    AUTH,         # Authorization denied
-    FORMAT,       # Auxiliary database format error
-    RANGE,        # 2nd parameter to sqlite3_bind out of range
-    NOTADB,       # File opened that is not a database file
-    NOTICE,       # Notifications from sqlite3_log()
-    WARNING,      # Warnings from sqlite3_log()
-    ROW,          # sqlite3_step() has another row ready
-    DONE,         # sqlite3_step() has finished executing
-]
-
-SQLiteError : {
-    code : I64,
-    message : Str,
-}
-

--- a/platform/InternalFile.roc
+++ b/platform/InternalFile.roc
@@ -12,7 +12,7 @@ ReadErr : [
     TimedOut,
     StaleNetworkFileHandle,
     OutOfMemory,
-    Unsupported, # e.g. trying to read from a directory 
+    Unsupported, # e.g. trying to read from a directory
     Unrecognized I32 Str,
 ]
 

--- a/platform/InternalHttp.roc
+++ b/platform/InternalHttp.roc
@@ -1,13 +1,13 @@
 interface InternalHttp
     exposes [
-        InternalRequest, 
-        InternalMethod, 
-        InternalHeader, 
-        InternalTimeoutConfig, 
-        InternalPart, 
-        InternalBody, 
-        InternalResponse, 
-        InternalMetadata, 
+        InternalRequest,
+        InternalMethod,
+        InternalHeader,
+        InternalTimeoutConfig,
+        InternalPart,
+        InternalBody,
+        InternalResponse,
+        InternalMetadata,
         InternalError,
     ]
     imports []
@@ -22,7 +22,7 @@ InternalRequest : {
 
 InternalMethod : [Options, Get, Post, Put, Delete, Head, Trace, Connect, Patch]
 
-InternalHeader : { name : Str, value: List U8 }
+InternalHeader : { name : Str, value : List U8 }
 
 # Name is distinguished from the Timeout tag used in InternalResponse and InternalError
 InternalTimeoutConfig : [TimeoutMilliseconds U64, NoTimeout]
@@ -34,9 +34,9 @@ InternalBody : [
     EmptyBody,
 ]
 
-InternalBodyBody : { mimeType: Str, body: List U8} # separate definition to help out glue gen
+InternalBodyBody : { mimeType : Str, body : List U8 } # separate definition to help out glue gen
 
-InternalResponse : { status : U16, headers : List InternalHeader, body: List U8 }
+InternalResponse : { status : U16, headers : List InternalHeader, body : List U8 }
 
 InternalMetadata : {
     url : Str,

--- a/platform/InternalSQL.roc
+++ b/platform/InternalSQL.roc
@@ -1,0 +1,59 @@
+interface InternalSQL
+    exposes [
+        SQLiteErrCode,
+        SQLiteError,
+        SQLiteValue,
+        SQLiteBindings,
+    ]
+    imports []
+
+SQLiteErrCode : [
+    ERROR, # SQL error or missing database
+    INTERNAL, # Internal logic error in SQLite
+    PERM, # Access permission denied
+    ABORT, # Callback routine requested an abort
+    BUSY, # The database file is locked
+    LOCKED, # A table in the database is locked
+    NOMEM, # A malloc() failed
+    READONLY, # Attempt to write a readonly database
+    INTERRUPT, # Operation terminated by sqlite3_interrupt(
+    IOERR, # Some kind of disk I/O error occurred
+    CORRUPT, # The database disk image is malformed
+    NOTFOUND, # Unknown opcode in sqlite3_file_control()
+    FULL, # Insertion failed because database is full
+    CANTOPEN, # Unable to open the database file
+    PROTOCOL, # Database lock protocol error
+    EMPTY, # Database is empty
+    SCHEMA, # The database schema changed
+    TOOBIG, # String or BLOB exceeds size limit
+    CONSTRAINT, # Abort due to constraint violation
+    MISMATCH, # Data type mismatch
+    MISUSE, # Library used incorrectly
+    NOLFS, # Uses OS features not supported on host
+    AUTH, # Authorization denied
+    FORMAT, # Auxiliary database format error
+    RANGE, # 2nd parameter to sqlite3_bind out of range
+    NOTADB, # File opened that is not a database file
+    NOTICE, # Notifications from sqlite3_log()
+    WARNING, # Warnings from sqlite3_log()
+    ROW, # sqlite3_step() has another row ready
+    DONE, # sqlite3_step() has finished executing
+]
+
+SQLiteError : {
+    code : I64,
+    message : Str,
+}
+
+SQLiteValue : [
+    Null,
+    Real F64,
+    Integer I64,
+    String Str,
+    Bytes (List U8),
+]
+
+SQLiteBindings : {
+    name : Str,
+    value : Str,
+}

--- a/platform/SQLite3.roc
+++ b/platform/SQLite3.roc
@@ -1,19 +1,26 @@
 interface SQLite3
     exposes [
+        Value,
+        Code,
+        Error,
+        Binding,
         execute,
         errToStr,
     ]
     imports [InternalTask, Task.{ Task }, InternalSQL, Effect]
 
-SQLErrorMessage : [SQLError InternalSQL.SQLiteErrCode Str]
+Value : InternalSQL.SQLiteValue
+Code : InternalSQL.SQLiteErrCode
+Error : [SQLError Code Str]
+Binding : InternalSQL.SQLiteBindings
 
 execute :
     {
         path : Str,
         query : Str,
-        bindings : List InternalSQL.SQLiteBindings,
+        bindings : List Binding,
     }
-    -> Task (List (List InternalSQL.SQLiteValue)) SQLErrorMessage
+    -> Task (List (List InternalSQL.SQLiteValue)) Error
 execute = \{ path, query, bindings } ->
     result <-
         Effect.sqliteExecute path query bindings
@@ -89,7 +96,7 @@ codeFromI64 = \code ->
     else
         crash "unsupported SQLite error code $(Num.toStr code)"
 
-errToStr : SQLErrorMessage -> Str
+errToStr : Error -> Str
 errToStr = \err ->
     (code, msg2) =
         when err is

--- a/platform/SQLite3.roc
+++ b/platform/SQLite3.roc
@@ -1,0 +1,149 @@
+interface SQLite3
+    exposes [
+        Types,
+        execute,
+        errToStr,
+    ]
+    imports [InternalTask, Task.{ Task }, InternalError, Effect]
+
+Types : [
+    F64,
+    I64,
+    String,
+    Bytes,
+    OptionalF64,
+    OptionalI64,
+    OptionalString,
+    OptionalBytes,
+]
+
+Code : InternalError.SQLiteErrCode
+
+SQLErrorMessage : [SQLError Code Str]
+
+execute : Str, Str -> Task {} SQLErrorMessage
+execute = \dbPath, query ->
+    result <- 
+        Effect.sqliteExecute dbPath query
+        |> InternalTask.fromEffect
+        |> Task.attempt
+
+    when result is 
+        Ok {} -> Task.ok {}
+        Err {code, message} -> Task.err (SQLError (codeFromI64 code) message)
+
+codeFromI64 : I64 -> InternalError.SQLiteErrCode
+codeFromI64 = \code ->
+    if code == 1 then 
+        ERROR
+    else if code == 2 then 
+        INTERNAL
+    else if code == 3 then 
+        PERM
+    else if code == 4 then 
+        ABORT
+    else if code == 5 then 
+        BUSY
+    else if code == 6 then 
+        LOCKED
+    else if code == 7 then 
+        NOMEM
+    else if code == 8 then 
+        READONLY
+    else if code == 9 then 
+        INTERRUPT
+    else if code == 10 then 
+        IOERR
+    else if code == 11 then 
+        CORRUPT
+    else if code == 12 then 
+        NOTFOUND
+    else if code == 13 then 
+        FULL
+    else if code == 14 then 
+        CANTOPEN
+    else if code == 15 then 
+        PROTOCOL
+    else if code == 16 then 
+        EMPTY
+    else if code == 17 then 
+        SCHEMA
+    else if code == 18 then 
+        TOOBIG
+    else if code == 19 then 
+        CONSTRAINT
+    else if code == 20 then 
+        MISMATCH
+    else if code == 21 then 
+        MISUSE
+    else if code == 22 then 
+        NOLFS
+    else if code == 23 then 
+        AUTH
+    else if code == 24 then 
+        FORMAT
+    else if code == 25 then 
+        RANGE
+    else if code == 26 then 
+        NOTADB
+    else if code == 27 then 
+        NOTICE
+    else if code == 28 then 
+        WARNING
+    else if code == 100 then 
+        ROW
+    else if code == 101 then 
+        DONE
+    else 
+        crash "unsupported SQLite error code $(Num.toStr code)"
+
+errToStr : SQLErrorMessage -> Str 
+errToStr = \err ->
+    (code, msg2 ) = 
+        when err is 
+            SQLError c m -> (c,m) 
+
+    msg1 = when code is 
+        ERROR -> "ERROR: SQL error or missing database"
+        INTERNAL -> "INTERNAL: Internal logic error in SQLite"
+        PERM -> "PERM: Access permission denied"
+        ABORT -> "ABORT: Callback routine requested an abort"
+        BUSY -> "BUSY: The database file is locked"
+        LOCKED -> "LOCKED: A table in the database is locked"
+        NOMEM -> "NOMEM: A malloc() failed"
+        READONLY -> "READONLY: Attempt to write a readonly database"
+        INTERRUPT -> "INTERRUPT: Operation terminated by sqlite3_interrupt("
+        IOERR -> "IOERR: Some kind of disk I/O error occurred"
+        CORRUPT -> "CORRUPT: The database disk image is malformed"
+        NOTFOUND -> "NOTFOUND: Unknown opcode in sqlite3_file_control()"
+        FULL -> "FULL: Insertion failed because database is full"
+        CANTOPEN -> "CANTOPEN: Unable to open the database file"
+        PROTOCOL -> "PROTOCOL: Database lock protocol error"
+        EMPTY -> "EMPTY: Database is empty"
+        SCHEMA -> "SCHEMA: The database schema changed"
+        TOOBIG -> "TOOBIG: String or BLOB exceeds size limit"
+        CONSTRAINT -> "CONSTRAINT: Abort due to constraint violation"
+        MISMATCH -> "MISMATCH: Data type mismatch"
+        MISUSE -> "MISUSE: Library used incorrectly"
+        NOLFS -> "NOLFS: Uses OS features not supported on host"
+        AUTH -> "AUTH: Authorization denied"
+        FORMAT -> "FORMAT: Auxiliary database format error"
+        RANGE -> "RANGE: 2nd parameter to sqlite3_bind out of range"
+        NOTADB -> "NOTADB: File opened that is not a database file"
+        NOTICE -> "NOTICE: Notifications from sqlite3_log()"
+        WARNING -> "WARNING: Warnings from sqlite3_log()"
+        ROW -> "ROW: sqlite3_step() has another row ready"
+        DONE -> "DONE: sqlite3_step() has finished executing"
+
+    "$(msg1) - $(msg2)"
+
+# prepare : Query -> PreparedStatement
+
+# bind : PreparedStatement, Bindings -> BoundStatement
+
+# read : BoundStatement -> [Row data, Done]
+
+
+
+
+

--- a/platform/SQLite3.roc
+++ b/platform/SQLite3.roc
@@ -1,149 +1,132 @@
 interface SQLite3
     exposes [
-        Types,
         execute,
         errToStr,
     ]
-    imports [InternalTask, Task.{ Task }, InternalError, Effect]
+    imports [InternalTask, Task.{ Task }, InternalSQL, Effect]
 
-Types : [
-    F64,
-    I64,
-    String,
-    Bytes,
-    OptionalF64,
-    OptionalI64,
-    OptionalString,
-    OptionalBytes,
-]
+SQLErrorMessage : [SQLError InternalSQL.SQLiteErrCode Str]
 
-Code : InternalError.SQLiteErrCode
-
-SQLErrorMessage : [SQLError Code Str]
-
-execute : Str, Str -> Task {} SQLErrorMessage
-execute = \dbPath, query ->
-    result <- 
-        Effect.sqliteExecute dbPath query
+execute :
+    {
+        path : Str,
+        query : Str,
+        bindings : List InternalSQL.SQLiteBindings,
+    }
+    -> Task (List (List InternalSQL.SQLiteValue)) SQLErrorMessage
+execute = \{ path, query, bindings } ->
+    result <-
+        Effect.sqliteExecute path query bindings
         |> InternalTask.fromEffect
         |> Task.attempt
 
-    when result is 
-        Ok {} -> Task.ok {}
-        Err {code, message} -> Task.err (SQLError (codeFromI64 code) message)
+    when result is
+        Ok rows -> Task.ok rows
+        Err { code, message } -> Task.err (SQLError (codeFromI64 code) message)
 
-codeFromI64 : I64 -> InternalError.SQLiteErrCode
+codeFromI64 : I64 -> InternalSQL.SQLiteErrCode
 codeFromI64 = \code ->
-    if code == 1 then 
+    if code == 1 then
         ERROR
-    else if code == 2 then 
+    else if code == 2 then
         INTERNAL
-    else if code == 3 then 
+    else if code == 3 then
         PERM
-    else if code == 4 then 
+    else if code == 4 then
         ABORT
-    else if code == 5 then 
+    else if code == 5 then
         BUSY
-    else if code == 6 then 
+    else if code == 6 then
         LOCKED
-    else if code == 7 then 
+    else if code == 7 then
         NOMEM
-    else if code == 8 then 
+    else if code == 8 then
         READONLY
-    else if code == 9 then 
+    else if code == 9 then
         INTERRUPT
-    else if code == 10 then 
+    else if code == 10 then
         IOERR
-    else if code == 11 then 
+    else if code == 11 then
         CORRUPT
-    else if code == 12 then 
+    else if code == 12 then
         NOTFOUND
-    else if code == 13 then 
+    else if code == 13 then
         FULL
-    else if code == 14 then 
+    else if code == 14 then
         CANTOPEN
-    else if code == 15 then 
+    else if code == 15 then
         PROTOCOL
-    else if code == 16 then 
+    else if code == 16 then
         EMPTY
-    else if code == 17 then 
+    else if code == 17 then
         SCHEMA
-    else if code == 18 then 
+    else if code == 18 then
         TOOBIG
-    else if code == 19 then 
+    else if code == 19 then
         CONSTRAINT
-    else if code == 20 then 
+    else if code == 20 then
         MISMATCH
-    else if code == 21 then 
+    else if code == 21 then
         MISUSE
-    else if code == 22 then 
+    else if code == 22 then
         NOLFS
-    else if code == 23 then 
+    else if code == 23 then
         AUTH
-    else if code == 24 then 
+    else if code == 24 then
         FORMAT
-    else if code == 25 then 
+    else if code == 25 then
         RANGE
-    else if code == 26 then 
+    else if code == 26 then
         NOTADB
-    else if code == 27 then 
+    else if code == 27 then
         NOTICE
-    else if code == 28 then 
+    else if code == 28 then
         WARNING
-    else if code == 100 then 
+    else if code == 100 then
         ROW
-    else if code == 101 then 
+    else if code == 101 then
         DONE
-    else 
+    else
         crash "unsupported SQLite error code $(Num.toStr code)"
 
-errToStr : SQLErrorMessage -> Str 
+errToStr : SQLErrorMessage -> Str
 errToStr = \err ->
-    (code, msg2 ) = 
-        when err is 
-            SQLError c m -> (c,m) 
+    (code, msg2) =
+        when err is
+            SQLError c m -> (c, m)
 
-    msg1 = when code is 
-        ERROR -> "ERROR: SQL error or missing database"
-        INTERNAL -> "INTERNAL: Internal logic error in SQLite"
-        PERM -> "PERM: Access permission denied"
-        ABORT -> "ABORT: Callback routine requested an abort"
-        BUSY -> "BUSY: The database file is locked"
-        LOCKED -> "LOCKED: A table in the database is locked"
-        NOMEM -> "NOMEM: A malloc() failed"
-        READONLY -> "READONLY: Attempt to write a readonly database"
-        INTERRUPT -> "INTERRUPT: Operation terminated by sqlite3_interrupt("
-        IOERR -> "IOERR: Some kind of disk I/O error occurred"
-        CORRUPT -> "CORRUPT: The database disk image is malformed"
-        NOTFOUND -> "NOTFOUND: Unknown opcode in sqlite3_file_control()"
-        FULL -> "FULL: Insertion failed because database is full"
-        CANTOPEN -> "CANTOPEN: Unable to open the database file"
-        PROTOCOL -> "PROTOCOL: Database lock protocol error"
-        EMPTY -> "EMPTY: Database is empty"
-        SCHEMA -> "SCHEMA: The database schema changed"
-        TOOBIG -> "TOOBIG: String or BLOB exceeds size limit"
-        CONSTRAINT -> "CONSTRAINT: Abort due to constraint violation"
-        MISMATCH -> "MISMATCH: Data type mismatch"
-        MISUSE -> "MISUSE: Library used incorrectly"
-        NOLFS -> "NOLFS: Uses OS features not supported on host"
-        AUTH -> "AUTH: Authorization denied"
-        FORMAT -> "FORMAT: Auxiliary database format error"
-        RANGE -> "RANGE: 2nd parameter to sqlite3_bind out of range"
-        NOTADB -> "NOTADB: File opened that is not a database file"
-        NOTICE -> "NOTICE: Notifications from sqlite3_log()"
-        WARNING -> "WARNING: Warnings from sqlite3_log()"
-        ROW -> "ROW: sqlite3_step() has another row ready"
-        DONE -> "DONE: sqlite3_step() has finished executing"
+    msg1 =
+        when code is
+            ERROR -> "ERROR: SQL error or missing database"
+            INTERNAL -> "INTERNAL: Internal logic error in SQLite"
+            PERM -> "PERM: Access permission denied"
+            ABORT -> "ABORT: Callback routine requested an abort"
+            BUSY -> "BUSY: The database file is locked"
+            LOCKED -> "LOCKED: A table in the database is locked"
+            NOMEM -> "NOMEM: A malloc() failed"
+            READONLY -> "READONLY: Attempt to write a readonly database"
+            INTERRUPT -> "INTERRUPT: Operation terminated by sqlite3_interrupt("
+            IOERR -> "IOERR: Some kind of disk I/O error occurred"
+            CORRUPT -> "CORRUPT: The database disk image is malformed"
+            NOTFOUND -> "NOTFOUND: Unknown opcode in sqlite3_file_control()"
+            FULL -> "FULL: Insertion failed because database is full"
+            CANTOPEN -> "CANTOPEN: Unable to open the database file"
+            PROTOCOL -> "PROTOCOL: Database lock protocol error"
+            EMPTY -> "EMPTY: Database is empty"
+            SCHEMA -> "SCHEMA: The database schema changed"
+            TOOBIG -> "TOOBIG: String or BLOB exceeds size limit"
+            CONSTRAINT -> "CONSTRAINT: Abort due to constraint violation"
+            MISMATCH -> "MISMATCH: Data type mismatch"
+            MISUSE -> "MISUSE: Library used incorrectly"
+            NOLFS -> "NOLFS: Uses OS features not supported on host"
+            AUTH -> "AUTH: Authorization denied"
+            FORMAT -> "FORMAT: Auxiliary database format error"
+            RANGE -> "RANGE: 2nd parameter to sqlite3_bind out of range"
+            NOTADB -> "NOTADB: File opened that is not a database file"
+            NOTICE -> "NOTICE: Notifications from sqlite3_log()"
+            WARNING -> "WARNING: Warnings from sqlite3_log()"
+            ROW -> "ROW: sqlite3_step() has another row ready"
+            DONE -> "DONE: sqlite3_step() has finished executing"
 
     "$(msg1) - $(msg2)"
-
-# prepare : Query -> PreparedStatement
-
-# bind : PreparedStatement, Bindings -> BoundStatement
-
-# read : BoundStatement -> [Row data, Done]
-
-
-
-
 

--- a/platform/SQLite3.roc
+++ b/platform/SQLite3.roc
@@ -33,7 +33,7 @@ execute = \{ path, query, bindings } ->
 
 codeFromI64 : I64 -> InternalSQL.SQLiteErrCode
 codeFromI64 = \code ->
-    if code == 1 then
+    if code == 1 || code == 0 then
         ERROR
     else if code == 2 then
         INTERNAL

--- a/platform/Stderr.roc
+++ b/platform/Stderr.roc
@@ -25,10 +25,10 @@ write = \str ->
     |> InternalTask.fromEffect
 
 ## Flush the [standard error](https://en.wikipedia.org/wiki/Standard_streams#Standard_error_(stderr)).
-## This will cause any buffered output to be written out. This is typically to 
+## This will cause any buffered output to be written out. This is typically to
 ## the terminal but may be captured and written to a file.
 ##
-## This may fail if the buffered output could not be written due to I/O 
+## This may fail if the buffered output could not be written due to I/O
 ## errors or EOF being reached.
 flush : Task {} *
 flush = Effect.stderrFlush |> Effect.map (\_ -> Ok {}) |> InternalTask.fromEffect

--- a/platform/Stdout.roc
+++ b/platform/Stdout.roc
@@ -7,8 +7,8 @@ interface Stdout
 ##
 ## > To write to `stdout` without the newline, see [Stdout.write].
 line : Str -> Task {} *
-line = \str -> 
-    Effect.stdoutLine str 
+line = \str ->
+    Effect.stdoutLine str
     |> Effect.map (\_ -> Ok {})
     |> InternalTask.fromEffect
 
@@ -25,10 +25,10 @@ write = \str ->
     |> InternalTask.fromEffect
 
 ## Flush the [standard output](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)).
-## This will cause any buffered output to be written out. This is typically to 
+## This will cause any buffered output to be written out. This is typically to
 ## the terminal but may be captured and written to a file.
 ##
-## This may fail if the buffered output could not be written due to I/O 
+## This may fail if the buffered output could not be written due to I/O
 ## errors or EOF being reached.
 flush : Task {} *
 flush = Effect.stdoutFlush |> Effect.map (\_ -> Ok {}) |> InternalTask.fromEffect

--- a/platform/main-manual-glue.roc
+++ b/platform/main-manual-glue.roc
@@ -8,6 +8,7 @@ platform "webserver"
         InternalTcp,
         InternalFile,
         InternalPath,
+        InternalSQL,
     ]
     provides [mainForHost]
 
@@ -23,11 +24,12 @@ GlueTypes : [
     I InternalTcp.WriteResult,
     J InternalTcp.ReadResult,
     K InternalTcp.ReadExactlyResult,
-    L InternalFile.ReadErr, 
+    L InternalFile.ReadErr,
     M InternalFile.WriteErr,
     N InternalError.InternalDirReadErr,
     O InternalError.InternalDirDeleteErr,
     P InternalPath.UnwrappedPath,
+    Q InternalSQL.SQLiteValue,
 ]
 
 mainForHost : GlueTypes

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -15,6 +15,7 @@ platform "webserver"
         Utc,
         Sleep,
         Command,
+        SQLite3,
     ]
     packages {}
     imports [

--- a/platform/src/glue/roc_std/src/lib.rs
+++ b/platform/src/glue/roc_std/src/lib.rs
@@ -36,6 +36,7 @@ extern "C" {
     ) -> *mut c_void;
     pub fn roc_dealloc(ptr: *mut c_void, alignment: u32);
     pub fn roc_panic(c_ptr: *mut c_void, tag_id: u32);
+    pub fn roc_dbg(loc: *mut c_void, msg: *mut c_void, src: *mut c_void);
     pub fn roc_memset(dst: *mut c_void, c: i32, n: usize) -> *mut c_void;
 }
 
@@ -309,10 +310,9 @@ impl RocDec {
             }
         };
 
-        let opt_after_point = match parts.next() {
-            Some(answer) if answer.len() <= Self::DECIMAL_PLACES => Some(answer),
-            _ => None,
-        };
+        let opt_after_point = parts
+            .next()
+            .map(|answer| &answer[..Ord::min(answer.len(), Self::DECIMAL_PLACES)]);
 
         // There should have only been one "." in the string!
         if parts.next().is_some() {
@@ -494,7 +494,7 @@ impl PartialEq for I128 {
 
 impl PartialOrd for I128 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        i128::from(*self).partial_cmp(&i128::from(*other))
+        Some(self.cmp(other))
     }
 }
 
@@ -546,7 +546,7 @@ impl PartialEq for U128 {
 
 impl PartialOrd for U128 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        u128::from(*self).partial_cmp(&u128::from(*other))
+        Some(self.cmp(other))
     }
 }
 

--- a/platform/src/glue/roc_std/src/roc_box.rs
+++ b/platform/src/glue/roc_std/src/roc_box.rs
@@ -48,7 +48,7 @@ impl<T> RocBox<T> {
     ///
     /// The box must be unique in order to leak it safely
     pub unsafe fn leak(self) -> *mut T {
-        let ptr = self.contents.as_ptr() as *mut T;
+        let ptr = self.contents.as_ptr();
         core::mem::forget(self);
         ptr
     }
@@ -59,7 +59,7 @@ impl<T> RocBox<T> {
     }
 
     pub fn into_inner(self) -> T {
-        unsafe { ptr::read(self.contents.as_ptr() as *mut T) }
+        unsafe { ptr::read(self.contents.as_ptr()) }
     }
 
     fn storage(&self) -> &Cell<Storage> {

--- a/platform/src/glue/roc_std/src/roc_str.rs
+++ b/platform/src/glue/roc_std/src/roc_str.rs
@@ -19,8 +19,9 @@ use core::{
 
 #[cfg(feature = "std")]
 use std::ffi::{CStr, CString};
+use std::{ops::Range, ptr::NonNull};
 
-use crate::RocList;
+use crate::{roc_realloc, RocList};
 
 #[repr(transparent)]
 pub struct RocStr(RocStrInner);
@@ -73,8 +74,34 @@ impl RocStr {
             Self(RocStrInner { small_string })
         } else {
             let heap_allocated = RocList::from_slice(slice);
+            let big_string = unsafe { std::mem::transmute(heap_allocated) };
             Self(RocStrInner {
-                heap_allocated: ManuallyDrop::new(heap_allocated),
+                heap_allocated: ManuallyDrop::new(big_string),
+            })
+        }
+    }
+
+    /// # Safety
+    ///
+    /// - `bytes` must be allocated for `cap` bytes
+    /// - `bytes` must be initialized for `len` bytes
+    /// - `bytes` must be preceded by a correctly-aligned refcount (usize)
+    /// - `bytes` must represent valid UTF-8
+    /// - `cap` >= `len`
+    pub unsafe fn from_raw_parts(bytes: *mut u8, len: usize, cap: usize) -> Self {
+        if len <= SmallString::CAPACITY {
+            unsafe {
+                let slice = std::slice::from_raw_parts(bytes, len);
+                let small_string = SmallString::try_from_utf8_bytes(slice).unwrap_unchecked();
+                Self(RocStrInner { small_string })
+            }
+        } else {
+            Self(RocStrInner {
+                heap_allocated: ManuallyDrop::new(BigString {
+                    elements: unsafe { NonNull::new_unchecked(bytes) },
+                    length: len,
+                    capacity_or_alloc_ptr: cap,
+                }),
             })
         }
     }
@@ -93,7 +120,7 @@ impl RocStr {
 
     pub fn capacity(&self) -> usize {
         match self.as_enum_ref() {
-            RocStrInnerRef::HeapAllocated(roc_list) => roc_list.capacity(),
+            RocStrInnerRef::HeapAllocated(big_string) => big_string.capacity(),
             RocStrInnerRef::SmallString(_) => SmallString::CAPACITY,
         }
     }
@@ -137,10 +164,12 @@ impl RocStr {
     /// There is no way to tell how many references it has and if it is safe to free.
     /// As such, only values that should have a static lifetime for the entire application run
     /// should be considered for marking read-only.
-    pub unsafe fn set_readonly(&self) {
-        match self.as_enum_ref() {
-            RocStrInnerRef::HeapAllocated(roc_list) => unsafe { roc_list.set_readonly() },
-            RocStrInnerRef::SmallString(_) => {}
+    pub unsafe fn set_readonly(&mut self) {
+        if self.is_small_str() {
+            /* do nothing */
+        } else {
+            let big = unsafe { &mut self.0.heap_allocated };
+            big.set_readonly()
         }
     }
 
@@ -167,7 +196,7 @@ impl RocStr {
         } else {
             // The requested capacity won't fit in a small string; we need to go big.
             RocStr(RocStrInner {
-                heap_allocated: ManuallyDrop::new(RocList::with_capacity(bytes)),
+                heap_allocated: ManuallyDrop::new(BigString::with_capacity(bytes)),
             })
         }
     }
@@ -182,21 +211,33 @@ impl RocStr {
 
             if target_cap > SmallString::CAPACITY {
                 // The requested capacity won't fit in a small string; we need to go big.
-                let mut roc_list = RocList::with_capacity(target_cap);
+                let mut big_string = BigString::with_capacity(target_cap);
 
-                roc_list.extend_from_slice(small_str.as_bytes());
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        self.as_bytes().as_ptr(),
+                        big_string.ptr_to_first_elem(),
+                        self.len(),
+                    )
+                };
 
-                *self = RocStr(RocStrInner {
-                    heap_allocated: ManuallyDrop::new(roc_list),
+                big_string.length = self.len();
+                big_string.capacity_or_alloc_ptr = target_cap;
+
+                let mut updated = RocStr(RocStrInner {
+                    heap_allocated: ManuallyDrop::new(big_string),
                 });
+
+                mem::swap(self, &mut updated);
+                mem::forget(updated);
             }
         } else {
-            let mut roc_list = unsafe { ManuallyDrop::take(&mut self.0.heap_allocated) };
+            let mut big_string = unsafe { ManuallyDrop::take(&mut self.0.heap_allocated) };
 
-            roc_list.reserve(bytes);
+            big_string.reserve(bytes);
 
             let mut updated = RocStr(RocStrInner {
-                heap_allocated: ManuallyDrop::new(roc_list),
+                heap_allocated: ManuallyDrop::new(big_string),
             });
 
             mem::swap(self, &mut updated);
@@ -204,12 +245,57 @@ impl RocStr {
         }
     }
 
+    #[track_caller]
+    pub fn slice_range(&self, range: Range<usize>) -> Self {
+        match self.try_slice_range(range) {
+            Some(x) => x,
+            None => panic!("slice index out of range"),
+        }
+    }
+
+    pub fn try_slice_range(&self, range: Range<usize>) -> Option<Self> {
+        if self.as_str().get(range.start..range.end).is_none() {
+            None
+        } else if range.end - range.start <= SmallString::CAPACITY && self.is_small_str() {
+            let slice = &self.as_bytes()[range];
+            let small_string =
+                unsafe { SmallString::try_from_utf8_bytes(slice).unwrap_unchecked() };
+
+            // NOTE decrements `self`
+            Some(RocStr(RocStrInner { small_string }))
+        } else {
+            // increment the refcount
+            std::mem::forget(self.clone());
+
+            let big = unsafe { &self.0.heap_allocated };
+            let ptr = unsafe { (self.as_bytes().as_ptr() as *mut u8).add(range.start) };
+
+            let heap_allocated = ManuallyDrop::new(BigString {
+                elements: unsafe { NonNull::new_unchecked(ptr) },
+                length: (isize::MIN as usize) | (range.end - range.start),
+                capacity_or_alloc_ptr: (big.ptr_to_first_elem() as usize) >> 1,
+            });
+
+            Some(RocStr(RocStrInner { heap_allocated }))
+        }
+    }
+
+    pub fn split_once(&self, delimiter: &str) -> Option<(Self, Self)> {
+        let (a, b) = self.as_str().split_once(delimiter)?;
+
+        let x = self.slice_range(0..a.len());
+        let y = self.slice_range(self.len() - b.len()..self.len());
+
+        Some((x, y))
+    }
+
+    pub fn split_whitespace(&self) -> SplitWhitespace<'_> {
+        SplitWhitespace(self.as_str().char_indices().peekable(), self)
+    }
+
     /// Returns the index of the first interior \0 byte in the string, or None if there are none.
     fn first_nul_byte(&self) -> Option<usize> {
-        match self.as_enum_ref() {
-            RocStrInnerRef::HeapAllocated(roc_list) => roc_list.iter().position(|byte| *byte == 0),
-            RocStrInnerRef::SmallString(small_string) => small_string.first_nul_byte(),
-        }
+        self.as_bytes().iter().position(|byte| *byte == 0)
     }
 
     // If the string is under this many bytes, the with_terminator family
@@ -267,60 +353,48 @@ impl RocStr {
         };
 
         match self.as_enum_ref() {
-            RocStrInnerRef::HeapAllocated(roc_list) => {
+            RocStrInnerRef::HeapAllocated(big_string) => {
                 unsafe {
-                    match roc_list.storage() {
-                        Some(storage) if storage.is_unique() => {
-                            // The backing RocList was unique, so we can mutate it in-place.
-                            let len = roc_list.len();
-                            let ptr = if len < roc_list.capacity() {
-                                // We happen to have excess capacity already, so we will be able
-                                // to write the terminator into the first byte of excess capacity.
-                                roc_list.ptr_to_first_elem() as *mut u8
-                            } else {
-                                // We always have an allocation that's even bigger than necessary,
-                                // because the refcount bytes take up more than the 1B needed for
-                                // the terminator. We just need to shift the bytes over on top
-                                // of the refcount.
-                                let alloc_ptr = roc_list.ptr_to_allocation() as *mut u8;
+                    if big_string.is_unique() {
+                        // The backing RocList was unique, so we can mutate it in-place.
+                        let len = big_string.len();
+                        let ptr = if len < big_string.capacity() {
+                            // We happen to have excess capacity already, so we will be able
+                            // to write the terminator into the first byte of excess capacity.
+                            big_string.ptr_to_first_elem()
+                        } else {
+                            // We always have an allocation that's even bigger than necessary,
+                            // because the refcount bytes take up more than the 1B needed for
+                            // the terminator. We just need to shift the bytes over on top
+                            // of the refcount.
+                            let alloc_ptr = big_string.ptr_to_allocation() as *mut u8;
 
-                                // First, copy the bytes over the original allocation - effectively
-                                // shifting everything over by one `usize`. Now we no longer have a
-                                // refcount (but the terminated won't use that anyway), but we do
-                                // have a free `usize` at the end.
-                                //
-                                // IMPORTANT: Must use ptr::copy instead of ptr::copy_nonoverlapping
-                                // because the regions definitely overlap!
-                                ptr::copy(roc_list.ptr_to_first_elem() as *mut u8, alloc_ptr, len);
-
-                                alloc_ptr
-                            };
-
-                            terminate(ptr, len)
-                        }
-                        Some(_) => {
-                            let len = roc_list.len();
-
-                            // The backing list was not unique, so we can't mutate it in-place.
-                            // ask for `len + 1` to store the original string and the terminator
-                            with_stack_bytes(len + 1, |alloc_ptr: *mut u8| {
-                                let alloc_ptr = alloc_ptr as *mut u8;
-                                let elem_ptr = roc_list.ptr_to_first_elem() as *mut u8;
-
-                                // memcpy the bytes into the stack allocation
-                                ptr::copy_nonoverlapping(elem_ptr, alloc_ptr, len);
-
-                                terminate(alloc_ptr, len)
-                            })
-                        }
-                        None => {
-                            // The backing list was empty.
+                            // First, copy the bytes over the original allocation - effectively
+                            // shifting everything over by one `usize`. Now we no longer have a
+                            // refcount (but the terminated won't use that anyway), but we do
+                            // have a free `usize` at the end.
                             //
-                            // No need to do a heap allocation for an empty string - we
-                            // can just do a stack allocation that will live for the
-                            // duration of the function.
-                            func([terminator].as_mut_ptr(), 0)
-                        }
+                            // IMPORTANT: Must use ptr::copy instead of ptr::copy_nonoverlapping
+                            // because the regions definitely overlap!
+                            ptr::copy(big_string.ptr_to_first_elem(), alloc_ptr, len);
+
+                            alloc_ptr
+                        };
+
+                        terminate(ptr, len)
+                    } else {
+                        let len = big_string.len();
+
+                        // The backing list was not unique, so we can't mutate it in-place.
+                        // ask for `len + 1` to store the original string and the terminator
+                        with_stack_bytes(len + 1, |alloc_ptr: *mut u8| {
+                            let elem_ptr = big_string.ptr_to_first_elem();
+
+                            // memcpy the bytes into the stack allocation
+                            std::ptr::copy_nonoverlapping(elem_ptr, alloc_ptr, len);
+
+                            terminate(alloc_ptr, len)
+                        })
                     }
                 }
             }
@@ -331,7 +405,7 @@ impl RocStr {
 
                 // Even if the small string is at capacity, there will be room to write
                 // a terminator in the byte that's used to store the length.
-                terminate(bytes.as_mut_ptr() as *mut u8, small_str.len())
+                terminate(bytes.as_mut_ptr(), small_str.len())
             }
         }
     }
@@ -485,57 +559,46 @@ impl RocStr {
         };
 
         match self.as_enum_ref() {
-            RocStrInnerRef::HeapAllocated(roc_list) => {
-                let len = roc_list.len();
+            RocStrInnerRef::HeapAllocated(big_string) => {
+                let len = big_string.len();
 
                 unsafe {
-                    match roc_list.storage() {
-                        Some(storage) if storage.is_unique() => {
-                            // The backing RocList was unique, so we can mutate it in-place.
+                    if big_string.is_unique() {
+                        // The backing RocList was unique, so we can mutate it in-place.
 
-                            // We need 1 extra elem for the terminator. It must be an elem,
-                            // not a byte, because we'll be providing a pointer to elems.
-                            let needed_bytes = (len + 1) * size_of::<E>();
+                        // We need 1 extra elem for the terminator. It must be an elem,
+                        // not a byte, because we'll be providing a pointer to elems.
+                        let needed_bytes = (len + 1) * size_of::<E>();
 
-                            // We can use not only the capacity on the heap, but also
-                            // the bytes originally used for the refcount.
-                            let available_bytes = roc_list.capacity() + size_of::<Storage>();
+                        // We can use not only the capacity on the heap, but also
+                        // the bytes originally used for the refcount.
+                        let available_bytes = big_string.capacity() + size_of::<Storage>();
 
-                            if needed_bytes < available_bytes {
-                                debug_assert!(align_of::<Storage>() >= align_of::<E>());
+                        if needed_bytes < available_bytes {
+                            debug_assert!(align_of::<Storage>() >= align_of::<E>());
 
-                                // We happen to have sufficient excess capacity already,
-                                // so we will be able to write the new elements as well as
-                                // the terminator into the existing allocation.
-                                let ptr = roc_list.ptr_to_allocation() as *mut E;
-                                let answer = terminate(ptr, self.as_str());
+                            // We happen to have sufficient excess capacity already,
+                            // so we will be able to write the new elements as well as
+                            // the terminator into the existing allocation.
+                            let ptr = big_string.ptr_to_allocation() as *mut E;
+                            let answer = terminate(ptr, self.as_str());
 
-                                // We cannot rely on the RocStr::drop implementation, because
-                                // it tries to use the refcount - which we just overwrote
-                                // with string bytes.
-                                mem::forget(self);
-                                crate::roc_dealloc(ptr.cast(), mem::align_of::<E>() as u32);
+                            // We cannot rely on the RocStr::drop implementation, because
+                            // it tries to use the refcount - which we just overwrote
+                            // with string bytes.
+                            mem::forget(self);
+                            crate::roc_dealloc(ptr.cast(), mem::align_of::<E>() as u32);
 
-                                answer
-                            } else {
-                                // We didn't have sufficient excess capacity already,
-                                // so we need to do either a new stack allocation or a new
-                                // heap allocation.
-                                fallback(self.as_str())
-                            }
-                        }
-                        Some(_) => {
-                            // The backing list was not unique, so we can't mutate it in-place.
+                            answer
+                        } else {
+                            // We didn't have sufficient excess capacity already,
+                            // so we need to do either a new stack allocation or a new
+                            // heap allocation.
                             fallback(self.as_str())
                         }
-                        None => {
-                            // The backing list was empty.
-                            //
-                            // No need to do a heap allocation for an empty string - we
-                            // can just do a stack allocation that will live for the
-                            // duration of the function.
-                            func([terminator].as_mut_ptr() as *mut E, "")
-                        }
+                    } else {
+                        // The backing list was not unique, so we can't mutate it in-place.
+                        fallback(self.as_str())
                     }
                 }
             }
@@ -558,12 +621,44 @@ impl RocStr {
     }
 }
 
+pub struct SplitWhitespace<'a>(std::iter::Peekable<std::str::CharIndices<'a>>, &'a RocStr);
+
+impl Iterator for SplitWhitespace<'_> {
+    type Item = RocStr;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let start = 'blk: {
+            while let Some((pos, c)) = self.0.peek() {
+                if c.is_whitespace() {
+                    self.0.next();
+                } else {
+                    break 'blk *pos;
+                }
+            }
+
+            return None;
+        };
+
+        let end = 'blk: {
+            for (pos, c) in self.0.by_ref() {
+                if c.is_whitespace() {
+                    break 'blk pos;
+                }
+            }
+
+            break 'blk self.1.len();
+        };
+
+        self.1.try_slice_range(start..end)
+    }
+}
+
 impl Deref for RocStr {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
         match self.as_enum_ref() {
-            RocStrInnerRef::HeapAllocated(h) => unsafe { core::str::from_utf8_unchecked(h) },
+            RocStrInnerRef::HeapAllocated(h) => h.as_str(),
             RocStrInnerRef::SmallString(s) => s,
         }
     }
@@ -620,7 +715,7 @@ impl Eq for RocStr {}
 
 impl PartialOrd for RocStr {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        self.as_str().partial_cmp(other.as_str())
+        Some(self.cmp(other))
     }
 }
 
@@ -698,18 +793,215 @@ impl From<SendSafeRocStr> for RocStr {
 }
 
 #[repr(C)]
+struct BigString {
+    elements: NonNull<u8>,
+    length: usize,
+    capacity_or_alloc_ptr: usize,
+}
+
+const SEAMLESS_SLICE_BIT: usize = isize::MIN as usize;
+
+impl BigString {
+    fn len(&self) -> usize {
+        self.length & !SEAMLESS_SLICE_BIT
+    }
+
+    fn capacity(&self) -> usize {
+        if self.is_seamless_slice() {
+            self.len()
+        } else {
+            self.capacity_or_alloc_ptr
+        }
+    }
+
+    fn is_seamless_slice(&self) -> bool {
+        (self.length as isize) < 0
+    }
+
+    fn ptr_to_first_elem(&self) -> *mut u8 {
+        unsafe { core::mem::transmute(self.elements) }
+    }
+
+    fn ptr_to_allocation(&self) -> *mut usize {
+        // these are the same because the alignment of u8 is just 1
+        self.ptr_to_refcount()
+    }
+
+    fn ptr_to_refcount(&self) -> *mut usize {
+        if self.is_seamless_slice() {
+            unsafe { ((self.capacity_or_alloc_ptr << 1) as *mut usize).sub(1) }
+        } else {
+            unsafe { self.ptr_to_first_elem().cast::<usize>().sub(1) }
+        }
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.ptr_to_first_elem(), self.len()) }
+    }
+
+    fn as_str(&self) -> &str {
+        unsafe { std::str::from_utf8_unchecked(self.as_bytes()) }
+    }
+
+    fn is_unique(&self) -> bool {
+        if self.capacity() == 0 {
+            return false;
+        }
+
+        let ptr = self.ptr_to_refcount();
+        let rc = unsafe { std::ptr::read(ptr) as isize };
+
+        rc == isize::MIN
+    }
+
+    fn is_readonly(&self) -> bool {
+        if self.capacity() == 0 {
+            return true;
+        }
+
+        let ptr = self.ptr_to_refcount();
+        let rc = unsafe { std::ptr::read(ptr) as isize };
+
+        rc == 0
+    }
+
+    fn set_readonly(&mut self) {
+        assert_ne!(self.capacity(), 0);
+
+        let ptr = self.ptr_to_refcount();
+        unsafe { std::ptr::write(ptr, 0) }
+    }
+
+    fn inc(&mut self, n: usize) {
+        let ptr = self.ptr_to_refcount();
+        unsafe {
+            let value = std::ptr::read(ptr);
+            std::ptr::write(ptr, Ord::max(0, ((value as isize) + n as isize) as usize));
+        }
+    }
+
+    fn dec(&mut self) {
+        if self.capacity() == 0 {
+            // no valid allocation, elements pointer is dangling
+            return;
+        }
+
+        let ptr = self.ptr_to_refcount();
+        unsafe {
+            let value = std::ptr::read(ptr) as isize;
+            match value {
+                0 => {
+                    // static lifetime, do nothing
+                }
+                isize::MIN => {
+                    // refcount becomes zero; free allocation
+                    crate::roc_dealloc(self.ptr_to_allocation().cast(), 1);
+                }
+                _ => {
+                    std::ptr::write(ptr, (value - 1) as usize);
+                }
+            }
+        }
+    }
+
+    fn with_capacity(cap: usize) -> Self {
+        let mut this = Self {
+            elements: NonNull::dangling(),
+            length: 0,
+            capacity_or_alloc_ptr: 0,
+        };
+
+        this.reserve(cap);
+
+        this
+    }
+
+    /// Increase a BigString's capacity by at least the requested number of elements (possibly more).
+    ///
+    /// May return a new BigString, if the provided one was not unique.
+    fn reserve(&mut self, n: usize) {
+        let align = std::mem::size_of::<usize>();
+        let desired_cap = self.len() + n;
+        let desired_alloc = align + desired_cap;
+
+        if self.is_unique() && !self.is_seamless_slice() {
+            if self.capacity() >= desired_cap {
+                return;
+            }
+
+            let new_alloc = unsafe {
+                roc_realloc(
+                    self.ptr_to_allocation().cast(),
+                    desired_alloc as _,
+                    align + self.capacity(),
+                    align as _,
+                )
+            };
+
+            let elements = unsafe { NonNull::new_unchecked(new_alloc.cast::<u8>().add(align)) };
+
+            let mut this = Self {
+                elements,
+                length: self.len(),
+                capacity_or_alloc_ptr: desired_cap,
+            };
+
+            std::mem::swap(&mut this, self);
+            std::mem::forget(this);
+        } else {
+            let ptr = unsafe { crate::roc_alloc(desired_alloc, align as _) } as *mut u8;
+            let elements = unsafe { NonNull::new_unchecked(ptr.cast::<u8>().add(align)) };
+
+            unsafe {
+                // Copy the old elements to the new allocation.
+                std::ptr::copy_nonoverlapping(self.ptr_to_first_elem(), ptr.add(align), self.len());
+            }
+
+            let mut this = Self {
+                elements,
+                length: self.len(),
+                capacity_or_alloc_ptr: desired_cap,
+            };
+
+            std::mem::swap(&mut this, self);
+            std::mem::drop(this);
+        }
+    }
+}
+
+impl Clone for BigString {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            elements: self.elements,
+            length: self.length,
+            capacity_or_alloc_ptr: self.capacity_or_alloc_ptr,
+        };
+
+        this.inc(1);
+
+        this
+    }
+}
+
+impl Drop for BigString {
+    fn drop(&mut self) {
+        self.dec()
+    }
+}
+
+#[repr(C)]
 union RocStrInner {
     // TODO: this really should be separated from the List type.
     // Due to length specifying seamless slices for Str and capacity for Lists they should not share the same code.
     // Currently, there are work arounds in RocList to handle both via removing the highest bit of length in many cases.
     // With glue changes, we should probably rewrite these cleanly to match what is in the zig bitcode.
     // It is definitely a bit stale now and I think the storage mechanism can be quite confusing with our extra pieces of state.
-    heap_allocated: ManuallyDrop<RocList<u8>>,
+    heap_allocated: ManuallyDrop<BigString>,
     small_string: SmallString,
 }
 
 enum RocStrInnerRef<'a> {
-    HeapAllocated(&'a RocList<u8>),
+    HeapAllocated(&'a BigString),
     SmallString(&'a SmallString),
 }
 
@@ -755,17 +1047,6 @@ impl SmallString {
 
     fn len(&self) -> usize {
         usize::from(self.len & !RocStr::MASK)
-    }
-
-    /// Returns the index of the first interior \0 byte in the string, or None if there are none.
-    fn first_nul_byte(&self) -> Option<usize> {
-        for (index, byte) in self.bytes[0..self.len()].iter().enumerate() {
-            if *byte == 0 {
-                return Some(index);
-            }
-        }
-
-        None
     }
 }
 

--- a/platform/src/glue_manual/src/arm.rs
+++ b/platform/src/glue_manual/src/arm.rs
@@ -3469,6 +3469,279 @@ impl core::fmt::Debug for InternalDirDeleteErr {
 
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash, )]
 #[repr(u8)]
+pub enum discriminant_SQLiteValue {
+    Bytes = 0,
+    Integer = 1,
+    Null = 2,
+    Real = 3,
+    String = 4,
+}
+
+impl core::fmt::Debug for discriminant_SQLiteValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Bytes => f.write_str("discriminant_SQLiteValue::Bytes"),
+            Self::Integer => f.write_str("discriminant_SQLiteValue::Integer"),
+            Self::Null => f.write_str("discriminant_SQLiteValue::Null"),
+            Self::Real => f.write_str("discriminant_SQLiteValue::Real"),
+            Self::String => f.write_str("discriminant_SQLiteValue::String"),
+        }
+    }
+}
+
+#[repr(C, align(8))]
+pub union union_SQLiteValue {
+    Bytes: core::mem::ManuallyDrop<roc_std::RocList<u8>>,
+    Integer: i64,
+    Null: (),
+    Real: f64,
+    String: core::mem::ManuallyDrop<roc_std::RocStr>,
+}
+
+const _SIZE_CHECK_union_SQLiteValue: () = assert!(core::mem::size_of::<union_SQLiteValue>() == 16);
+const _ALIGN_CHECK_union_SQLiteValue: () = assert!(core::mem::align_of::<union_SQLiteValue>() == 8);
+
+const _SIZE_CHECK_SQLiteValue: () = assert!(core::mem::size_of::<SQLiteValue>() == 24);
+const _ALIGN_CHECK_SQLiteValue: () = assert!(core::mem::align_of::<SQLiteValue>() == 8);
+
+impl SQLiteValue {
+    /// Returns which variant this tag union holds. Note that this never includes a payload!
+    pub fn discriminant(&self) -> discriminant_SQLiteValue {
+        unsafe {
+            let bytes = core::mem::transmute::<&Self, &[u8; core::mem::size_of::<Self>()]>(self);
+
+            core::mem::transmute::<u8, discriminant_SQLiteValue>(*bytes.as_ptr().add(16))
+        }
+    }
+
+    /// Internal helper
+    fn set_discriminant(&mut self, discriminant: discriminant_SQLiteValue) {
+        let discriminant_ptr: *mut discriminant_SQLiteValue = (self as *mut SQLiteValue).cast();
+
+        unsafe {
+            *(discriminant_ptr.add(16)) = discriminant;
+        }
+    }
+}
+
+#[repr(C)]
+pub struct SQLiteValue {
+    payload: union_SQLiteValue,
+    discriminant: discriminant_SQLiteValue,
+}
+
+impl Clone for SQLiteValue {
+    fn clone(&self) -> Self {
+        use discriminant_SQLiteValue::*;
+
+        let payload = unsafe {
+            match self.discriminant {
+                Bytes => union_SQLiteValue {
+                    Bytes: self.payload.Bytes.clone(),
+                },
+                Integer => union_SQLiteValue {
+                    Integer: self.payload.Integer.clone(),
+                },
+                Null => union_SQLiteValue {
+                    Null: self.payload.Null.clone(),
+                },
+                Real => union_SQLiteValue {
+                    Real: self.payload.Real.clone(),
+                },
+                String => union_SQLiteValue {
+                    String: self.payload.String.clone(),
+                },
+            }
+        };
+
+        Self {
+            discriminant: self.discriminant,
+            payload,
+        }
+    }
+}
+
+impl core::fmt::Debug for SQLiteValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use discriminant_SQLiteValue::*;
+
+        unsafe {
+            match self.discriminant {
+                Bytes => {
+                    let field: &roc_std::RocList<u8> = &self.payload.Bytes;
+                    f.debug_tuple("SQLiteValue::Bytes").field(field).finish()
+                },
+                Integer => {
+                    let field: &i64 = &self.payload.Integer;
+                    f.debug_tuple("SQLiteValue::Integer").field(field).finish()
+                },
+                Null => {
+                    let field: &() = &self.payload.Null;
+                    f.debug_tuple("SQLiteValue::Null").field(field).finish()
+                },
+                Real => {
+                    let field: &f64 = &self.payload.Real;
+                    f.debug_tuple("SQLiteValue::Real").field(field).finish()
+                },
+                String => {
+                    let field: &roc_std::RocStr = &self.payload.String;
+                    f.debug_tuple("SQLiteValue::String").field(field).finish()
+                },
+            }
+        }
+    }
+}
+
+impl PartialEq for SQLiteValue {
+    fn eq(&self, other: &Self) -> bool {
+        use discriminant_SQLiteValue::*;
+
+        if self.discriminant != other.discriminant {
+            return false;
+        }
+
+        unsafe {
+            match self.discriminant {
+                Bytes => self.payload.Bytes == other.payload.Bytes,
+                Integer => self.payload.Integer == other.payload.Integer,
+                Null => self.payload.Null == other.payload.Null,
+                Real => self.payload.Real == other.payload.Real,
+                String => self.payload.String == other.payload.String,
+            }
+        }
+    }
+}
+
+impl PartialOrd for SQLiteValue {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        use discriminant_SQLiteValue::*;
+
+        use std::cmp::Ordering::*;
+
+        match self.discriminant.cmp(&other.discriminant) {
+            Less => Option::Some(Less),
+            Greater => Option::Some(Greater),
+            Equal => unsafe {
+                match self.discriminant {
+                    Bytes => self.payload.Bytes.partial_cmp(&other.payload.Bytes),
+                    Integer => self.payload.Integer.partial_cmp(&other.payload.Integer),
+                    Null => self.payload.Null.partial_cmp(&other.payload.Null),
+                    Real => self.payload.Real.partial_cmp(&other.payload.Real),
+                    String => self.payload.String.partial_cmp(&other.payload.String),
+                }
+            },
+        }
+    }
+}
+
+impl SQLiteValue {
+
+    pub fn unwrap_Bytes(mut self) -> roc_std::RocList<u8> {
+        debug_assert_eq!(self.discriminant, discriminant_SQLiteValue::Bytes);
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.Bytes) }
+    }
+
+    pub fn is_Bytes(&self) -> bool {
+        matches!(self.discriminant, discriminant_SQLiteValue::Bytes)
+    }
+
+    pub fn unwrap_Integer(mut self) -> i64 {
+        debug_assert_eq!(self.discriminant, discriminant_SQLiteValue::Integer);
+        unsafe { self.payload.Integer }
+    }
+
+    pub fn is_Integer(&self) -> bool {
+        matches!(self.discriminant, discriminant_SQLiteValue::Integer)
+    }
+
+    pub fn is_Null(&self) -> bool {
+        matches!(self.discriminant, discriminant_SQLiteValue::Null)
+    }
+
+    pub fn unwrap_Real(mut self) -> f64 {
+        debug_assert_eq!(self.discriminant, discriminant_SQLiteValue::Real);
+        unsafe { self.payload.Real }
+    }
+
+    pub fn is_Real(&self) -> bool {
+        matches!(self.discriminant, discriminant_SQLiteValue::Real)
+    }
+
+    pub fn unwrap_String(mut self) -> roc_std::RocStr {
+        debug_assert_eq!(self.discriminant, discriminant_SQLiteValue::String);
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.String) }
+    }
+
+    pub fn is_String(&self) -> bool {
+        matches!(self.discriminant, discriminant_SQLiteValue::String)
+    }
+}
+
+
+
+impl SQLiteValue {
+
+    pub fn Bytes(payload: roc_std::RocList<u8>) -> Self {
+        Self {
+            discriminant: discriminant_SQLiteValue::Bytes,
+            payload: union_SQLiteValue {
+                Bytes: core::mem::ManuallyDrop::new(payload),
+            }
+        }
+    }
+
+    pub fn Integer(payload: i64) -> Self {
+        Self {
+            discriminant: discriminant_SQLiteValue::Integer,
+            payload: union_SQLiteValue {
+                Integer: payload,
+            }
+        }
+    }
+
+    pub fn Null() -> Self {
+        Self {
+            discriminant: discriminant_SQLiteValue::Null,
+            payload: union_SQLiteValue {
+                Null: (),
+            }
+        }
+    }
+
+    pub fn Real(payload: f64) -> Self {
+        Self {
+            discriminant: discriminant_SQLiteValue::Real,
+            payload: union_SQLiteValue {
+                Real: payload,
+            }
+        }
+    }
+
+    pub fn String(payload: roc_std::RocStr) -> Self {
+        Self {
+            discriminant: discriminant_SQLiteValue::String,
+            payload: union_SQLiteValue {
+                String: core::mem::ManuallyDrop::new(payload),
+            }
+        }
+    }
+}
+
+impl Drop for SQLiteValue {
+    fn drop(&mut self) {
+        // Drop the payloads
+        match self.discriminant() {
+            discriminant_SQLiteValue::Bytes => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.Bytes) },
+            discriminant_SQLiteValue::Integer => {}
+            discriminant_SQLiteValue::Null => {}
+            discriminant_SQLiteValue::Real => {}
+            discriminant_SQLiteValue::String => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.String) },
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash, )]
+#[repr(u8)]
 pub enum discriminant_GlueTypes {
     A = 0,
     B = 1,
@@ -3486,6 +3759,7 @@ pub enum discriminant_GlueTypes {
     N = 13,
     O = 14,
     P = 15,
+    Q = 16,
 }
 
 impl core::fmt::Debug for discriminant_GlueTypes {
@@ -3507,11 +3781,12 @@ impl core::fmt::Debug for discriminant_GlueTypes {
             Self::N => f.write_str("discriminant_GlueTypes::N"),
             Self::O => f.write_str("discriminant_GlueTypes::O"),
             Self::P => f.write_str("discriminant_GlueTypes::P"),
+            Self::Q => f.write_str("discriminant_GlueTypes::Q"),
         }
     }
 }
 
-#[repr(C, align(4))]
+#[repr(C, align(8))]
 pub union union_GlueTypes {
     A: core::mem::ManuallyDrop<InternalCommand>,
     B: core::mem::ManuallyDrop<InternalOutput>,
@@ -3529,13 +3804,14 @@ pub union union_GlueTypes {
     N: core::mem::ManuallyDrop<InternalDirReadErr>,
     O: core::mem::ManuallyDrop<InternalDirDeleteErr>,
     P: core::mem::ManuallyDrop<UnwrappedPath>,
+    Q: core::mem::ManuallyDrop<SQLiteValue>,
 }
 
-const _SIZE_CHECK_union_GlueTypes: () = assert!(core::mem::size_of::<union_GlueTypes>() == 44);
-const _ALIGN_CHECK_union_GlueTypes: () = assert!(core::mem::align_of::<union_GlueTypes>() == 4);
+const _SIZE_CHECK_union_GlueTypes: () = assert!(core::mem::size_of::<union_GlueTypes>() == 48);
+const _ALIGN_CHECK_union_GlueTypes: () = assert!(core::mem::align_of::<union_GlueTypes>() == 8);
 
-const _SIZE_CHECK_GlueTypes: () = assert!(core::mem::size_of::<GlueTypes>() == 48);
-const _ALIGN_CHECK_GlueTypes: () = assert!(core::mem::align_of::<GlueTypes>() == 4);
+const _SIZE_CHECK_GlueTypes: () = assert!(core::mem::size_of::<GlueTypes>() == 56);
+const _ALIGN_CHECK_GlueTypes: () = assert!(core::mem::align_of::<GlueTypes>() == 8);
 
 impl GlueTypes {
     /// Returns which variant this tag union holds. Note that this never includes a payload!
@@ -3543,7 +3819,7 @@ impl GlueTypes {
         unsafe {
             let bytes = core::mem::transmute::<&Self, &[u8; core::mem::size_of::<Self>()]>(self);
 
-            core::mem::transmute::<u8, discriminant_GlueTypes>(*bytes.as_ptr().add(44))
+            core::mem::transmute::<u8, discriminant_GlueTypes>(*bytes.as_ptr().add(48))
         }
     }
 
@@ -3552,7 +3828,7 @@ impl GlueTypes {
         let discriminant_ptr: *mut discriminant_GlueTypes = (self as *mut GlueTypes).cast();
 
         unsafe {
-            *(discriminant_ptr.add(44)) = discriminant;
+            *(discriminant_ptr.add(48)) = discriminant;
         }
     }
 }
@@ -3616,6 +3892,9 @@ impl Clone for GlueTypes {
                 },
                 P => union_GlueTypes {
                     P: self.payload.P.clone(),
+                },
+                Q => union_GlueTypes {
+                    Q: self.payload.Q.clone(),
                 },
             }
         };
@@ -3697,12 +3976,14 @@ impl core::fmt::Debug for GlueTypes {
                     let field: &UnwrappedPath = &self.payload.P;
                     f.debug_tuple("GlueTypes::P").field(field).finish()
                 },
+                Q => {
+                    let field: &SQLiteValue = &self.payload.Q;
+                    f.debug_tuple("GlueTypes::Q").field(field).finish()
+                },
             }
         }
     }
 }
-
-impl Eq for GlueTypes {}
 
 impl PartialEq for GlueTypes {
     fn eq(&self, other: &Self) -> bool {
@@ -3730,14 +4011,9 @@ impl PartialEq for GlueTypes {
                 N => self.payload.N == other.payload.N,
                 O => self.payload.O == other.payload.O,
                 P => self.payload.P == other.payload.P,
+                Q => self.payload.Q == other.payload.Q,
             }
         }
-    }
-}
-
-impl Ord for GlueTypes {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
     }
 }
 
@@ -3768,35 +4044,9 @@ impl PartialOrd for GlueTypes {
                     N => self.payload.N.partial_cmp(&other.payload.N),
                     O => self.payload.O.partial_cmp(&other.payload.O),
                     P => self.payload.P.partial_cmp(&other.payload.P),
+                    Q => self.payload.Q.partial_cmp(&other.payload.Q),
                 }
             },
-        }
-    }
-}
-
-impl core::hash::Hash for GlueTypes {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        use discriminant_GlueTypes::*;
-
-        unsafe {
-            match self.discriminant {
-                A => self.payload.A.hash(state),
-                B => self.payload.B.hash(state),
-                C => self.payload.C.hash(state),
-                D => self.payload.D.hash(state),
-                E => self.payload.E.hash(state),
-                F => self.payload.F.hash(state),
-                G => self.payload.G.hash(state),
-                H => self.payload.H.hash(state),
-                I => self.payload.I.hash(state),
-                J => self.payload.J.hash(state),
-                K => self.payload.K.hash(state),
-                L => self.payload.L.hash(state),
-                M => self.payload.M.hash(state),
-                N => self.payload.N.hash(state),
-                O => self.payload.O.hash(state),
-                P => self.payload.P.hash(state),
-            }
         }
     }
 }
@@ -3945,6 +4195,15 @@ impl GlueTypes {
 
     pub fn is_P(&self) -> bool {
         matches!(self.discriminant, discriminant_GlueTypes::P)
+    }
+
+    pub fn unwrap_Q(mut self) -> SQLiteValue {
+        debug_assert_eq!(self.discriminant, discriminant_GlueTypes::Q);
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.Q) }
+    }
+
+    pub fn is_Q(&self) -> bool {
+        matches!(self.discriminant, discriminant_GlueTypes::Q)
     }
 }
 
@@ -4095,6 +4354,15 @@ impl GlueTypes {
             }
         }
     }
+
+    pub fn Q(payload: SQLiteValue) -> Self {
+        Self {
+            discriminant: discriminant_GlueTypes::Q,
+            payload: union_GlueTypes {
+                Q: core::mem::ManuallyDrop::new(payload),
+            }
+        }
+    }
 }
 
 impl Drop for GlueTypes {
@@ -4117,6 +4385,7 @@ impl Drop for GlueTypes {
             discriminant_GlueTypes::N => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.N) },
             discriminant_GlueTypes::O => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.O) },
             discriminant_GlueTypes::P => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.P) },
+            discriminant_GlueTypes::Q => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.Q) },
         }
     }
 }

--- a/platform/src/glue_manual/src/wasm32.rs
+++ b/platform/src/glue_manual/src/wasm32.rs
@@ -3469,6 +3469,279 @@ impl core::fmt::Debug for InternalDirDeleteErr {
 
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash, )]
 #[repr(u8)]
+pub enum discriminant_SQLiteValue {
+    Bytes = 0,
+    Integer = 1,
+    Null = 2,
+    Real = 3,
+    String = 4,
+}
+
+impl core::fmt::Debug for discriminant_SQLiteValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Bytes => f.write_str("discriminant_SQLiteValue::Bytes"),
+            Self::Integer => f.write_str("discriminant_SQLiteValue::Integer"),
+            Self::Null => f.write_str("discriminant_SQLiteValue::Null"),
+            Self::Real => f.write_str("discriminant_SQLiteValue::Real"),
+            Self::String => f.write_str("discriminant_SQLiteValue::String"),
+        }
+    }
+}
+
+#[repr(C, align(8))]
+pub union union_SQLiteValue {
+    Bytes: core::mem::ManuallyDrop<roc_std::RocList<u8>>,
+    Integer: i64,
+    Null: (),
+    Real: f64,
+    String: core::mem::ManuallyDrop<roc_std::RocStr>,
+}
+
+const _SIZE_CHECK_union_SQLiteValue: () = assert!(core::mem::size_of::<union_SQLiteValue>() == 16);
+const _ALIGN_CHECK_union_SQLiteValue: () = assert!(core::mem::align_of::<union_SQLiteValue>() == 8);
+
+const _SIZE_CHECK_SQLiteValue: () = assert!(core::mem::size_of::<SQLiteValue>() == 24);
+const _ALIGN_CHECK_SQLiteValue: () = assert!(core::mem::align_of::<SQLiteValue>() == 8);
+
+impl SQLiteValue {
+    /// Returns which variant this tag union holds. Note that this never includes a payload!
+    pub fn discriminant(&self) -> discriminant_SQLiteValue {
+        unsafe {
+            let bytes = core::mem::transmute::<&Self, &[u8; core::mem::size_of::<Self>()]>(self);
+
+            core::mem::transmute::<u8, discriminant_SQLiteValue>(*bytes.as_ptr().add(16))
+        }
+    }
+
+    /// Internal helper
+    fn set_discriminant(&mut self, discriminant: discriminant_SQLiteValue) {
+        let discriminant_ptr: *mut discriminant_SQLiteValue = (self as *mut SQLiteValue).cast();
+
+        unsafe {
+            *(discriminant_ptr.add(16)) = discriminant;
+        }
+    }
+}
+
+#[repr(C)]
+pub struct SQLiteValue {
+    payload: union_SQLiteValue,
+    discriminant: discriminant_SQLiteValue,
+}
+
+impl Clone for SQLiteValue {
+    fn clone(&self) -> Self {
+        use discriminant_SQLiteValue::*;
+
+        let payload = unsafe {
+            match self.discriminant {
+                Bytes => union_SQLiteValue {
+                    Bytes: self.payload.Bytes.clone(),
+                },
+                Integer => union_SQLiteValue {
+                    Integer: self.payload.Integer.clone(),
+                },
+                Null => union_SQLiteValue {
+                    Null: self.payload.Null.clone(),
+                },
+                Real => union_SQLiteValue {
+                    Real: self.payload.Real.clone(),
+                },
+                String => union_SQLiteValue {
+                    String: self.payload.String.clone(),
+                },
+            }
+        };
+
+        Self {
+            discriminant: self.discriminant,
+            payload,
+        }
+    }
+}
+
+impl core::fmt::Debug for SQLiteValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use discriminant_SQLiteValue::*;
+
+        unsafe {
+            match self.discriminant {
+                Bytes => {
+                    let field: &roc_std::RocList<u8> = &self.payload.Bytes;
+                    f.debug_tuple("SQLiteValue::Bytes").field(field).finish()
+                },
+                Integer => {
+                    let field: &i64 = &self.payload.Integer;
+                    f.debug_tuple("SQLiteValue::Integer").field(field).finish()
+                },
+                Null => {
+                    let field: &() = &self.payload.Null;
+                    f.debug_tuple("SQLiteValue::Null").field(field).finish()
+                },
+                Real => {
+                    let field: &f64 = &self.payload.Real;
+                    f.debug_tuple("SQLiteValue::Real").field(field).finish()
+                },
+                String => {
+                    let field: &roc_std::RocStr = &self.payload.String;
+                    f.debug_tuple("SQLiteValue::String").field(field).finish()
+                },
+            }
+        }
+    }
+}
+
+impl PartialEq for SQLiteValue {
+    fn eq(&self, other: &Self) -> bool {
+        use discriminant_SQLiteValue::*;
+
+        if self.discriminant != other.discriminant {
+            return false;
+        }
+
+        unsafe {
+            match self.discriminant {
+                Bytes => self.payload.Bytes == other.payload.Bytes,
+                Integer => self.payload.Integer == other.payload.Integer,
+                Null => self.payload.Null == other.payload.Null,
+                Real => self.payload.Real == other.payload.Real,
+                String => self.payload.String == other.payload.String,
+            }
+        }
+    }
+}
+
+impl PartialOrd for SQLiteValue {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        use discriminant_SQLiteValue::*;
+
+        use std::cmp::Ordering::*;
+
+        match self.discriminant.cmp(&other.discriminant) {
+            Less => Option::Some(Less),
+            Greater => Option::Some(Greater),
+            Equal => unsafe {
+                match self.discriminant {
+                    Bytes => self.payload.Bytes.partial_cmp(&other.payload.Bytes),
+                    Integer => self.payload.Integer.partial_cmp(&other.payload.Integer),
+                    Null => self.payload.Null.partial_cmp(&other.payload.Null),
+                    Real => self.payload.Real.partial_cmp(&other.payload.Real),
+                    String => self.payload.String.partial_cmp(&other.payload.String),
+                }
+            },
+        }
+    }
+}
+
+impl SQLiteValue {
+
+    pub fn unwrap_Bytes(mut self) -> roc_std::RocList<u8> {
+        debug_assert_eq!(self.discriminant, discriminant_SQLiteValue::Bytes);
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.Bytes) }
+    }
+
+    pub fn is_Bytes(&self) -> bool {
+        matches!(self.discriminant, discriminant_SQLiteValue::Bytes)
+    }
+
+    pub fn unwrap_Integer(mut self) -> i64 {
+        debug_assert_eq!(self.discriminant, discriminant_SQLiteValue::Integer);
+        unsafe { self.payload.Integer }
+    }
+
+    pub fn is_Integer(&self) -> bool {
+        matches!(self.discriminant, discriminant_SQLiteValue::Integer)
+    }
+
+    pub fn is_Null(&self) -> bool {
+        matches!(self.discriminant, discriminant_SQLiteValue::Null)
+    }
+
+    pub fn unwrap_Real(mut self) -> f64 {
+        debug_assert_eq!(self.discriminant, discriminant_SQLiteValue::Real);
+        unsafe { self.payload.Real }
+    }
+
+    pub fn is_Real(&self) -> bool {
+        matches!(self.discriminant, discriminant_SQLiteValue::Real)
+    }
+
+    pub fn unwrap_String(mut self) -> roc_std::RocStr {
+        debug_assert_eq!(self.discriminant, discriminant_SQLiteValue::String);
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.String) }
+    }
+
+    pub fn is_String(&self) -> bool {
+        matches!(self.discriminant, discriminant_SQLiteValue::String)
+    }
+}
+
+
+
+impl SQLiteValue {
+
+    pub fn Bytes(payload: roc_std::RocList<u8>) -> Self {
+        Self {
+            discriminant: discriminant_SQLiteValue::Bytes,
+            payload: union_SQLiteValue {
+                Bytes: core::mem::ManuallyDrop::new(payload),
+            }
+        }
+    }
+
+    pub fn Integer(payload: i64) -> Self {
+        Self {
+            discriminant: discriminant_SQLiteValue::Integer,
+            payload: union_SQLiteValue {
+                Integer: payload,
+            }
+        }
+    }
+
+    pub fn Null() -> Self {
+        Self {
+            discriminant: discriminant_SQLiteValue::Null,
+            payload: union_SQLiteValue {
+                Null: (),
+            }
+        }
+    }
+
+    pub fn Real(payload: f64) -> Self {
+        Self {
+            discriminant: discriminant_SQLiteValue::Real,
+            payload: union_SQLiteValue {
+                Real: payload,
+            }
+        }
+    }
+
+    pub fn String(payload: roc_std::RocStr) -> Self {
+        Self {
+            discriminant: discriminant_SQLiteValue::String,
+            payload: union_SQLiteValue {
+                String: core::mem::ManuallyDrop::new(payload),
+            }
+        }
+    }
+}
+
+impl Drop for SQLiteValue {
+    fn drop(&mut self) {
+        // Drop the payloads
+        match self.discriminant() {
+            discriminant_SQLiteValue::Bytes => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.Bytes) },
+            discriminant_SQLiteValue::Integer => {}
+            discriminant_SQLiteValue::Null => {}
+            discriminant_SQLiteValue::Real => {}
+            discriminant_SQLiteValue::String => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.String) },
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash, )]
+#[repr(u8)]
 pub enum discriminant_GlueTypes {
     A = 0,
     B = 1,
@@ -3486,6 +3759,7 @@ pub enum discriminant_GlueTypes {
     N = 13,
     O = 14,
     P = 15,
+    Q = 16,
 }
 
 impl core::fmt::Debug for discriminant_GlueTypes {
@@ -3507,11 +3781,12 @@ impl core::fmt::Debug for discriminant_GlueTypes {
             Self::N => f.write_str("discriminant_GlueTypes::N"),
             Self::O => f.write_str("discriminant_GlueTypes::O"),
             Self::P => f.write_str("discriminant_GlueTypes::P"),
+            Self::Q => f.write_str("discriminant_GlueTypes::Q"),
         }
     }
 }
 
-#[repr(C, align(4))]
+#[repr(C, align(8))]
 pub union union_GlueTypes {
     A: core::mem::ManuallyDrop<InternalCommand>,
     B: core::mem::ManuallyDrop<InternalOutput>,
@@ -3529,13 +3804,14 @@ pub union union_GlueTypes {
     N: core::mem::ManuallyDrop<InternalDirReadErr>,
     O: core::mem::ManuallyDrop<InternalDirDeleteErr>,
     P: core::mem::ManuallyDrop<UnwrappedPath>,
+    Q: core::mem::ManuallyDrop<SQLiteValue>,
 }
 
-const _SIZE_CHECK_union_GlueTypes: () = assert!(core::mem::size_of::<union_GlueTypes>() == 44);
-const _ALIGN_CHECK_union_GlueTypes: () = assert!(core::mem::align_of::<union_GlueTypes>() == 4);
+const _SIZE_CHECK_union_GlueTypes: () = assert!(core::mem::size_of::<union_GlueTypes>() == 48);
+const _ALIGN_CHECK_union_GlueTypes: () = assert!(core::mem::align_of::<union_GlueTypes>() == 8);
 
-const _SIZE_CHECK_GlueTypes: () = assert!(core::mem::size_of::<GlueTypes>() == 48);
-const _ALIGN_CHECK_GlueTypes: () = assert!(core::mem::align_of::<GlueTypes>() == 4);
+const _SIZE_CHECK_GlueTypes: () = assert!(core::mem::size_of::<GlueTypes>() == 56);
+const _ALIGN_CHECK_GlueTypes: () = assert!(core::mem::align_of::<GlueTypes>() == 8);
 
 impl GlueTypes {
     /// Returns which variant this tag union holds. Note that this never includes a payload!
@@ -3543,7 +3819,7 @@ impl GlueTypes {
         unsafe {
             let bytes = core::mem::transmute::<&Self, &[u8; core::mem::size_of::<Self>()]>(self);
 
-            core::mem::transmute::<u8, discriminant_GlueTypes>(*bytes.as_ptr().add(44))
+            core::mem::transmute::<u8, discriminant_GlueTypes>(*bytes.as_ptr().add(48))
         }
     }
 
@@ -3552,7 +3828,7 @@ impl GlueTypes {
         let discriminant_ptr: *mut discriminant_GlueTypes = (self as *mut GlueTypes).cast();
 
         unsafe {
-            *(discriminant_ptr.add(44)) = discriminant;
+            *(discriminant_ptr.add(48)) = discriminant;
         }
     }
 }
@@ -3616,6 +3892,9 @@ impl Clone for GlueTypes {
                 },
                 P => union_GlueTypes {
                     P: self.payload.P.clone(),
+                },
+                Q => union_GlueTypes {
+                    Q: self.payload.Q.clone(),
                 },
             }
         };
@@ -3697,12 +3976,14 @@ impl core::fmt::Debug for GlueTypes {
                     let field: &UnwrappedPath = &self.payload.P;
                     f.debug_tuple("GlueTypes::P").field(field).finish()
                 },
+                Q => {
+                    let field: &SQLiteValue = &self.payload.Q;
+                    f.debug_tuple("GlueTypes::Q").field(field).finish()
+                },
             }
         }
     }
 }
-
-impl Eq for GlueTypes {}
 
 impl PartialEq for GlueTypes {
     fn eq(&self, other: &Self) -> bool {
@@ -3730,14 +4011,9 @@ impl PartialEq for GlueTypes {
                 N => self.payload.N == other.payload.N,
                 O => self.payload.O == other.payload.O,
                 P => self.payload.P == other.payload.P,
+                Q => self.payload.Q == other.payload.Q,
             }
         }
-    }
-}
-
-impl Ord for GlueTypes {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
     }
 }
 
@@ -3768,35 +4044,9 @@ impl PartialOrd for GlueTypes {
                     N => self.payload.N.partial_cmp(&other.payload.N),
                     O => self.payload.O.partial_cmp(&other.payload.O),
                     P => self.payload.P.partial_cmp(&other.payload.P),
+                    Q => self.payload.Q.partial_cmp(&other.payload.Q),
                 }
             },
-        }
-    }
-}
-
-impl core::hash::Hash for GlueTypes {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        use discriminant_GlueTypes::*;
-
-        unsafe {
-            match self.discriminant {
-                A => self.payload.A.hash(state),
-                B => self.payload.B.hash(state),
-                C => self.payload.C.hash(state),
-                D => self.payload.D.hash(state),
-                E => self.payload.E.hash(state),
-                F => self.payload.F.hash(state),
-                G => self.payload.G.hash(state),
-                H => self.payload.H.hash(state),
-                I => self.payload.I.hash(state),
-                J => self.payload.J.hash(state),
-                K => self.payload.K.hash(state),
-                L => self.payload.L.hash(state),
-                M => self.payload.M.hash(state),
-                N => self.payload.N.hash(state),
-                O => self.payload.O.hash(state),
-                P => self.payload.P.hash(state),
-            }
         }
     }
 }
@@ -3945,6 +4195,15 @@ impl GlueTypes {
 
     pub fn is_P(&self) -> bool {
         matches!(self.discriminant, discriminant_GlueTypes::P)
+    }
+
+    pub fn unwrap_Q(mut self) -> SQLiteValue {
+        debug_assert_eq!(self.discriminant, discriminant_GlueTypes::Q);
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.Q) }
+    }
+
+    pub fn is_Q(&self) -> bool {
+        matches!(self.discriminant, discriminant_GlueTypes::Q)
     }
 }
 
@@ -4095,6 +4354,15 @@ impl GlueTypes {
             }
         }
     }
+
+    pub fn Q(payload: SQLiteValue) -> Self {
+        Self {
+            discriminant: discriminant_GlueTypes::Q,
+            payload: union_GlueTypes {
+                Q: core::mem::ManuallyDrop::new(payload),
+            }
+        }
+    }
 }
 
 impl Drop for GlueTypes {
@@ -4117,6 +4385,7 @@ impl Drop for GlueTypes {
             discriminant_GlueTypes::N => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.N) },
             discriminant_GlueTypes::O => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.O) },
             discriminant_GlueTypes::P => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.P) },
+            discriminant_GlueTypes::Q => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.Q) },
         }
     }
 }

--- a/platform/src/glue_manual/src/x86.rs
+++ b/platform/src/glue_manual/src/x86.rs
@@ -3469,6 +3469,279 @@ impl core::fmt::Debug for InternalDirDeleteErr {
 
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash, )]
 #[repr(u8)]
+pub enum discriminant_SQLiteValue {
+    Bytes = 0,
+    Integer = 1,
+    Null = 2,
+    Real = 3,
+    String = 4,
+}
+
+impl core::fmt::Debug for discriminant_SQLiteValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Bytes => f.write_str("discriminant_SQLiteValue::Bytes"),
+            Self::Integer => f.write_str("discriminant_SQLiteValue::Integer"),
+            Self::Null => f.write_str("discriminant_SQLiteValue::Null"),
+            Self::Real => f.write_str("discriminant_SQLiteValue::Real"),
+            Self::String => f.write_str("discriminant_SQLiteValue::String"),
+        }
+    }
+}
+
+#[repr(C, align(4))]
+pub union union_SQLiteValue {
+    Bytes: core::mem::ManuallyDrop<roc_std::RocList<u8>>,
+    Integer: i64,
+    Null: (),
+    Real: f64,
+    String: core::mem::ManuallyDrop<roc_std::RocStr>,
+}
+
+const _SIZE_CHECK_union_SQLiteValue: () = assert!(core::mem::size_of::<union_SQLiteValue>() == 12);
+const _ALIGN_CHECK_union_SQLiteValue: () = assert!(core::mem::align_of::<union_SQLiteValue>() == 4);
+
+const _SIZE_CHECK_SQLiteValue: () = assert!(core::mem::size_of::<SQLiteValue>() == 16);
+const _ALIGN_CHECK_SQLiteValue: () = assert!(core::mem::align_of::<SQLiteValue>() == 4);
+
+impl SQLiteValue {
+    /// Returns which variant this tag union holds. Note that this never includes a payload!
+    pub fn discriminant(&self) -> discriminant_SQLiteValue {
+        unsafe {
+            let bytes = core::mem::transmute::<&Self, &[u8; core::mem::size_of::<Self>()]>(self);
+
+            core::mem::transmute::<u8, discriminant_SQLiteValue>(*bytes.as_ptr().add(12))
+        }
+    }
+
+    /// Internal helper
+    fn set_discriminant(&mut self, discriminant: discriminant_SQLiteValue) {
+        let discriminant_ptr: *mut discriminant_SQLiteValue = (self as *mut SQLiteValue).cast();
+
+        unsafe {
+            *(discriminant_ptr.add(12)) = discriminant;
+        }
+    }
+}
+
+#[repr(C)]
+pub struct SQLiteValue {
+    payload: union_SQLiteValue,
+    discriminant: discriminant_SQLiteValue,
+}
+
+impl Clone for SQLiteValue {
+    fn clone(&self) -> Self {
+        use discriminant_SQLiteValue::*;
+
+        let payload = unsafe {
+            match self.discriminant {
+                Bytes => union_SQLiteValue {
+                    Bytes: self.payload.Bytes.clone(),
+                },
+                Integer => union_SQLiteValue {
+                    Integer: self.payload.Integer.clone(),
+                },
+                Null => union_SQLiteValue {
+                    Null: self.payload.Null.clone(),
+                },
+                Real => union_SQLiteValue {
+                    Real: self.payload.Real.clone(),
+                },
+                String => union_SQLiteValue {
+                    String: self.payload.String.clone(),
+                },
+            }
+        };
+
+        Self {
+            discriminant: self.discriminant,
+            payload,
+        }
+    }
+}
+
+impl core::fmt::Debug for SQLiteValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use discriminant_SQLiteValue::*;
+
+        unsafe {
+            match self.discriminant {
+                Bytes => {
+                    let field: &roc_std::RocList<u8> = &self.payload.Bytes;
+                    f.debug_tuple("SQLiteValue::Bytes").field(field).finish()
+                },
+                Integer => {
+                    let field: &i64 = &self.payload.Integer;
+                    f.debug_tuple("SQLiteValue::Integer").field(field).finish()
+                },
+                Null => {
+                    let field: &() = &self.payload.Null;
+                    f.debug_tuple("SQLiteValue::Null").field(field).finish()
+                },
+                Real => {
+                    let field: &f64 = &self.payload.Real;
+                    f.debug_tuple("SQLiteValue::Real").field(field).finish()
+                },
+                String => {
+                    let field: &roc_std::RocStr = &self.payload.String;
+                    f.debug_tuple("SQLiteValue::String").field(field).finish()
+                },
+            }
+        }
+    }
+}
+
+impl PartialEq for SQLiteValue {
+    fn eq(&self, other: &Self) -> bool {
+        use discriminant_SQLiteValue::*;
+
+        if self.discriminant != other.discriminant {
+            return false;
+        }
+
+        unsafe {
+            match self.discriminant {
+                Bytes => self.payload.Bytes == other.payload.Bytes,
+                Integer => self.payload.Integer == other.payload.Integer,
+                Null => self.payload.Null == other.payload.Null,
+                Real => self.payload.Real == other.payload.Real,
+                String => self.payload.String == other.payload.String,
+            }
+        }
+    }
+}
+
+impl PartialOrd for SQLiteValue {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        use discriminant_SQLiteValue::*;
+
+        use std::cmp::Ordering::*;
+
+        match self.discriminant.cmp(&other.discriminant) {
+            Less => Option::Some(Less),
+            Greater => Option::Some(Greater),
+            Equal => unsafe {
+                match self.discriminant {
+                    Bytes => self.payload.Bytes.partial_cmp(&other.payload.Bytes),
+                    Integer => self.payload.Integer.partial_cmp(&other.payload.Integer),
+                    Null => self.payload.Null.partial_cmp(&other.payload.Null),
+                    Real => self.payload.Real.partial_cmp(&other.payload.Real),
+                    String => self.payload.String.partial_cmp(&other.payload.String),
+                }
+            },
+        }
+    }
+}
+
+impl SQLiteValue {
+
+    pub fn unwrap_Bytes(mut self) -> roc_std::RocList<u8> {
+        debug_assert_eq!(self.discriminant, discriminant_SQLiteValue::Bytes);
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.Bytes) }
+    }
+
+    pub fn is_Bytes(&self) -> bool {
+        matches!(self.discriminant, discriminant_SQLiteValue::Bytes)
+    }
+
+    pub fn unwrap_Integer(mut self) -> i64 {
+        debug_assert_eq!(self.discriminant, discriminant_SQLiteValue::Integer);
+        unsafe { self.payload.Integer }
+    }
+
+    pub fn is_Integer(&self) -> bool {
+        matches!(self.discriminant, discriminant_SQLiteValue::Integer)
+    }
+
+    pub fn is_Null(&self) -> bool {
+        matches!(self.discriminant, discriminant_SQLiteValue::Null)
+    }
+
+    pub fn unwrap_Real(mut self) -> f64 {
+        debug_assert_eq!(self.discriminant, discriminant_SQLiteValue::Real);
+        unsafe { self.payload.Real }
+    }
+
+    pub fn is_Real(&self) -> bool {
+        matches!(self.discriminant, discriminant_SQLiteValue::Real)
+    }
+
+    pub fn unwrap_String(mut self) -> roc_std::RocStr {
+        debug_assert_eq!(self.discriminant, discriminant_SQLiteValue::String);
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.String) }
+    }
+
+    pub fn is_String(&self) -> bool {
+        matches!(self.discriminant, discriminant_SQLiteValue::String)
+    }
+}
+
+
+
+impl SQLiteValue {
+
+    pub fn Bytes(payload: roc_std::RocList<u8>) -> Self {
+        Self {
+            discriminant: discriminant_SQLiteValue::Bytes,
+            payload: union_SQLiteValue {
+                Bytes: core::mem::ManuallyDrop::new(payload),
+            }
+        }
+    }
+
+    pub fn Integer(payload: i64) -> Self {
+        Self {
+            discriminant: discriminant_SQLiteValue::Integer,
+            payload: union_SQLiteValue {
+                Integer: payload,
+            }
+        }
+    }
+
+    pub fn Null() -> Self {
+        Self {
+            discriminant: discriminant_SQLiteValue::Null,
+            payload: union_SQLiteValue {
+                Null: (),
+            }
+        }
+    }
+
+    pub fn Real(payload: f64) -> Self {
+        Self {
+            discriminant: discriminant_SQLiteValue::Real,
+            payload: union_SQLiteValue {
+                Real: payload,
+            }
+        }
+    }
+
+    pub fn String(payload: roc_std::RocStr) -> Self {
+        Self {
+            discriminant: discriminant_SQLiteValue::String,
+            payload: union_SQLiteValue {
+                String: core::mem::ManuallyDrop::new(payload),
+            }
+        }
+    }
+}
+
+impl Drop for SQLiteValue {
+    fn drop(&mut self) {
+        // Drop the payloads
+        match self.discriminant() {
+            discriminant_SQLiteValue::Bytes => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.Bytes) },
+            discriminant_SQLiteValue::Integer => {}
+            discriminant_SQLiteValue::Null => {}
+            discriminant_SQLiteValue::Real => {}
+            discriminant_SQLiteValue::String => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.String) },
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash, )]
+#[repr(u8)]
 pub enum discriminant_GlueTypes {
     A = 0,
     B = 1,
@@ -3486,6 +3759,7 @@ pub enum discriminant_GlueTypes {
     N = 13,
     O = 14,
     P = 15,
+    Q = 16,
 }
 
 impl core::fmt::Debug for discriminant_GlueTypes {
@@ -3507,6 +3781,7 @@ impl core::fmt::Debug for discriminant_GlueTypes {
             Self::N => f.write_str("discriminant_GlueTypes::N"),
             Self::O => f.write_str("discriminant_GlueTypes::O"),
             Self::P => f.write_str("discriminant_GlueTypes::P"),
+            Self::Q => f.write_str("discriminant_GlueTypes::Q"),
         }
     }
 }
@@ -3529,6 +3804,7 @@ pub union union_GlueTypes {
     N: core::mem::ManuallyDrop<InternalDirReadErr>,
     O: core::mem::ManuallyDrop<InternalDirDeleteErr>,
     P: core::mem::ManuallyDrop<UnwrappedPath>,
+    Q: core::mem::ManuallyDrop<SQLiteValue>,
 }
 
 const _SIZE_CHECK_union_GlueTypes: () = assert!(core::mem::size_of::<union_GlueTypes>() == 44);
@@ -3617,6 +3893,9 @@ impl Clone for GlueTypes {
                 P => union_GlueTypes {
                     P: self.payload.P.clone(),
                 },
+                Q => union_GlueTypes {
+                    Q: self.payload.Q.clone(),
+                },
             }
         };
 
@@ -3697,12 +3976,14 @@ impl core::fmt::Debug for GlueTypes {
                     let field: &UnwrappedPath = &self.payload.P;
                     f.debug_tuple("GlueTypes::P").field(field).finish()
                 },
+                Q => {
+                    let field: &SQLiteValue = &self.payload.Q;
+                    f.debug_tuple("GlueTypes::Q").field(field).finish()
+                },
             }
         }
     }
 }
-
-impl Eq for GlueTypes {}
 
 impl PartialEq for GlueTypes {
     fn eq(&self, other: &Self) -> bool {
@@ -3730,14 +4011,9 @@ impl PartialEq for GlueTypes {
                 N => self.payload.N == other.payload.N,
                 O => self.payload.O == other.payload.O,
                 P => self.payload.P == other.payload.P,
+                Q => self.payload.Q == other.payload.Q,
             }
         }
-    }
-}
-
-impl Ord for GlueTypes {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
     }
 }
 
@@ -3768,35 +4044,9 @@ impl PartialOrd for GlueTypes {
                     N => self.payload.N.partial_cmp(&other.payload.N),
                     O => self.payload.O.partial_cmp(&other.payload.O),
                     P => self.payload.P.partial_cmp(&other.payload.P),
+                    Q => self.payload.Q.partial_cmp(&other.payload.Q),
                 }
             },
-        }
-    }
-}
-
-impl core::hash::Hash for GlueTypes {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        use discriminant_GlueTypes::*;
-
-        unsafe {
-            match self.discriminant {
-                A => self.payload.A.hash(state),
-                B => self.payload.B.hash(state),
-                C => self.payload.C.hash(state),
-                D => self.payload.D.hash(state),
-                E => self.payload.E.hash(state),
-                F => self.payload.F.hash(state),
-                G => self.payload.G.hash(state),
-                H => self.payload.H.hash(state),
-                I => self.payload.I.hash(state),
-                J => self.payload.J.hash(state),
-                K => self.payload.K.hash(state),
-                L => self.payload.L.hash(state),
-                M => self.payload.M.hash(state),
-                N => self.payload.N.hash(state),
-                O => self.payload.O.hash(state),
-                P => self.payload.P.hash(state),
-            }
         }
     }
 }
@@ -3945,6 +4195,15 @@ impl GlueTypes {
 
     pub fn is_P(&self) -> bool {
         matches!(self.discriminant, discriminant_GlueTypes::P)
+    }
+
+    pub fn unwrap_Q(mut self) -> SQLiteValue {
+        debug_assert_eq!(self.discriminant, discriminant_GlueTypes::Q);
+        unsafe { core::mem::ManuallyDrop::take(&mut self.payload.Q) }
+    }
+
+    pub fn is_Q(&self) -> bool {
+        matches!(self.discriminant, discriminant_GlueTypes::Q)
     }
 }
 
@@ -4095,6 +4354,15 @@ impl GlueTypes {
             }
         }
     }
+
+    pub fn Q(payload: SQLiteValue) -> Self {
+        Self {
+            discriminant: discriminant_GlueTypes::Q,
+            payload: union_GlueTypes {
+                Q: core::mem::ManuallyDrop::new(payload),
+            }
+        }
+    }
 }
 
 impl Drop for GlueTypes {
@@ -4117,6 +4385,7 @@ impl Drop for GlueTypes {
             discriminant_GlueTypes::N => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.N) },
             discriminant_GlueTypes::O => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.O) },
             discriminant_GlueTypes::P => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.P) },
+            discriminant_GlueTypes::Q => unsafe { core::mem::ManuallyDrop::drop(&mut self.payload.Q) },
         }
     }
 }

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -4,7 +4,6 @@ use std::cell::RefCell;
 use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
 use std::iter::FromIterator;
 use std::net::TcpStream;
-use std::os::macos::raw::stat;
 use std::os::raw::c_void;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -731,14 +730,59 @@ fn os_str_to_roc_path(os_str: &std::ffi::OsStr) -> RocList<u8> {
 
 #[repr(C, align(8))]
 pub struct SQLiteError {
-    code : i64,
-    message : roc_std::RocStr,
+    code: i64,
+    message: roc_std::RocStr,
 }
 
 #[repr(C, align(8))]
 pub struct SQLiteBindings {
-    name : roc_std::RocStr,
-    value : roc_std::RocStr,
+    name: roc_std::RocStr,
+    value: roc_std::RocStr,
+}
+
+struct SQLiteConnection {
+    path: String,
+    connection: std::sync::Arc<sqlite::Connection>,
+}
+
+static INIT_GLOBAL_CONNECTION_STORE: std::sync::Once = std::sync::Once::new();
+static mut GLOBAL_SQLITE_CONNECTIONS: *mut std::sync::Mutex<Vec<SQLiteConnection>> =
+    std::ptr::null_mut();
+
+fn get_connection(path: &str) -> Result<std::sync::Arc<sqlite::Connection>, sqlite::Error> {
+    use std::sync::Arc;
+
+    let store: &'static std::sync::Mutex<Vec<SQLiteConnection>> = unsafe {
+        INIT_GLOBAL_CONNECTION_STORE.call_once(|| {
+            GLOBAL_SQLITE_CONNECTIONS = Box::into_raw(Box::new(std::sync::Mutex::new(Vec::new())));
+        });
+        &*GLOBAL_SQLITE_CONNECTIONS
+    };
+
+    let mut opened_store = store.lock().unwrap();
+
+    for c in opened_store.iter() {
+        if c.path == path {
+            return Ok(Arc::clone(&c.connection));
+        }
+    }
+
+    let connection: sqlite::Connection = match sqlite::open(path) {
+        Ok(new_con) => new_con,
+        Err(err) => {
+            return Err(err);
+        }
+    };
+
+    let arc_connection = Arc::new(connection);
+    let new_connection = SQLiteConnection {
+        path: path.to_owned(),
+        connection: Arc::clone(&arc_connection),
+    };
+
+    opened_store.push(new_connection);
+
+    Ok(arc_connection)
 }
 
 #[roc_fn(name = "sqliteExecute")]
@@ -747,10 +791,9 @@ fn sqlite_execute(
     query: &roc_std::RocStr,
     bindings: &roc_std::RocList<SQLiteBindings>,
 ) -> roc_std::RocResult<RocList<RocList<glue_manual::SQLiteValue>>, SQLiteError> {
-    
-    // Create the connection
-    let connection : sqlite::Connection = {
-        match sqlite::open(db_path.as_str()) {
+    // Get the connection
+    let connection = {
+        match get_connection(db_path.as_str()) {
             Ok(c) => c,
             Err(err) => {
                 return RocResult::err(SQLiteError {
@@ -776,8 +819,8 @@ fn sqlite_execute(
 
     // Add bindings for the query
     for binding in bindings {
-        match statement.bind((binding.name.as_str(),binding.value.as_str())) {
-            Ok(()) => {},
+        match statement.bind((binding.name.as_str(), binding.value.as_str())) {
+            Ok(()) => {}
             Err(err) => {
                 return RocResult::err(SQLiteError {
                     code: err.code.unwrap_or_default() as i64,
@@ -791,12 +834,11 @@ fn sqlite_execute(
     let column_count = cursor.column_count();
 
     // Save space for 1000 rows without allocating
-    let mut roc_values : RocList<RocList<glue_manual::SQLiteValue>> = RocList::with_capacity(1000); 
+    let mut roc_values: RocList<RocList<glue_manual::SQLiteValue>> = RocList::with_capacity(1000);
 
     while let Ok(Some(row_values)) = cursor.try_next() {
-
         let mut row = RocList::with_capacity(column_count);
-        
+
         // For each column in the row
         for value in row_values {
             row.push(roc_sql_from_sqlite_value(value));
@@ -806,12 +848,13 @@ fn sqlite_execute(
     }
 
     RocResult::ok(roc_values)
-
 }
 
 fn roc_sql_from_sqlite_value(value: sqlite::Value) -> glue_manual::SQLiteValue {
     match value {
-        sqlite::Value::Binary(bytes) => glue_manual::SQLiteValue::Bytes(RocList::from_slice(&bytes[..])),
+        sqlite::Value::Binary(bytes) => {
+            glue_manual::SQLiteValue::Bytes(RocList::from_slice(&bytes[..]))
+        }
         sqlite::Value::Float(f64) => glue_manual::SQLiteValue::Real(f64),
         sqlite::Value::Integer(i64) => glue_manual::SQLiteValue::Integer(i64),
         sqlite::Value::String(str) => glue_manual::SQLiteValue::String(RocStr::from(str.as_str())),

--- a/platform/src/roc_fn/src/lib.rs
+++ b/platform/src/roc_fn/src/lib.rs
@@ -155,8 +155,8 @@ const ROC_HOSTED_FNS: &[HostedFn] = &[
     },
     HostedFn {
         name: "sqliteExecute",
-        arg_types: &["&roc_std::RocStr", "&roc_std::RocStr"],
-        ret_type: "roc_std::RocResult<(), SQLiteError>",
+        arg_types: &["&roc_std::RocStr", "&roc_std::RocStr", "&roc_std::RocList<SQLiteBindings>"],
+        ret_type: "roc_std::RocResult<RocList<RocList<glue_manual::SQLiteValue>>, SQLiteError>",
     },
     ];
 

--- a/platform/src/roc_fn/src/lib.rs
+++ b/platform/src/roc_fn/src/lib.rs
@@ -153,6 +153,11 @@ const ROC_HOSTED_FNS: &[HostedFn] = &[
         arg_types: &["&roc_std::RocList<u8>"],
         ret_type: "roc_std::RocResult<roc_std::RocList<roc_std::RocList<u8>>, glue_manual::InternalDirReadErr>",
     },
+    HostedFn {
+        name: "sqliteExecute",
+        arg_types: &["&roc_std::RocStr", "&roc_std::RocStr"],
+        ret_type: "roc_std::RocResult<(), SQLiteError>",
+    },
     ];
 
 fn find_hosted_fn_by_name(name: &str) -> Option<HostedFn> {


### PR DESCRIPTION
This PR adds functionality for querying SQLite3, see discussion on [zulip](https://roc.zulipchat.com/#narrow/stream/304641-ideas/topic/basic-webserver.20Sqlite3/near/420178165). 

The current API includes an `execute` task which is minimal but covers most use cases.

```ruby
# Definition in "platform/SQLite3.roc"
execute :
    {
        path : Str,
        query : Str,
        bindings : List Binding,
    }
    -> Task (List (List Value)) Error

# Query todos table
rows <-
    SQLite3.execute {
        path: maybeDbPath |> Result.withDefault "<DB_PATH> not set on environment",
        query: "SELECT id, task FROM todos WHERE status = :status;",
        bindings: [{ name: ":status", value: "completed" }],
    }
    |> Task.map \rows ->
        # Parse each row into a string
        List.map rows \cols ->
            when cols is
                [Integer id, String task] -> "row $(Num.toStr id), task: $(task)"
                _ -> crash "unexpected values returned, expected Integer and String got $(Inspect.toStr cols)"
    |> Task.onErr \err ->
        # Crash on any errors for now
        crash "$(SQLite3.errToStr err)"
    |> Task.await
```

The SQLIite3 values supported are;

```ruby
SQLiteValue : [
    Null,
    Real F64,
    Integer I64,
    String Str,
    Bytes (List U8),
]
```

Connections are cached in the platform so that they can be reused between calls.

Here is an example of parsing the rows returned by a query

```ruby
parseCompletedTodos : List (List SQLite3.Value) -> List Str
parseCompletedTodos = \rows ->
    rows
    |> List.map \cols ->
        when cols is
            [Integer id, String task] -> "row $(Num.toStr id), task: $(task)"
            _ -> crash "unexpected values returned, expected Integer and String got $(Inspect.toStr cols)"
```