### PR TITLE
Add `Task.result`

### DIFF
--- a/ci/all_tests.sh
+++ b/ci/all_tests.sh
@@ -61,6 +61,7 @@ expect ci/expect_scripts/error-handling.exp
 expect ci/expect_scripts/file.exp
 expect ci/expect_scripts/hello-web.exp
 expect ci/expect_scripts/sleep.exp
+expect ci/expect_scripts/result.exp
 
 # test building website
 $ROC docs platform/main.roc

--- a/ci/expect_scripts/result.exp
+++ b/ci/expect_scripts/result.exp
@@ -1,0 +1,22 @@
+#!/usr/bin/expect
+
+# uncomment line below for debugging
+# exp_internal 1
+
+set timeout 7
+
+spawn $env(EXAMPLES_DIR)result
+
+expect "Listening on localhost port 8000\r\n" {
+    set curlOutput [exec curl -sS localhost:8000 -d ""]
+
+    if {$curlOutput eq "GOOD"} {
+        exit 0
+    } else {
+        puts "Error: curl output was different than expected: $curlOutput"
+        exit 1
+    }
+}
+
+puts stderr "\nError: output was different than expected."
+exit 1

--- a/examples/result.roc
+++ b/examples/result.roc
@@ -1,0 +1,23 @@
+app "result"
+    packages { pf: "../platform/main.roc" }
+    imports [
+        pf.Task.{ Task },
+        pf.Http.{ Request, Response },
+    ]
+    provides [main] to pf
+
+main : Request -> Task Response []
+main = \_ ->
+    when checkFile "good" |> Task.result! is
+        Ok Good -> Task.ok { status: 200, headers: [], body: Str.toUtf8 "GOOD" }
+        Ok Bad -> Task.ok { status: 200, headers: [], body: Str.toUtf8 "BAD" }
+        Err IOError -> Task.ok { status: 200, headers: [], body: Str.toUtf8 "ERROR" }     
+
+checkFile : Str -> Task [Good, Bad] [IOError]
+checkFile = \str ->
+    if str == "good" then 
+        Task.ok Good 
+    else if str == "bad" then 
+        Task.ok Bad 
+    else 
+        Task.err IOError

--- a/examples/result.roc
+++ b/examples/result.roc
@@ -6,12 +6,16 @@ app "result"
     ]
     provides [main] to pf
 
+# This example demonstrates the use of `Task.result`.
+# It transforms a task that can either succeed with `ok`, or fail with `err`, into
+# a task that succeeds with `Result ok err`.
+
 main : Request -> Task Response []
 main = \_ ->
     when checkFile "good" |> Task.result! is
         Ok Good -> Task.ok { status: 200, headers: [], body: Str.toUtf8 "GOOD" }
         Ok Bad -> Task.ok { status: 200, headers: [], body: Str.toUtf8 "BAD" }
-        Err IOError -> Task.ok { status: 200, headers: [], body: Str.toUtf8 "ERROR" }     
+        Err IOError -> Task.ok { status: 500, headers: [], body: Str.toUtf8 "ERROR: IoError when executing checkFile." }     
 
 checkFile : Str -> Task [Good, Bad] [IOError]
 checkFile = \str ->

--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1713180354,
-        "narHash": "sha256-laLEu12yP0gD+dqqT3OClH6LLD1uAtPiyto0y5D7xus=",
+        "lastModified": 1713751891,
+        "narHash": "sha256-IuCUqK6N5P/uClhmAM/Z+JNNvrTpSSe6nkC7dxXMikI=",
         "owner": "roc-lang",
         "repo": "roc",
-        "rev": "a0cf09f9802eb07a05a73155729e370ebf3a9e9a",
+        "rev": "e4713ce2c5c07619e39e59fbfde29e9021cd78d1",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712973993,
-        "narHash": "sha256-ZJxC6t2K0UAPW+lV+bJ+pAtwbn29eqZQzXLTG54oL+I=",
+        "lastModified": 1713752081,
+        "narHash": "sha256-x0QDETp7paa8qq+LX6191JwSq8abUFXCnKNulQ8L7ps=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a497535d074432133b683dda3a1faa8c8ab587ad",
+        "rev": "606c0ecb23c676c444a0b026eecf800d5bd5fec2",
         "type": "github"
       },
       "original": {

--- a/platform/Task.roc
+++ b/platform/Task.roc
@@ -222,7 +222,7 @@ batch = \current -> \next ->
 ## Transform a task that can either succeed with `ok`, or fail with `err`, into
 ## a task that succeeds with `Result ok err`.
 ##
-## This is useful when chaining tasks using the `!` suffix. For example
+## This is useful when chaining tasks using the `!` suffix. For example:
 ##
 ## ```
 ## # Path.roc

--- a/platform/Task.roc
+++ b/platform/Task.roc
@@ -13,6 +13,7 @@ interface Task
         loop,
         fromResult,
         batch,
+        result,
     ]
     imports [Effect, InternalTask]
 
@@ -45,7 +46,7 @@ loop = \state, step ->
             \res ->
                 when res is
                     Ok (Step newState) -> Step newState
-                    Ok (Done result) -> Done (Ok result)
+                    Ok (Done newResult) -> Done (Ok newResult)
                     Err e -> Done (Err e)
 
     Effect.loop state looper
@@ -100,8 +101,8 @@ attempt : Task a b, (Result a b -> Task c d) -> Task c d
 attempt = \task, transform ->
     effect = Effect.after
         (InternalTask.toEffect task)
-        \result ->
-            when result is
+        \res ->
+            when res is
                 Ok a -> transform (Ok a) |> InternalTask.toEffect
                 Err b -> transform (Err b) |> InternalTask.toEffect
 
@@ -122,8 +123,8 @@ await : Task a b, (a -> Task c b) -> Task c b
 await = \task, transform ->
     effect = Effect.after
         (InternalTask.toEffect task)
-        \result ->
-            when result is
+        \res ->
+            when res is
                 Ok a -> transform a |> InternalTask.toEffect
                 Err b -> err b |> InternalTask.toEffect
 
@@ -140,8 +141,8 @@ onErr : Task a b, (b -> Task a c) -> Task a c
 onErr = \task, transform ->
     effect = Effect.after
         (InternalTask.toEffect task)
-        \result ->
-            when result is
+        \res ->
+            when res is
                 Ok a -> ok a |> InternalTask.toEffect
                 Err b -> transform b |> InternalTask.toEffect
 
@@ -158,8 +159,8 @@ map : Task a c, (a -> b) -> Task b c
 map = \task, transform ->
     effect = Effect.after
         (InternalTask.toEffect task)
-        \result ->
-            when result is
+        \res ->
+            when res is
                 Ok a -> ok (transform a) |> InternalTask.toEffect
                 Err b -> err b |> InternalTask.toEffect
 
@@ -176,8 +177,8 @@ mapErr : Task c a, (a -> b) -> Task c b
 mapErr = \task, transform ->
     effect = Effect.after
         (InternalTask.toEffect task)
-        \result ->
-            when result is
+        \res ->
+            when res is
                 Ok c -> ok c |> InternalTask.toEffect
                 Err a -> err (transform a) |> InternalTask.toEffect
 
@@ -185,16 +186,16 @@ mapErr = \task, transform ->
 
 ## Use a Result among other Tasks by converting it into a [Task].
 fromResult : Result a b -> Task a b
-fromResult = \result ->
-    when result is
+fromResult = \res ->
+    when res is
         Ok a -> ok a
         Err b -> err b
 
 ## Shorthand for calling [Task.fromResult] on a [Result], and then
 ## [Task.await] on that [Task].
 awaitResult : Result a err, (a -> Task c err) -> Task c err
-awaitResult = \result, transform ->
-    when result is
+awaitResult = \res, transform ->
+    when res is
         Ok a -> transform a
         Err b -> err b
 
@@ -217,3 +218,28 @@ batch = \current -> \next ->
         f <- next |> await
 
         map current f
+
+## Transform a task that can either succeed with `ok`, or fail with `err`, into
+## a task that succeeds with `Result ok err`.
+##
+## This is useful when chaining tasks using the `!` suffix. For example
+##
+## ```
+## # Path.roc
+## checkFile : Str -> Task [Good, Bad] [IOError]
+##
+## # main.roc
+## when checkFile "/usr/local/bin/roc" |> Task.result! is
+##     Ok Good -> "..."
+##     Ok Bad -> "..."
+##     Err IOError -> "..."
+## ```
+##
+result : Task ok err -> Task (Result ok err) *
+result = \task ->
+    effect =
+        Effect.after
+            (InternalTask.toEffect task)
+            \res -> res |> ok |> InternalTask.toEffect
+
+    InternalTask.fromEffect effect


### PR DESCRIPTION
[Zulip discussion](https://roc.zulipchat.com/#narrow/stream/304902-show-and-tell/topic/Initial.20Chaining.20Syntax/near/433559391)

## Test program

```roc 
app "test"
    packages { pf: "../platform/main.roc" }
    imports [
        pf.Stdout,
        pf.Task.{ Task },
        pf.Http.{ Request, Response },
        pf.Utc,
    ]
    provides [main] to pf

main : Request -> Task Response []
main = \req ->

    result = checkFile "bad" |> Task.result!

    when result is
        Ok Good -> Task.ok { status: 200, headers: [], body: Str.toUtf8 "GOOD" }
        Ok Bad -> Task.ok { status: 200, headers: [], body: Str.toUtf8 "BAD" }
        Err IOError -> Task.ok { status: 200, headers: [], body: Str.toUtf8 "ERROR" }     

checkFile : Str -> Task [Good, Bad] [IOError]
checkFile = \str ->
    if str == "good" then 
        Task.ok Good 
    else if str == "bad" then 
        Task.ok Bad 
    else 
        Task.err IOError
```