### PR TITLE
Add support for http extension methods

### DIFF
--- a/ci/expect_scripts/command.exp
+++ b/ci/expect_scripts/command.exp
@@ -11,7 +11,7 @@ expect "Listening on <http://127.0.0.1:8000>\r\n" {
     set curlOutput [exec curl -sS localhost:8000]
 
     if {$curlOutput eq "Command succeeded."} {
-        expect "Z Get /\r\n" {
+        expect "Z GET /\r\n" {
             exit 0
         }
     } else {

--- a/ci/expect_scripts/echo.exp
+++ b/ci/expect_scripts/echo.exp
@@ -11,7 +11,7 @@ expect "Listening on <http://127.0.0.1:8000>\r\n" {
     set curlOutput [exec curl -sS localhost:8000 -d "echo me"]
 
     if {$curlOutput eq "echo me"} {
-        expect "Z Post /\r\n" {
+        expect "Z POST /\r\n" {
             exit 0
         }
     } else {

--- a/ci/expect_scripts/error-handling.exp
+++ b/ci/expect_scripts/error-handling.exp
@@ -13,7 +13,7 @@ expect "Listening on <http://127.0.0.1:8000>\r\n" {
     set curlOutput [exec curl -sS localhost:8000]
 
     if {[string match "*Example Domain*" $curlOutput]} {
-        expect "Z Get /\r\n" {
+        expect "Z GET /\r\n" {
             exit 0
         }
     } else {

--- a/ci/expect_scripts/hello-web.exp
+++ b/ci/expect_scripts/hello-web.exp
@@ -11,7 +11,7 @@ expect "Listening on <http://127.0.0.1:8000>\r\n" {
     set curlOutput [exec curl -sS localhost:8000]
 
     if {$curlOutput eq "<b>Hello from server</b></br>"} {
-        expect "Z Get /\r\n" {
+        expect "Z GET /\r\n" {
             exit 0
         }
     } else {

--- a/ci/expect_scripts/init-basic.exp
+++ b/ci/expect_scripts/init-basic.exp
@@ -11,7 +11,7 @@ expect "Listening on <http://127.0.0.1:8000>\r\n" {
     set curlOutput [exec curl -sS localhost:8000]
 
     if {$curlOutput eq "<b>init gave me 🎁</b>"} {
-        expect "Z Get /\r\n" {
+        expect "Z GET /\r\n" {
             exit 0
         }
     } else {

--- a/ci/expect_scripts/todos.exp
+++ b/ci/expect_scripts/todos.exp
@@ -18,19 +18,19 @@ expect "Listening on <http://127.0.0.1:8000>\r\n" {
     set curlOutputIndex [exec curl -sS localhost:8000]
 
     if {[string match "*addTodoForm*" $curlOutputIndex]} {
-        expect "Z Get /\r\n" {
+        expect "Z GET /\r\n" {
 
             set curlOutputTodos [exec curl -sS localhost:8000/todos]
 
             puts $curlOutputTodos
 
             if {[string match "*Prepare for AoC*" $curlOutputTodos]} {
-                 expect "Z Get /todos\r\n" {
+                 expect "Z GET /todos\r\n" {
 
                     set curlOutputPost [exec curl -sSX POST "localhost:8000/todos?task=Task%206&status=planned"]
 
                     if {[string match "*planned*" $curlOutputPost]} {
-                        expect "Z Post /todos?task=Task%206&status=planned\r\n" {
+                        expect "Z POST /todos?task=Task%206&status=planned\r\n" {
 
                             set curlOutputTodos2 [exec curl -sS localhost:8000/todos]
 

--- a/crates/roc_host/src/roc_http.rs
+++ b/crates/roc_host/src/roc_http.rs
@@ -1,4 +1,5 @@
 use roc_std::{RocList, RocStr};
+use std::str::FromStr;
 
 #[derive(Debug)]
 #[repr(C)]
@@ -18,18 +19,7 @@ impl RequestToAndFromHost {
         reqwest_method: reqwest::Method,
         url: hyper::Uri,
     ) -> RequestToAndFromHost {
-        let method = match reqwest_method {
-            reqwest::Method::OPTIONS => "Options".into(),
-            reqwest::Method::GET => "Get".into(),
-            reqwest::Method::POST => "Post".into(),
-            reqwest::Method::PUT => "Put".into(),
-            reqwest::Method::DELETE => "Delete".into(),
-            reqwest::Method::HEAD => "Head".into(),
-            reqwest::Method::TRACE => "Trace".into(),
-            reqwest::Method::CONNECT => "Connect".into(),
-            reqwest::Method::PATCH => "Patch".into(),
-            _ => panic!("reqwest method not supported"),
-        };
+        let method = reqwest_method.as_str().into();
 
         RequestToAndFromHost {
             body: body_bytes.to_vec().as_slice().into(),
@@ -50,19 +40,11 @@ impl RequestToAndFromHost {
     }
 
     pub fn to_reqwest_method(&self) -> reqwest::Method {
-        match self.method.as_str() {
-            "Options" => reqwest::Method::OPTIONS,
-            "Get" => reqwest::Method::GET,
-            "Post" => reqwest::Method::POST,
-            "Put" => reqwest::Method::PUT,
-            "Delete" => reqwest::Method::DELETE,
-            "Head" => reqwest::Method::HEAD,
-            "Trace" => reqwest::Method::TRACE,
-            "Connect" => reqwest::Method::CONNECT,
-            "Patch" => reqwest::Method::PATCH,
-            other => panic!(
+        match reqwest::Method::from_str(self.method.as_str()) {
+            Ok(method) => method,
+            Err(err) => panic!(
                 "The platform reveived an unknown HTTP method Str from Roc: {}.",
-                other
+                err
             ),
         }
     }

--- a/platform/Http.roc
+++ b/platform/Http.roc
@@ -180,15 +180,15 @@ getUtf8 = \url ->
 methodToStr : Method -> Str
 methodToStr = \method ->
     when method is
-        Options -> "Options"
-        Get -> "Get"
-        Post -> "Post"
-        Put -> "Put"
-        Delete -> "Delete"
-        Head -> "Head"
-        Trace -> "Trace"
-        Connect -> "Connect"
-        Patch -> "Patch"
+        Options -> "OPTIONS"
+        Get -> "GET"
+        Post -> "POST"
+        Put -> "PUT"
+        Delete -> "DELETE"
+        Head -> "HEAD"
+        Trace -> "TRACE"
+        Connect -> "CONNECT"
+        Patch -> "PATCH"
 
 ## Parse URL-encoded form values (`todo=foo&status=bar`) into a Dict (`("todo", "foo"), ("status", "bar")`).
 ##

--- a/platform/Http.roc
+++ b/platform/Http.roc
@@ -189,6 +189,7 @@ methodToStr = \method ->
         Trace -> "TRACE"
         Connect -> "CONNECT"
         Patch -> "PATCH"
+        Extension inner -> inner
 
 ## Parse URL-encoded form values (`todo=foo&status=bar`) into a Dict (`("todo", "foo"), ("status", "bar")`).
 ##

--- a/platform/InternalHttp.roc
+++ b/platform/InternalHttp.roc
@@ -50,15 +50,15 @@ Method : [Options, Get, Post, Put, Delete, Head, Trace, Connect, Patch]
 methodFromStr : Str -> Method
 methodFromStr = \str ->
     when str is
-        "Options" -> Options
-        "Get" -> Get
-        "Post" -> Post
-        "Put" -> Put
-        "Delete" -> Delete
-        "Head" -> Head
-        "Trace" -> Trace
-        "Connect" -> Connect
-        "Patch" -> Patch
+        "OPTIONS" -> Options
+        "GET" -> Get
+        "POST" -> Post
+        "PUT" -> Put
+        "DELETE" -> Delete
+        "HEAD" -> Head
+        "TRACE" -> Trace
+        "CONNECT" -> Connect
+        "PATCH" -> Patch
         _ -> crash "unrecognized method from host"
 
 Header : {

--- a/platform/InternalHttp.roc
+++ b/platform/InternalHttp.roc
@@ -45,7 +45,7 @@ fromHostRequest = \{ method, headers, url, mimeType, body, timeoutMilliseconds }
 # Name is distinguished from the Timeout tag used in Response and Error
 TimeoutConfig : [TimeoutMilliseconds U64, NoTimeout]
 
-Method : [Options, Get, Post, Put, Delete, Head, Trace, Connect, Patch]
+Method : [Options, Get, Post, Put, Delete, Head, Trace, Connect, Patch, Extension Str]
 
 methodFromStr : Str -> Method
 methodFromStr = \str ->
@@ -59,7 +59,7 @@ methodFromStr = \str ->
         "TRACE" -> Trace
         "CONNECT" -> Connect
         "PATCH" -> Patch
-        _ -> crash "unrecognized method from host"
+        extension -> Extension extension
 
 Header : {
     name : Str,


### PR DESCRIPTION
This patch adds support for any arbitrary http method. I discovered this while trying to implement a server that would respond to the QUERY (draft) method, which caused a crash when I tried it. Since this functionality is supported in the upstream rust http libraries, I can't see any reason why it cannot be supported here too.