### PR TITLE
fix hardcoded host value in println

### DIFF
--- a/ci/expect_scripts/command.exp
+++ b/ci/expect_scripts/command.exp
@@ -7,7 +7,7 @@ set timeout 7
 
 spawn $env(EXAMPLES_DIR)command
 
-expect "Listening on <http://localhost:8000>\r\n" {
+expect "Listening on <http://127.0.0.1:8000>\r\n" {
     set curlOutput [exec curl -sS localhost:8000]
 
     if {$curlOutput eq "Command succeeded"} {

--- a/ci/expect_scripts/dir.exp
+++ b/ci/expect_scripts/dir.exp
@@ -7,7 +7,7 @@ set timeout 7
 
 spawn $env(EXAMPLES_DIR)dir
 
-expect "Listening on <http://localhost:8000>\r\n" {
+expect "Listening on <http://127.0.0.1:8000>\r\n" {
     set curlOutput [exec curl -sS localhost:8000]
 
     if {$curlOutput eq "Logged request"} {

--- a/ci/expect_scripts/echo.exp
+++ b/ci/expect_scripts/echo.exp
@@ -7,7 +7,7 @@ set timeout 7
 
 spawn $env(EXAMPLES_DIR)echo
 
-expect "Listening on <http://localhost:8000>\r\n" {
+expect "Listening on <http://127.0.0.1:8000>\r\n" {
     set curlOutput [exec curl -sS localhost:8000 -d "echo me"]
 
     if {$curlOutput eq "echo me"} {

--- a/ci/expect_scripts/env.exp
+++ b/ci/expect_scripts/env.exp
@@ -7,7 +7,7 @@ set timeout 7
 
 spawn $env(EXAMPLES_DIR)env
 
-expect "Listening on <http://localhost:8000>\r\n" {
+expect "Listening on <http://127.0.0.1:8000>\r\n" {
     set curlOutput [exec curl -sS localhost:8000]
 
     if {$curlOutput eq "DEBUG var not set"} {

--- a/ci/expect_scripts/error-handling.exp
+++ b/ci/expect_scripts/error-handling.exp
@@ -9,7 +9,7 @@ set env(TARGET_URL) "http://www.example.com"
 
 spawn $env(EXAMPLES_DIR)error-handling
 
-expect "Listening on <http://localhost:8000>\r\n" {
+expect "Listening on <http://127.0.0.1:8000>\r\n" {
     set curlOutput [exec curl -sS localhost:8000]
 
     if {[string match "*Example Domain*" $curlOutput]} {

--- a/ci/expect_scripts/file.exp
+++ b/ci/expect_scripts/file.exp
@@ -7,7 +7,7 @@ set timeout 7
 
 spawn $env(EXAMPLES_DIR)file
 
-expect "Listening on <http://localhost:8000>\r\n" {
+expect "Listening on <http://127.0.0.1:8000>\r\n" {
     set curlOutput [exec curl -sS localhost:8000]
 
     if { [string match "Source code of current program:\n\napp *" $curlOutput] } {

--- a/ci/expect_scripts/hello-web.exp
+++ b/ci/expect_scripts/hello-web.exp
@@ -7,7 +7,7 @@ set timeout 7
 
 spawn $env(EXAMPLES_DIR)hello-web
 
-expect "Listening on <http://localhost:8000>\r\n" {
+expect "Listening on <http://127.0.0.1:8000>\r\n" {
     set curlOutput [exec curl -sS localhost:8000]
 
     if {$curlOutput eq "<b>Hello, world!</b>"} {

--- a/ci/expect_scripts/result.exp
+++ b/ci/expect_scripts/result.exp
@@ -7,7 +7,7 @@ set timeout 7
 
 spawn $env(EXAMPLES_DIR)result
 
-expect "Listening on <http://localhost:8000>\r\n" {
+expect "Listening on <http://127.0.0.1:8000>\r\n" {
     set curlOutput [exec curl -sS localhost:8000 -d ""]
 
     if {$curlOutput eq "GOOD"} {

--- a/ci/expect_scripts/sleep.exp
+++ b/ci/expect_scripts/sleep.exp
@@ -7,7 +7,7 @@ set timeout 7
 
 spawn $env(EXAMPLES_DIR)sleep
 
-expect "Listening on <http://localhost:8000>\r\n" {
+expect "Listening on <http://127.0.0.1:8000>\r\n" {
     set curlOutput [exec curl -sS localhost:8000]
 
     if {$curlOutput eq "Response delayed by 1 second"} {

--- a/ci/expect_scripts/todos.exp
+++ b/ci/expect_scripts/todos.exp
@@ -7,7 +7,7 @@ set timeout 7
 
 spawn $env(EXAMPLES_DIR)todos
 
-expect "Listening on <http://localhost:8000>\r\n" {
+expect "Listening on <http://127.0.0.1:8000>\r\n" {
 
     set curlOutputIndex [exec curl -sS localhost:8000]
 

--- a/platform/src/server.rs
+++ b/platform/src/server.rs
@@ -142,7 +142,7 @@ async fn run_server() -> i32 {
         }))
     }));
 
-    println!("Listening on <http://localhost:{port}>");
+    println!("Listening on <http://{host}:{port}>");
 
     match server.await {
         Ok(_) => 0,


### PR DESCRIPTION
The pr https://github.com/roc-lang/basic-webserver/pull/15 exposed host and port as env vars, but left the println hardcoded to 'localhost'. This can be misleading since it makes it seem that the host env var is not taking effect.