### PR TITLE
Upgrade module syntax and fix import warnings

### DIFF
--- a/ci/expect_scripts/file.exp
+++ b/ci/expect_scripts/file.exp
@@ -10,7 +10,7 @@ spawn $env(EXAMPLES_DIR)file
 expect "Listening on <http://localhost:8000>\r\n" {
     set curlOutput [exec curl -sS localhost:8000]
 
-    if { [string match "Source code of current program:\n\napp \"file\"*" $curlOutput] } {
+    if { [string match "Source code of current program:\n\napp *" $curlOutput] } {
         exit 0
     } else {
         puts "Error: curl output was different than expected: $curlOutput"

--- a/examples/command.roc
+++ b/examples/command.roc
@@ -1,12 +1,9 @@
-app "command"
-    packages { pf: "../platform/main.roc" }
-    imports [
-        pf.Task.{ Task },
-        pf.Http.{ Request, Response },
-        pf.Command,
-        pf.Utc,
-    ]
-    provides [main] to pf
+app [main] { pf: platform "../platform/main.roc" }
+
+import pf.Task exposing [Task]
+import pf.Http exposing [Request, Response]
+import pf.Command
+import pf.Utc
 
 main : Request -> Task Response []
 main = \req ->
@@ -22,7 +19,7 @@ main = \req ->
     when result is
         Ok {} -> respond "Command succeeded\n"
         Err (ExitCode code) -> respond "Command exited with code $(Num.toStr code)\n"
-        Err (KilledBySignal) -> respond "Command was killed by signal\n"
+        Err KilledBySignal -> respond "Command was killed by signal\n"
         Err (IOError str) -> respond "IO Error: $(str)\n"
 
 respond = \str -> Task.ok { status: 200, headers: [], body: Str.toUtf8 str }

--- a/examples/dir.roc
+++ b/examples/dir.roc
@@ -1,15 +1,12 @@
-app "dir"
-    packages { pf: "../platform/main.roc" }
-    imports [
-        pf.Stdout,
-        pf.Stderr,
-        pf.Dir,
-        pf.Env,
-        pf.Path,
-        pf.Task.{ Task },
-        pf.Http.{ Request, Response },
-    ]
-    provides [main] to pf
+app [main] { pf: platform "../platform/main.roc" }
+
+import pf.Stdout
+import pf.Stderr
+import pf.Dir
+import pf.Env
+import pf.Path
+import pf.Task exposing [Task]
+import pf.Http exposing [Request, Response]
 
 main : Request -> Task Response []
 main = \_ ->

--- a/examples/echo.roc
+++ b/examples/echo.roc
@@ -1,12 +1,9 @@
-app "echo"
-    packages { pf: "../platform/main.roc" }
-    imports [
-        pf.Stdout,
-        pf.Task.{ Task },
-        pf.Http.{ Request, Response },
-        pf.Utc,
-    ]
-    provides [main] to pf
+app [main] { pf: platform "../platform/main.roc" }
+
+import pf.Stdout
+import pf.Task exposing [Task]
+import pf.Http exposing [Request, Response]
+import pf.Utc
 
 main : Request -> Task Response []
 main = \req ->

--- a/examples/env.roc
+++ b/examples/env.roc
@@ -1,11 +1,8 @@
-app "env"
-    packages { pf: "../platform/main.roc" }
-    imports [
-        pf.Task.{ Task },
-        pf.Http.{ Request, Response },
-        pf.Env,
-    ]
-    provides [main] to pf
+app [main] { pf: platform "../platform/main.roc" }
+
+import pf.Task exposing [Task]
+import pf.Http exposing [Request, Response]
+import pf.Env
 
 main : Request -> Task Response []
 main = \_ ->

--- a/examples/error-handling.roc
+++ b/examples/error-handling.roc
@@ -1,15 +1,12 @@
 # This example demonstrates error handling and fetching content from another website.
-app "error-handling"
-    packages { pf: "../platform/main.roc" }
-    imports [
-        pf.Stdout,
-        pf.Stderr,
-        pf.Task.{ Task },
-        pf.Http.{ Request, Response },
-        pf.Utc,
-        pf.Env,
-    ]
-    provides [main] to pf
+app [main] { pf: platform "../platform/main.roc" }
+
+import pf.Stdout
+import pf.Stderr
+import pf.Task exposing [Task]
+import pf.Http exposing [Request, Response]
+import pf.Utc
+import pf.Env
 
 main : Request -> Task Response []
 main = \req ->
@@ -43,7 +40,7 @@ logRequest = \req ->
 
 readEnvVar : Str -> Task Str [EnvVarNotSet Str]
 readEnvVar = \envVarName ->
-    Env.var envVarName 
+    Env.var envVarName
     |> Task.mapErr \_ -> EnvVarNotSet envVarName
 
 fetchContent : Str -> Task Str [HttpError Http.Error]

--- a/examples/file.roc
+++ b/examples/file.roc
@@ -1,12 +1,9 @@
-app "file"
-    packages { pf: "../platform/main.roc" }
-    imports [
-        pf.File,
-        pf.Path,
-        pf.Task.{ Task },
-        pf.Http.{ Request, Response },
-    ]
-    provides [main] to pf
+app [main] { pf: platform "../platform/main.roc" }
+
+import pf.File
+import pf.Path
+import pf.Task exposing [Task]
+import pf.Http exposing [Request, Response]
 
 main : Request -> Task Response []
 main = \_ ->

--- a/examples/hello-web.roc
+++ b/examples/hello-web.roc
@@ -1,12 +1,9 @@
-app "hello-web"
-    packages { pf: "../platform/main.roc" }
-    imports [
-        pf.Stdout,
-        pf.Task.{ Task },
-        pf.Http.{ Request, Response },
-        pf.Utc,
-    ]
-    provides [main] to pf
+app [main] { pf: platform "../platform/main.roc" }
+
+import pf.Stdout
+import pf.Task exposing [Task]
+import pf.Http exposing [Request, Response]
+import pf.Utc
 
 main : Request -> Task Response []
 main = \req ->

--- a/examples/result.roc
+++ b/examples/result.roc
@@ -1,10 +1,7 @@
-app "result"
-    packages { pf: "../platform/main.roc" }
-    imports [
-        pf.Task.{ Task },
-        pf.Http.{ Request, Response },
-    ]
-    provides [main] to pf
+app [main] { pf: platform "../platform/main.roc" }
+
+import pf.Task exposing [Task]
+import pf.Http exposing [Request, Response]
 
 # This example demonstrates the use of `Task.result`.
 # It transforms a task that can either succeed with `ok`, or fail with `err`, into
@@ -15,13 +12,13 @@ main = \_ ->
     when checkFile "good" |> Task.result! is
         Ok Good -> Task.ok { status: 200, headers: [], body: Str.toUtf8 "GOOD" }
         Ok Bad -> Task.ok { status: 200, headers: [], body: Str.toUtf8 "BAD" }
-        Err IOError -> Task.ok { status: 500, headers: [], body: Str.toUtf8 "ERROR: IoError when executing checkFile." }     
+        Err IOError -> Task.ok { status: 500, headers: [], body: Str.toUtf8 "ERROR: IoError when executing checkFile." }
 
 checkFile : Str -> Task [Good, Bad] [IOError]
 checkFile = \str ->
-    if str == "good" then 
-        Task.ok Good 
-    else if str == "bad" then 
-        Task.ok Bad 
-    else 
+    if str == "good" then
+        Task.ok Good
+    else if str == "bad" then
+        Task.ok Bad
+    else
         Task.err IOError

--- a/examples/sleep.roc
+++ b/examples/sleep.roc
@@ -1,12 +1,9 @@
-app "echo"
-    packages { pf: "../platform/main.roc" }
-    imports [
-        pf.Stdout,
-        pf.Task.{ Task },
-        pf.Http.{ Request, Response },
-        pf.Sleep,
-    ]
-    provides [main] to pf
+app [main] { pf: platform "../platform/main.roc" }
+
+import pf.Stdout
+import pf.Task exposing [Task]
+import pf.Http exposing [Request, Response]
+import pf.Sleep
 
 main : Request -> Task Response []
 main = \_ ->

--- a/examples/sqlite3.roc
+++ b/examples/sqlite3.roc
@@ -1,13 +1,10 @@
-app "echo"
-    packages { pf: "../platform/main.roc" }
-    imports [
-        pf.Stdout,
-        pf.Task.{ Task },
-        pf.Http.{ Request, Response },
-        pf.SQLite3,
-        pf.Env,
-    ]
-    provides [main] to pf
+app [main] { pf: platform "../platform/main.roc" }
+
+import pf.Stdout
+import pf.Task exposing [Task]
+import pf.Http exposing [Request, Response]
+import pf.SQLite3
+import pf.Env
 
 main : Request -> Task Response []
 main = \_ ->

--- a/examples/todos.roc
+++ b/examples/todos.roc
@@ -1,19 +1,16 @@
 # Webapp for todos using a SQLite 3 database
-app "todos"
-    packages { pf: "../platform/main.roc" }
-    imports [
-        pf.Stdout,
-        pf.Stderr,
-        pf.Task.{ Task },
-        pf.Http.{ Request, Response },
-        pf.Command,
-        pf.Env,
-        pf.Url,
-        pf.Utc,
-        Dict,
-        "todos.html" as todoHtml : List U8,
-    ]
-    provides [main] to pf
+app [main] { pf: platform "../platform/main.roc" }
+
+import pf.Stdout
+import pf.Stderr
+import pf.Task exposing [Task]
+import pf.Http exposing [Request, Response]
+import pf.Command
+import pf.Env
+import pf.Url
+import pf.Utc
+import Dict
+import "todos.html" as todoHtml : List U8
 
 main : Request -> Task Response []
 main = \req ->
@@ -136,10 +133,10 @@ isSqliteInstalled =
         |> Command.status
         |> Task.attempt
 
-    when sqlite3Res is 
+    when sqlite3Res is
         Ok {} -> Task.ok {}
         Err _ -> Task.err Sqlite3NotInstalled
-    
+
 logRequest : Request -> Task {} *
 logRequest = \req ->
     datetime <- Utc.now |> Task.map Utc.toIso8601Str |> Task.await
@@ -148,7 +145,7 @@ logRequest = \req ->
 
 readEnvVar : Str -> Task Str [EnvVarNotSet Str]_
 readEnvVar = \envVarName ->
-    Env.var envVarName 
+    Env.var envVarName
     |> Task.mapErr \_ -> EnvVarNotSet envVarName
 
 handleErr : AppError -> Task Response *

--- a/examples/todos.roc
+++ b/examples/todos.roc
@@ -9,7 +9,6 @@ import pf.Command
 import pf.Env
 import pf.Url
 import pf.Utc
-import Dict
 import "todos.html" as todoHtml : List U8
 
 main : Request -> Task Response []

--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1713751891,
-        "narHash": "sha256-IuCUqK6N5P/uClhmAM/Z+JNNvrTpSSe6nkC7dxXMikI=",
+        "lastModified": 1714713919,
+        "narHash": "sha256-OYh6PruTz8n4bKlzis03jOJSDheRHi7t2hvZQ4hNKcE=",
         "owner": "roc-lang",
         "repo": "roc",
-        "rev": "e4713ce2c5c07619e39e59fbfde29e9021cd78d1",
+        "rev": "f7011c8e33b92a7e9f809e6f16849de9fcfa8dd7",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713752081,
-        "narHash": "sha256-x0QDETp7paa8qq+LX6191JwSq8abUFXCnKNulQ8L7ps=",
+        "lastModified": 1714702555,
+        "narHash": "sha256-/NoUbE5S5xpK1FU3nlHhQ/tL126+JcisXdzy3Ng4pDU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "606c0ecb23c676c444a0b026eecf800d5bd5fec2",
+        "rev": "7f0e3ef7b7fbed78e12e5100851175d28af4b7c6",
         "type": "github"
       },
       "original": {

--- a/platform/Base64.roc
+++ b/platform/Base64.roc
@@ -1,6 +1,4 @@
-interface Base64
-    exposes [toBytes, toStr]
-    imports []
+module [toBytes, toStr]
 
 ## Base64-encodes a [Str] into another [Str].
 toStr : Str -> Str

--- a/platform/Command.roc
+++ b/platform/Command.roc
@@ -1,22 +1,20 @@
-interface Command
-    exposes [
-        Command,
-        Output,
-        new,
-        arg,
-        args,
-        env,
-        envs,
-        clearEnvs,
-        status,
-        output,
-    ]
-    imports [
-        Task.{ Task },
-        InternalTask,
-        InternalCommand,
-        Effect,
-    ]
+module [
+    Command,
+    Output,
+    new,
+    arg,
+    args,
+    env,
+    envs,
+    clearEnvs,
+    status,
+    output,
+]
+
+import Task exposing [Task]
+import InternalTask
+import InternalCommand
+import Effect
 
 ## Represents a command to be executed in a child process.
 ## ```

--- a/platform/Dir.roc
+++ b/platform/Dir.roc
@@ -1,6 +1,11 @@
-interface Dir
-    exposes [deleteEmptyDir, deleteRecursive, list]
-    imports [Effect, Task.{ Task }, InternalTask, Path.{ Path }, InternalPath, InternalError]
+module [deleteEmptyDir, deleteRecursive, list]
+
+import Effect
+import Task exposing [Task]
+import InternalTask
+import Path exposing [Path]
+import InternalPath
+import InternalError
 
 ReadErr : InternalError.InternalDirReadErr
 

--- a/platform/Env.roc
+++ b/platform/Env.roc
@@ -1,6 +1,11 @@
-interface Env
-    exposes [cwd, list, var, decode, exePath, setCwd]
-    imports [Task.{ Task }, Path.{ Path }, InternalPath, Effect, InternalTask, EnvDecoding]
+module [cwd, list, var, decode, exePath, setCwd]
+
+import Task exposing [Task]
+import Path exposing [Path]
+import InternalPath
+import Effect
+import InternalTask
+import EnvDecoding
 
 ## Reads the [current working directory](https://en.wikipedia.org/wiki/Working_directory)
 ## from the environment. File operations on relative [Path]s are relative to this directory.

--- a/platform/EnvDecoding.roc
+++ b/platform/EnvDecoding.roc
@@ -1,4 +1,4 @@
-interface EnvDecoding exposes [EnvFormat, format] imports []
+module [EnvFormat, format]
 
 EnvFormat := {} implements [
         DecoderFormatting {

--- a/platform/File.roc
+++ b/platform/File.roc
@@ -1,6 +1,11 @@
-interface File
-    exposes [ReadErr, WriteErr, write, writeUtf8, writeBytes, readUtf8, readBytes, delete, writeErrToStr, readErrToStr]
-    imports [Task.{ Task }, InternalTask, InternalFile, Path.{ Path }, InternalPath, Effect.{ Effect }]
+module [ReadErr, WriteErr, write, writeUtf8, writeBytes, readUtf8, readBytes, delete, writeErrToStr, readErrToStr]
+
+import Task exposing [Task]
+import InternalTask
+import InternalFile
+import Path exposing [Path]
+import InternalPath
+import Effect exposing [Effect]
 
 ## Tag union of possible errors when reading a file or directory.
 ReadErr : InternalFile.ReadErr

--- a/platform/FileMetadata.roc
+++ b/platform/FileMetadata.roc
@@ -1,6 +1,4 @@
-interface FileMetadata
-    exposes [FileMetadata, bytes, type, isReadonly, mode]
-    imports []
+module [FileMetadata, bytes, type, isReadonly, mode]
 
 # Design note: this is an opaque type rather than a type alias so that
 # we can add new operating system info if new OS releases introduce them,

--- a/platform/Http.roc
+++ b/platform/Http.roc
@@ -1,22 +1,25 @@
-interface Http
-    exposes [
-        Request,
-        Method,
-        methodToStr,
-        Header,
-        TimeoutConfig,
-        Response,
-        Metadata,
-        Error,
-        header,
-        handleStringResponse,
-        defaultRequest,
-        errorToString,
-        send,
-        getUtf8,
-        parseFormUrlEncoded,
-    ]
-    imports [Effect, InternalTask, Task.{ Task }, InternalHttp]
+module [
+    Request,
+    Method,
+    methodToStr,
+    Header,
+    TimeoutConfig,
+    Response,
+    Metadata,
+    Error,
+    header,
+    handleStringResponse,
+    defaultRequest,
+    errorToString,
+    send,
+    getUtf8,
+    parseFormUrlEncoded,
+]
+
+import Effect
+import InternalTask
+import Task exposing [Task]
+import InternalHttp
 
 ## Represents an HTTP request.
 Request : InternalHttp.InternalRequest

--- a/platform/InternalCommand.roc
+++ b/platform/InternalCommand.roc
@@ -1,10 +1,8 @@
-interface InternalCommand
-    exposes [
-        InternalCommand,
-        InternalOutput,
-        InternalCommandErr,
-    ]
-    imports []
+module [
+    InternalCommand,
+    InternalOutput,
+    InternalCommandErr,
+]
 
 InternalCommandErr : [
     ExitCode I32,

--- a/platform/InternalDateTime.roc
+++ b/platform/InternalDateTime.roc
@@ -1,10 +1,8 @@
-interface InternalDateTime
-    exposes [
-        DateTime,
-        toIso8601Str,
-        epochMillisToDateTime,
-    ]
-    imports []
+module [
+    DateTime,
+    toIso8601Str,
+    epochMillisToDateTime,
+]
 
 DateTime : { year : I128, month : I128, day : I128, hours : I128, minutes : I128, seconds : I128 }
 

--- a/platform/InternalError.roc
+++ b/platform/InternalError.roc
@@ -1,10 +1,10 @@
-interface InternalError
-    exposes [
-        InternalError,
-        InternalDirReadErr,
-        InternalDirDeleteErr,
-    ]
-    imports [Path.{ Path }]
+module [
+    InternalError,
+    InternalDirReadErr,
+    InternalDirDeleteErr,
+]
+
+import Path exposing [Path]
 
 InternalError : [
     IOError Str,

--- a/platform/InternalFile.roc
+++ b/platform/InternalFile.roc
@@ -1,6 +1,4 @@
-interface InternalFile
-    exposes [ReadErr, WriteErr]
-    imports []
+module [ReadErr, WriteErr]
 
 ReadErr : [
     NotFound,

--- a/platform/InternalHttp.roc
+++ b/platform/InternalHttp.roc
@@ -1,15 +1,13 @@
-interface InternalHttp
-    exposes [
-        InternalRequest,
-        InternalMethod,
-        InternalHeader,
-        InternalTimeoutConfig,
-        InternalPart,
-        InternalResponse,
-        InternalMetadata,
-        InternalError,
-    ]
-    imports []
+module [
+    InternalRequest,
+    InternalMethod,
+    InternalHeader,
+    InternalTimeoutConfig,
+    InternalPart,
+    InternalResponse,
+    InternalMetadata,
+    InternalError,
+]
 
 InternalRequest : {
     method : InternalMethod,

--- a/platform/InternalPath.roc
+++ b/platform/InternalPath.roc
@@ -1,14 +1,12 @@
-interface InternalPath
-    exposes [
-        UnwrappedPath,
-        InternalPath,
-        wrap,
-        unwrap,
-        toBytes,
-        fromArbitraryBytes,
-        fromOsBytes,
-    ]
-    imports []
+module [
+    UnwrappedPath,
+    InternalPath,
+    wrap,
+    unwrap,
+    toBytes,
+    fromArbitraryBytes,
+    fromOsBytes,
+]
 
 InternalPath := UnwrappedPath
 

--- a/platform/InternalSQL.roc
+++ b/platform/InternalSQL.roc
@@ -1,11 +1,9 @@
-interface InternalSQL
-    exposes [
-        SQLiteErrCode,
-        SQLiteError,
-        SQLiteValue,
-        SQLiteBindings,
-    ]
-    imports []
+module [
+    SQLiteErrCode,
+    SQLiteError,
+    SQLiteValue,
+    SQLiteBindings,
+]
 
 SQLiteErrCode : [
     ERROR, # SQL error or missing database

--- a/platform/InternalTask.roc
+++ b/platform/InternalTask.roc
@@ -1,6 +1,6 @@
-interface InternalTask
-    exposes [Task, fromEffect, toEffect, ok, err]
-    imports [Effect.{ Effect }]
+module [Task, fromEffect, toEffect, ok, err]
+
+import Effect exposing [Effect]
 
 Task ok err := Effect (Result ok err)
 

--- a/platform/InternalTcp.roc
+++ b/platform/InternalTcp.roc
@@ -1,17 +1,15 @@
-interface InternalTcp
-    exposes [
-        Stream,
-        ConnectErr,
-        StreamErr,
-        ConnectResult,
-        WriteResult,
-        ReadResult,
-        ReadExactlyResult,
-        fromConnectResult,
-        fromWriteResult,
-        fromReadResult,
-    ]
-    imports []
+module [
+    Stream,
+    ConnectErr,
+    StreamErr,
+    ConnectResult,
+    WriteResult,
+    ReadResult,
+    ReadExactlyResult,
+    fromConnectResult,
+    fromWriteResult,
+    fromReadResult,
+]
 
 Stream := U64
 

--- a/platform/Path.roc
+++ b/platform/Path.roc
@@ -1,17 +1,17 @@
-interface Path
-    exposes [
-        Path,
-        PathComponent,
-        CanonicalizeErr,
-        WindowsRoot,
-        # toComponents,
-        # walkComponents,
-        display,
-        fromStr,
-        fromBytes,
-        withExtension,
-    ]
-    imports [InternalPath.{ InternalPath }]
+module [
+    Path,
+    PathComponent,
+    CanonicalizeErr,
+    WindowsRoot,
+    # toComponents,
+    # walkComponents,
+    display,
+    fromStr,
+    fromBytes,
+    withExtension,
+]
+
+import InternalPath exposing [InternalPath]
 
 # You can canonicalize a [Path] using `Path.canonicalize`.
 #

--- a/platform/SQLite3.roc
+++ b/platform/SQLite3.roc
@@ -1,13 +1,16 @@
-interface SQLite3
-    exposes [
-        Value,
-        Code,
-        Error,
-        Binding,
-        execute,
-        errToStr,
-    ]
-    imports [InternalTask, Task.{ Task }, InternalSQL, Effect]
+module [
+    Value,
+    Code,
+    Error,
+    Binding,
+    execute,
+    errToStr,
+]
+
+import InternalTask
+import Task exposing [Task]
+import InternalSQL
+import Effect
 
 Value : InternalSQL.SQLiteValue
 Code : InternalSQL.SQLiteErrCode

--- a/platform/Sleep.roc
+++ b/platform/Sleep.roc
@@ -1,8 +1,10 @@
-interface Sleep
-    exposes [
-        millis,
-    ]
-    imports [Effect, InternalTask, Task.{ Task }]
+module [
+    millis,
+]
+
+import Effect
+import InternalTask
+import Task exposing [Task]
 
 ## Sleep for at least the given number of milliseconds.
 ## This uses [rust's std::thread::sleep](https://doc.rust-lang.org/std/thread/fn.sleep.html).

--- a/platform/Stderr.roc
+++ b/platform/Stderr.roc
@@ -1,6 +1,8 @@
-interface Stderr
-    exposes [line, write, flush]
-    imports [Effect, Task.{ Task }, InternalTask]
+module [line, write, flush]
+
+import Effect
+import Task exposing [Task]
+import InternalTask
 
 ## Write the given string to [standard error](https://en.wikipedia.org/wiki/Standard_streams#Standard_error_(stderr)),
 ## followed by a newline.

--- a/platform/Stdout.roc
+++ b/platform/Stdout.roc
@@ -1,6 +1,8 @@
-interface Stdout
-    exposes [line, write, flush]
-    imports [Effect, Task.{ Task }, InternalTask]
+module [line, write, flush]
+
+import Effect
+import Task exposing [Task]
+import InternalTask
 
 ## Write the given string to [standard output](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)),
 ## followed by a newline.

--- a/platform/Task.roc
+++ b/platform/Task.roc
@@ -1,21 +1,22 @@
-interface Task
-    exposes [
-        Task,
-        ok,
-        err,
-        await,
-        awaitResult,
-        map,
-        mapErr,
-        onErr,
-        attempt,
-        forever,
-        loop,
-        fromResult,
-        batch,
-        result,
-    ]
-    imports [Effect, InternalTask]
+module [
+    Task,
+    ok,
+    err,
+    await,
+    awaitResult,
+    map,
+    mapErr,
+    onErr,
+    attempt,
+    forever,
+    loop,
+    fromResult,
+    batch,
+    result,
+]
+
+import Effect
+import InternalTask
 
 ## A Task represents an effect; an interaction with state outside your Roc
 ## program, such as the terminal's standard output, or a file.

--- a/platform/Tcp.roc
+++ b/platform/Tcp.roc
@@ -1,19 +1,22 @@
-interface Tcp
-    exposes [
-        Stream,
-        withConnect,
-        readUpTo,
-        readExactly,
-        readUntil,
-        readLine,
-        write,
-        writeUtf8,
-        ConnectErr,
-        connectErrToStr,
-        StreamErr,
-        streamErrToStr,
-    ]
-    imports [Effect, Task.{ Task }, InternalTask, InternalTcp]
+module [
+    Stream,
+    withConnect,
+    readUpTo,
+    readExactly,
+    readUntil,
+    readLine,
+    write,
+    writeUtf8,
+    ConnectErr,
+    connectErrToStr,
+    StreamErr,
+    streamErrToStr,
+]
+
+import Effect
+import Task exposing [Task]
+import InternalTask
+import InternalTcp
 
 ## Represents a TCP stream.
 Stream : InternalTcp.Stream

--- a/platform/Url.roc
+++ b/platform/Url.roc
@@ -1,21 +1,19 @@
-interface Url
-    exposes [
-        Url,
-        append,
-        fromStr,
-        toStr,
-        appendParam,
-        hasQuery,
-        hasFragment,
-        path,
-        query,
-        queryParams,
-        fragment,
-        reserve,
-        withQuery,
-        withFragment,
-    ]
-    imports []
+module [
+    Url,
+    append,
+    fromStr,
+    toStr,
+    appendParam,
+    hasQuery,
+    hasFragment,
+    path,
+    query,
+    queryParams,
+    fragment,
+    reserve,
+    withQuery,
+    withFragment,
+]
 
 ## A [Uniform Resource Locator](https://en.wikipedia.org/wiki/URL).
 ##

--- a/platform/Utc.roc
+++ b/platform/Utc.roc
@@ -1,21 +1,19 @@
-interface Utc
-    exposes [
-        Utc,
-        now,
-        toMillisSinceEpoch,
-        fromMillisSinceEpoch,
-        toNanosSinceEpoch,
-        fromNanosSinceEpoch,
-        deltaAsMillis,
-        deltaAsNanos,
-        toIso8601Str,
-    ]
-    imports [
-        Effect,
-        InternalTask,
-        InternalDateTime,
-        Task.{ Task },
-    ]
+module [
+    Utc,
+    now,
+    toMillisSinceEpoch,
+    fromMillisSinceEpoch,
+    toNanosSinceEpoch,
+    fromNanosSinceEpoch,
+    deltaAsMillis,
+    deltaAsNanos,
+    toIso8601Str,
+]
+
+import Effect
+import InternalTask
+import InternalDateTime
+import Task exposing [Task]
 
 ## Stores a timestamp as nanoseconds since UNIX EPOCH
 Utc := I128

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -20,7 +20,7 @@ platform "webserver"
     packages {}
     imports [
         Task.{ Task },
-        Http.{ Request, Method, Response },
+        Http.{ Request, Response },
     ]
     provides [mainForHost]
 


### PR DESCRIPTION
Runs `roc format` on everything in order to update to the new module headers and imports.

 I also fixed an [unused import warning](https://github.com/roc-lang/basic-webserver/pull/52/commits/2745a80ef8b5540c78922ea758b82e5d45695aca), and an [unnecessary builtin import](https://github.com/roc-lang/basic-webserver/pull/52/commits/6014bc4f4e0b6403136198bca7be9ab1356ed285) that the new compiler version will catch.