### PR TITLE
basic-cli syncing Path+File

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "arrayvec"
@@ -28,12 +28,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
@@ -64,18 +58,18 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.24"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "core-foundation"
@@ -213,9 +207,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -232,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "host"
@@ -349,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -365,9 +359,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -397,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -489,7 +483,7 @@ dependencies = [
 [[package]]
 name = "roc_command"
 version = "0.0.1"
-source = "git+https://github.com/roc-lang/basic-cli.git#8a08cebbc31fe458816f7b98e1f5c176c43556b5"
+source = "git+https://github.com/roc-lang/basic-cli.git#bd752372b058e8c42cd4e8cfb74b36db64af01e8"
 dependencies = [
  "roc_io_error",
  "roc_std",
@@ -498,7 +492,7 @@ dependencies = [
 [[package]]
 name = "roc_env"
 version = "0.0.1"
-source = "git+https://github.com/roc-lang/basic-cli.git#8a08cebbc31fe458816f7b98e1f5c176c43556b5"
+source = "git+https://github.com/roc-lang/basic-cli.git#bd752372b058e8c42cd4e8cfb74b36db64af01e8"
 dependencies = [
  "roc_file",
  "roc_std",
@@ -508,7 +502,7 @@ dependencies = [
 [[package]]
 name = "roc_file"
 version = "0.0.1"
-source = "git+https://github.com/roc-lang/basic-cli.git#8a08cebbc31fe458816f7b98e1f5c176c43556b5"
+source = "git+https://github.com/roc-lang/basic-cli.git#bd752372b058e8c42cd4e8cfb74b36db64af01e8"
 dependencies = [
  "memchr",
  "roc_io_error",
@@ -549,7 +543,7 @@ dependencies = [
 [[package]]
 name = "roc_http"
 version = "0.0.1"
-source = "git+https://github.com/roc-lang/basic-cli.git#8a08cebbc31fe458816f7b98e1f5c176c43556b5"
+source = "git+https://github.com/roc-lang/basic-cli.git#bd752372b058e8c42cd4e8cfb74b36db64af01e8"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -566,7 +560,7 @@ dependencies = [
 [[package]]
 name = "roc_io_error"
 version = "0.0.1"
-source = "git+https://github.com/roc-lang/basic-cli.git#8a08cebbc31fe458816f7b98e1f5c176c43556b5"
+source = "git+https://github.com/roc-lang/basic-cli.git#bd752372b058e8c42cd4e8cfb74b36db64af01e8"
 dependencies = [
  "roc_std",
  "roc_std_heap",
@@ -575,7 +569,7 @@ dependencies = [
 [[package]]
 name = "roc_sqlite"
 version = "0.0.1"
-source = "git+https://github.com/roc-lang/basic-cli.git#8a08cebbc31fe458816f7b98e1f5c176c43556b5"
+source = "git+https://github.com/roc-lang/basic-cli.git#bd752372b058e8c42cd4e8cfb74b36db64af01e8"
 dependencies = [
  "libsqlite3-sys",
  "roc_std",
@@ -586,7 +580,7 @@ dependencies = [
 [[package]]
 name = "roc_std"
 version = "0.0.1"
-source = "git+https://github.com/roc-lang/roc.git#d02adf08a6d81ed0a7191047dcd1ee32070384da"
+source = "git+https://github.com/roc-lang/roc.git#09779cba0f6660f22e86cc2a5a930bcafff176b8"
 dependencies = [
  "arrayvec",
  "static_assertions",
@@ -595,7 +589,7 @@ dependencies = [
 [[package]]
 name = "roc_std_heap"
 version = "0.0.1"
-source = "git+https://github.com/roc-lang/roc.git#d02adf08a6d81ed0a7191047dcd1ee32070384da"
+source = "git+https://github.com/roc-lang/roc.git#09779cba0f6660f22e86cc2a5a930bcafff176b8"
 dependencies = [
  "memmap2",
  "roc_std",
@@ -604,7 +598,7 @@ dependencies = [
 [[package]]
 name = "roc_stdio"
 version = "0.0.1"
-source = "git+https://github.com/roc-lang/basic-cli.git#8a08cebbc31fe458816f7b98e1f5c176c43556b5"
+source = "git+https://github.com/roc-lang/basic-cli.git#bd752372b058e8c42cd4e8cfb74b36db64af01e8"
 dependencies = [
  "roc_io_error",
  "roc_std",
@@ -612,15 +606,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "once_cell",
  "ring",
@@ -702,18 +696,15 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -739,9 +730,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -835,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
@@ -877,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "windows-sys"

--- a/ci/expect_scripts/file-read.exp
+++ b/ci/expect_scripts/file-read.exp
@@ -5,7 +5,7 @@
 
 set timeout 7
 
-spawn $env(EXAMPLES_DIR)file
+spawn $env(EXAMPLES_DIR)file-read
 
 expect "Listening on <http://127.0.0.1:8000>\r\n" {
     set curlOutput [exec curl -sS localhost:8000]

--- a/ci/expect_scripts/file-read.exp
+++ b/ci/expect_scripts/file-read.exp
@@ -1,0 +1,22 @@
+#!/usr/bin/expect
+
+# uncomment line below for debugging
+# exp_internal 1
+
+set timeout 7
+
+spawn $env(EXAMPLES_DIR)file
+
+expect "Listening on <http://127.0.0.1:8000>\r\n" {
+    set curlOutput [exec curl -sS localhost:8000]
+
+    if { [string match "Source code of current program:\n\napp *" $curlOutput] } {
+        exit 0
+    } else {
+        puts "Error: curl output was different than expected: $curlOutput"
+        exit 1
+    }
+}
+
+puts stderr "\nError: output was different than expected."
+exit 1

--- a/ci/expect_scripts/file.exp
+++ b/ci/expect_scripts/file.exp
@@ -5,18 +5,113 @@
 
 set timeout 7
 
-spawn $env(EXAMPLES_DIR)file
+source ./ci/expect_scripts/shared-code.exp
 
-expect "Listening on <http://127.0.0.1:8000>\r\n" {
-    set curlOutput [exec curl -sS localhost:8000]
+spawn $env(TESTS_DIR)file
 
-    if { [string match "Source code of current program:\n\napp *" $curlOutput] } {
-        exit 0
-    } else {
-        puts "Error: curl output was different than expected: $curlOutput"
-        exit 1
+expect "Testing some File functions..." {
+    expect "This will create and manipulate test files in the current directory." {
+        
+        # Test File.write_bytes! and File.read_bytes!
+        expect "Testing File.write_bytes! and File.read_bytes!:" {
+            expect "Bytes in test_bytes.txt: \\\[72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33\\\]" {
+                
+                # Test File.write!
+                expect "Testing File.write!:" {
+                    expect "Content of test_write.json: {\"some\":\"json stuff\"}" {
+                        
+                        # Test File.is_file!
+                        expect "Testing File.is_file!:" {
+                            expect "✓ test_bytes.txt is confirmed to be a file" {
+                                
+                                # Test File.is_sym_link!
+                                expect "Testing File.is_sym_link!:" {
+                                    expect "✓ test_bytes.txt is not a symbolic link" {
+                                        expect "✓ test_symlink.txt is a symbolic link" {
+                                            
+                                            # Test File.type!
+                                            expect "Testing File.type!:" {
+                                                expect "test_bytes.txt file type: IsFile" {
+                                                    expect ". file type: IsDir" {
+                                                        expect "test_symlink.txt file type: IsSymLink" {
+                                                            
+                                                            # Test File.open_reader_with_capacity!
+                                                            expect "Testing File.open_reader_with_capacity!:" {
+                                                                expect "✓ Successfully opened reader with 3 byte capacity" {
+                                                                    
+                                                                    # Test reading lines from file
+                                                                    expect "Reading lines from file:" {
+                                                                        expect "Line 1: First line" {
+                                                                            expect "" {
+                                                                                expect "Line 2: Second line" {
+                                                                                    expect "" {
+                                                                                        
+                                                                                        # Test File.hard_link!
+                                                                                        expect "Testing File.hard_link!:" {
+                                                                                            expect "✓ Successfully created hard link: test_link_to_original.txt" {
+                                                                                                expect "Hard link inodes should be equal: Bool.true" {
+                                                                                                    expect "✓ Hard link contains same content as original" {
+                                                                                                        
+                                                                                                        # Test File.rename!
+                                                                                                        expect "Testing File.rename!:" {
+                                                                                                            expect "✓ Successfully renamed test_rename_original.txt to test_rename_new.txt" {
+                                                                                                                expect "✓ Original file test_rename_original.txt no longer exists" {
+                                                                                                                    expect "✓ Renamed file test_rename_new.txt exists" {
+                                                                                                                        expect "✓ Renamed file has correct content" {
+                                                                                                                            
+                                                                                                                            # Test File.exists!
+                                                                                                                            expect "Testing File.exists!:" {
+                                                                                                                                expect "✓ File.exists! returns true for a file that exists" {
+                                                                                                                                    expect "✓ File.exists! returns false for a file that does not exist" {
+                                                                                                                                        
+                                                                                                                                        expect "I ran all file function tests." {
+
+                                                                                                                                            expect "Cleaning up test files..." {
+                                                                                                                                                expect "✓ Deleted all files." {
+                                                                                                                                                
+                                                                                                                                                    expect "Ran all tests." {
+                                                                                                                                                        expect eof {
+                                                                                                                                                            check_exit_and_segfault
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
-puts stderr "\nError: output was different than expected."
+puts stderr "\nExpect script failed: output was different from expected value. uncomment `exp_internal 1` to debug."
 exit 1

--- a/ci/expect_scripts/issue_104.exp
+++ b/ci/expect_scripts/issue_104.exp
@@ -11,7 +11,7 @@ set env(DB_PATH) "$env(TESTS_DIR)todos.db"
 
 spawn $env(TESTS_DIR)issue_104
 
-expect "Program exited with error:" {
+expect "Server `init!` failed with error:" {
     expect -re {.*RowsReturned.*} {
                 exit 0
     }

--- a/ci/expect_scripts/path-test.exp
+++ b/ci/expect_scripts/path-test.exp
@@ -1,0 +1,197 @@
+#!/usr/bin/expect
+
+# uncomment line below for debugging
+# exp_internal 1
+
+set timeout 7
+
+source ./ci/expect_scripts/shared-code.exp
+
+spawn $env(TESTS_DIR)path-test
+
+expect "Testing Path functions..." {
+    expect "This will create and manipulate test files and directories in the current directory." {
+        
+        # Test Path.from_bytes and Path.with_extension
+        expect "Testing Path.from_bytes and Path.with_extension:" {
+            expect "Created path from bytes: test_path" {
+                expect "Path.from_bytes result matches expected: Bool.true" {
+                    expect "Path with extension: test_file.txt" {
+                        expect "Extension added correctly: Bool.true" {
+                            expect "Path with dot and extension: test_file.json" {
+                                expect "Extension after dot: Bool.true" {
+                                    expect "Path with replaced extension: test_file.new" {
+                                        expect "Extension replaced: Bool.true" {
+                                            
+                                            # Test Path file operations
+                                            expect "Testing Path file operations:" {
+                                                expect "test_path_bytes.txt exists: Bool.true" {
+                                                    expect "Bytes written: \\\[72, 101, 108, 108, 111, 44, 32, 80, 97, 116, 104, 33\\\]" {
+                                                        expect "Bytes read: \\\[72, 101, 108, 108, 111, 44, 32, 80, 97, 116, 104, 33\\\]" {
+                                                            expect "Bytes match: Bool.true" {
+                                                                expect "File content via cat: Hello from Path module! 🚀" {
+                                                                    expect "UTF-8 written: Hello from Path module! 🚀" {
+                                                                        expect "UTF-8 read: Hello from Path module! 🚀" {
+                                                                            expect "UTF-8 content matches: Bool.true" {
+                                                                                expect "JSON content: {\"message\":\"Path test\",\"numbers\":\\\[1,2,3\\\]}" {
+                                                                                    expect "JSON contains 'message' field: Bool.true" {
+                                                                                        expect "JSON contains 'numbers' field: Bool.true" {
+                                                                                            expect "File exists before delete: Bool.true" {
+                                                                                                expect "File exists after delete: Bool.false" {
+                                                                                                    
+                                                                                                    # Test Path directory operations
+                                                                                                    expect "Testing Path directory operations:" {
+                                                                                                        expect -re "Created directory: drwxr-xr-x \\d+ \\w+ (\\w+ )? *\\d+ \\w+ +\\d+ \\d+:\\d+ test_single_dir" {
+                                                                                                            expect "Is a directory: Bool.true" {
+                                                                                                                expect "" {
+                                                                                                                    expect "Nested directory structure:" {
+                                                                                                                        expect "test_parent" {
+                                                                                                                            expect "test_parent/test_child" {
+                                                                                                                                expect "test_parent/test_child/test_grandchild" {
+                                                                                                                                    expect "" {
+                                                                                                                                        expect "Number of directories created: 3" {
+                                                                                                                                            expect "Directory contents:" {
+                                                                                                                                                expect -re "total \\d+" {
+                                                                                                                                                    expect -re "dr\[-rwx\]+ +\\d+ \\w+ (\\w+ )? *\\d+ \\w+ +\\d+ \\d+:\\d+ \\." {
+                                                                                                                                                        expect -re "dr\[-rwx\]+ +\\d+ \\w+ (\\w+ )? *\\d+ \\w+ +\\d+ \\d+:\\d+ \\.\\." {
+                                                                                                                                                            expect -re "-\[-rwx\]+ +\\d+ \\w+ (\\w+ )? *\\d+ \\w+ +\\d+ \\d+:\\d+ file1\\.txt" {
+                                                                                                                                                                expect -re "-\[-rwx\]+ +\\d+ \\w+ (\\w+ )? *\\d+ \\w+ +\\d+ \\d+:\\d+ file2\\.txt" {
+                                                                                                                                                                    expect -re "dr\[-rwx\]+ +\\d+ \\w+ (\\w+ )? *\\d+ \\w+ +\\d+ \\d+:\\d+ subdir" {
+                                                                                                                                                                        expect "" {
+                                                                                                                                                                            expect "Empty dir exists before delete: Bool.true" {
+                                                                                                                                                                                expect "Empty dir exists after delete: Bool.false" {
+                                                                                                                                                                                    expect -re "Size before delete_all: \\d+\\w*\\s*test_parent" {
+                                                                                                                                                                                        expect "" {
+                                                                                                                                                                                            expect "Parent dir exists after delete_all: Bool.false" {
+                                                                                                                                                                                                expect "" {
+                                                                                                                                                                                                    
+                                                                                                                                                                                                    # Test Path.hard_link!
+                                                                                                                                                                                                    expect "Testing Path.hard_link!:" {
+                                                                                                                                                                                                        expect "Hard link count before: 1" {
+                                                                                                                                                                                                            expect "Hard link count after: 2" {
+                                                                                                                                                                                                                expect "Original content: Original content for Path hard link test" {
+                                                                                                                                                                                                                    expect "Link content: Original content for Path hard link test" {
+                                                                                                                                                                                                                        expect "Content matches: Bool.true" {
+                                                                                                                                                                                                                            expect "Inode information:" {
+                                                                                                                                                                                                                                expect -re "\\d+ -rw-r--r-- \\d+ \\w+ (\\w+ )? *\\d+ \\w+ +\\d+ \\d+:\\d+ test_path_hardlink\\.txt" {
+                                                                                                                                                                                                                                    expect -re "\\d+ -rw-r--r-- \\d+ \\w+ (\\w+ )? *\\d+ \\w+ +\\d+ \\d+:\\d+ test_path_original\\.txt" {
+                                                                                                                                                                                                                                        expect "" {
+                                                                                                                                                                                                                                            expect -re "First file inode: \\\[\"\\d+\"\\\]" {
+                                                                                                                                                                                                                                                expect -re "Second file inode: \\\[\"\\d+\"\\\]" {
+                                                                                                                                                                                                                                                    expect "Inodes are equal: Bool.true" {
+                                                                                                                                                                                                                                                        expect "" {
+                                                                                                                                                                                                                                                            expect "Testing Path.rename!:" {
+                                                                                                                                                                                                                                                                expect "✓ Original file no longer exists" {
+                                                                                                                                                                                                                                                                    expect "✓ Renamed file exists" {
+                                                                                                                                                                                                                                                                        expect "✓ Renamed file has correct content" {
+                                                                                                                                                                                                                                                                            expect "" {
+                                                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                # Test Path.exists!
+                                                                                                                                                                                                                                                                                expect "Testing Path.exists!:" {
+                                                                                                                                                                                                                                                                                    expect "✓ Path.exists! returns true for a file that exists" {
+                                                                                                                                                                                                                                                                                        expect "✓ Path.exists! returns false for a file that does not exist" {
+                                                                                                                                                                                                                                                                                            expect "" {
+                                                                                                                                                                                                                                                                                                expect "I ran all Path function tests." {
+                                                                                                                                                                                                                                                                                                    expect "" {
+
+                                                                                                                                                                                                                                                                                                        # Cleanup phase
+                                                                                                                                                                                                                                                                                                        expect "Cleaning up test files..." {
+                                                                                                                                                                                                                                                                                                            expect "Files to clean up:" {
+                                                                                                                                                                                                                                                                                                                expect -re "-rw-r--r-- \\d+ \\w+ \\w+ \\d+ \\w+ +\\d+ \\d+:\\d+ test_path_bytes\\.txt" {
+                                                                                                                                                                                                                                                                                                                    expect -re "-rw-r--r-- \\d+ \\w+ \\w+ \\d+ \\w+ +\\d+ \\d+:\\d+ test_path_hardlink\\.txt" {
+                                                                                                                                                                                                                                                                                                                        expect -re "-rw-r--r-- \\d+ \\w+ \\w+ \\d+ \\w+ +\\d+ \\d+:\\d+ test_path_json\\.json" {
+                                                                                                                                                                                                                                                                                                                            expect -re "-rw-r--r-- \\d+ \\w+ \\w+ \\d+ \\w+ +\\d+ \\d+:\\d+ test_path_original\\.txt" {
+                                                                                                                                                                                                                                                                                                                                expect -re "-rw-r--r-- \\d+ \\w+ \\w+ \\d+ \\w+ +\\d+ \\d+:\\d+ test_path_rename_new\\.txt" {
+                                                                                                                                                                                                                                                                                                                                    expect -re "-rw-r--r-- \\d+ \\w+ \\w+ \\d+ \\w+ +\\d+ \\d+:\\d+ test_path_utf8\\.txt" {
+                                                                                                                                                                                                                                                                                                                                        expect "" {
+                                                                                                                                                                                                                                                                                                                                            expect "Files remaining after cleanup: Bool.false" {        
+                                                                                                                                                                                                                                                                                                                                                expect eof {
+                                                                                                                                                                                                                                                                                                                                                        check_exit_and_segfault
+                                                                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+puts stderr "\nExpected script failed: output was different from expected value. uncomment `exp_internal 1` to debug."
+exit 1

--- a/crates/roc_host/src/roc.rs
+++ b/crates/roc_host/src/roc.rs
@@ -420,10 +420,41 @@ pub extern "C" fn roc_fx_file_rename(
 }
 
 #[no_mangle]
+pub extern "C" fn roc_fx_dir_create(roc_path: &RocList<u8>) -> RocResult<(), roc_io_error::IOErr> {
+    roc_file::dir_create(roc_path)
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_dir_create_all(
+    roc_path: &RocList<u8>,
+) -> RocResult<(), roc_io_error::IOErr> {
+    roc_file::dir_create_all(roc_path)
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_dir_delete_empty(
+    roc_path: &RocList<u8>,
+) -> RocResult<(), roc_io_error::IOErr> {
+    roc_file::dir_delete_empty(roc_path)
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_dir_delete_all(
+    roc_path: &RocList<u8>,
+) -> RocResult<(), roc_io_error::IOErr> {
+    roc_file::dir_delete_all(roc_path)
+}
+
+#[no_mangle]
 pub extern "C" fn roc_fx_dir_list(
     roc_path: &RocList<u8>,
 ) -> RocResult<RocList<RocList<u8>>, roc_io_error::IOErr> {
     roc_file::dir_list(roc_path)
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_temp_dir() -> RocList<u8> {
+    roc_env::temp_dir()
 }
 
 #[no_mangle]
@@ -432,11 +463,6 @@ pub extern "C" fn roc_fx_hard_link(
     path_link: &RocList<u8>,
 ) -> RocResult<(), roc_io_error::IOErr> {
     roc_file::hard_link(path_original, path_link)
-}
-
-#[no_mangle]
-pub extern "C" fn roc_fx_temp_dir() -> RocList<u8> {
-    roc_env::temp_dir()
 }
 
 #[derive(Clone, Debug)]

--- a/crates/roc_host/src/roc.rs
+++ b/crates/roc_host/src/roc.rs
@@ -34,6 +34,18 @@ pub unsafe extern "C" fn roc_realloc(
 
 #[no_mangle]
 pub unsafe extern "C" fn roc_dealloc(c_ptr: *mut c_void, _alignment: u32) {
+    let heap = roc_file::heap();
+    if heap.in_range(c_ptr) {
+        heap.dealloc(c_ptr);
+        return;
+    }
+
+    let heap = roc_http::heap();
+    if heap.in_range(c_ptr) {
+        heap.dealloc(c_ptr);
+        return;
+    }
+
     let heap = roc_sqlite::heap();
     if heap.in_range(c_ptr) {
         heap.dealloc(c_ptr);

--- a/crates/roc_host/src/roc.rs
+++ b/crates/roc_host/src/roc.rs
@@ -294,6 +294,14 @@ pub extern "C" fn roc_fx_tcp_write(stream: RocBox<()>, msg: &RocList<u8>) -> Roc
     roc_http::tcp_write(stream, msg)
 }
 
+
+#[no_mangle]
+pub extern "C" fn roc_fx_path_type(
+    roc_path: &RocList<u8>,
+) -> RocResult<roc_file::InternalPathType, roc_io_error::IOErr> {
+    roc_file::path_type(roc_path)
+}
+
 #[no_mangle]
 pub extern "C" fn roc_fx_file_write_utf8(
     roc_path: &RocList<u8>,
@@ -308,13 +316,6 @@ pub extern "C" fn roc_fx_file_write_bytes(
     roc_bytes: &RocList<u8>,
 ) -> RocResult<(), roc_io_error::IOErr> {
     roc_file::file_write_bytes(roc_path, roc_bytes)
-}
-
-#[no_mangle]
-pub extern "C" fn roc_fx_path_type(
-    roc_path: &RocList<u8>,
-) -> RocResult<roc_file::InternalPathType, roc_io_error::IOErr> {
-    roc_file::path_type(roc_path)
 }
 
 #[no_mangle]
@@ -345,10 +346,80 @@ pub extern "C" fn roc_fx_file_delete(roc_path: &RocList<u8>) -> RocResult<(), ro
 }
 
 #[no_mangle]
+pub extern "C" fn roc_fx_file_size_in_bytes(
+    roc_path: &RocList<u8>,
+) -> RocResult<u64, roc_io_error::IOErr> {
+    roc_file::file_size_in_bytes(roc_path)
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_file_is_executable(
+    roc_path: &RocList<u8>,
+) -> RocResult<bool, roc_io_error::IOErr> {
+    roc_file::file_is_executable(roc_path)
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_file_is_readable(
+    roc_path: &RocList<u8>,
+) -> RocResult<bool, roc_io_error::IOErr> {
+    roc_file::file_is_readable(roc_path)
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_file_is_writable(
+    roc_path: &RocList<u8>,
+) -> RocResult<bool, roc_io_error::IOErr> {
+    roc_file::file_is_writable(roc_path)
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_file_time_accessed(
+    roc_path: &RocList<u8>,
+) -> RocResult<roc_std::U128, roc_io_error::IOErr> {
+    roc_file::file_time_accessed(roc_path)
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_file_time_modified(
+    roc_path: &RocList<u8>,
+) -> RocResult<roc_std::U128, roc_io_error::IOErr> {
+    roc_file::file_time_modified(roc_path)
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_file_time_created(
+    roc_path: &RocList<u8>,
+) -> RocResult<roc_std::U128, roc_io_error::IOErr> {
+    roc_file::file_time_created(roc_path)
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_file_exists(roc_path: &RocList<u8>) -> RocResult<bool, roc_io_error::IOErr> {
+    roc_file::file_exists(roc_path)
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_file_rename(
+    from_path: &RocList<u8>,
+    to_path: &RocList<u8>,
+) -> RocResult<(), roc_io_error::IOErr> {
+    roc_file::file_rename(from_path, to_path)
+}
+
+#[no_mangle]
 pub extern "C" fn roc_fx_dir_list(
     roc_path: &RocList<u8>,
 ) -> RocResult<RocList<RocList<u8>>, roc_io_error::IOErr> {
     roc_file::dir_list(roc_path)
+}
+
+#[no_mangle]
+pub extern "C" fn roc_fx_hard_link(
+    path_original: &RocList<u8>,
+    path_link: &RocList<u8>,
+) -> RocResult<(), roc_io_error::IOErr> {
+    roc_file::hard_link(path_original, path_link)
 }
 
 #[no_mangle]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,10 @@
+
+These are examples of how to make server programs using `basic-webserver` as the [platform](https://www.roc-lang.org/platforms).
+Check out the [basic-cli examples](https://github.com/roc-lang/basic-cli/tree/main/examples) for more, there is a very large overlap in exposed functions between the two platforms.
+
+> [!IMPORTANT]
+> - If you want to run an example here but don't want to build basic-webserver from source; go to the examples of a specific version: https://github.com/roc-lang/basic-webserver/tree/0.VERSION.0/examples and in the example; replace the `"../platform/main.roc"` with the release link, for example `"https://github.com/roc-lang/basic-webserver/releases/download/0.12.0/Q4h_In-sz1BqAvlpmCsBHhEJnn_YvfRRMiNACB_fBbk.tar.br"`. Next, run with `roc ./examples/YOUREXAMPLE.roc`.
+> - To use these examples as is with basic-webserver built from source you'll need to [build the platform first](https://github.com/roc-lang/basic-webserver?tab=readme-ov-file#developing--building-locally).
+
+Feel free to ask [on Zulip](https://roc.zulipchat.com) in the `#beginners` channel if you have questions about making
+basic-webserver programs, or if there are functions you'd like to see added to this platform .

--- a/examples/command.roc
+++ b/examples/command.roc
@@ -4,6 +4,8 @@ import pf.Http exposing [Request, Response]
 import pf.Cmd
 import pf.Utc
 
+# To run this example: check the README.md in this folder
+
 Model : {}
 
 init! : {} => Result Model _

--- a/examples/dir.roc
+++ b/examples/dir.roc
@@ -6,6 +6,8 @@ import pf.Env
 import pf.Path
 import pf.Http exposing [Request, Response]
 
+# To run this example: check the README.md in this folder
+
 Model : {}
 
 init! : {} => Result Model _

--- a/examples/echo.roc
+++ b/examples/echo.roc
@@ -4,6 +4,8 @@ import pf.Stdout
 import pf.Http exposing [Request, Response]
 import pf.Utc
 
+# To run this example: check the README.md in this folder
+
 Model : {}
 
 init! : {} => Result Model []

--- a/examples/env.roc
+++ b/examples/env.roc
@@ -3,6 +3,8 @@ app [Model, init!, respond!] { pf: platform "../platform/main.roc" }
 import pf.Http exposing [Request, Response]
 import pf.Env
 
+# To run this example: check the README.md in this folder
+
 # We'll set this based on env var at server startup
 Model : [DebugPrintMode, NonDebugMode]
 

--- a/examples/error-handling.roc
+++ b/examples/error-handling.roc
@@ -6,6 +6,8 @@ import pf.Http exposing [Request, Response]
 import pf.Utc
 import pf.Env
 
+# To run this example: check the README.md in this folder
+
 Model : {}
 
 init! : {} => Result Model []

--- a/examples/file-read.roc
+++ b/examples/file-read.roc
@@ -4,6 +4,8 @@ import pf.File
 import pf.Path
 import pf.Http exposing [Request, Response]
 
+# To run this example: check the README.md in this folder
+
 # Model represents the content of the file we read in `init`.
 Model : Str
 

--- a/examples/file-read.roc
+++ b/examples/file-read.roc
@@ -13,7 +13,7 @@ Model : Str
 init! : {} => Result Model [Exit I32 Str]_
 init! = |{}|
     # Read the contents of examples/file.roc
-    File.read_utf8!("examples/file.roc")
+    File.read_utf8!("examples/file-read.roc")
     |> Result.map_ok(|contents| "Source code of current program:\n\n${contents}")
     |> Result.map_err(
         |err|

--- a/examples/file-upload-form.roc
+++ b/examples/file-upload-form.roc
@@ -7,6 +7,8 @@ import utils.Base64
 import pf.Http exposing [Request, Response]
 import pf.MultipartFormData
 
+# To run this example: check the README.md in this folder
+
 # Model is produced by `init`.
 Model : {}
 

--- a/examples/hello-web.roc
+++ b/examples/hello-web.roc
@@ -4,6 +4,8 @@ import pf.Stdout
 import pf.Http exposing [Request, Response]
 import pf.Utc
 
+# To run this example: check the README.md in this folder
+
 # Model is produced by `init`.
 Model : {}
 

--- a/examples/init-basic.roc
+++ b/examples/init-basic.roc
@@ -4,6 +4,8 @@ import pf.Stdout
 import pf.Http exposing [Request, Response]
 import pf.Utc
 
+# To run this example: check the README.md in this folder
+
 # Model is produced by `init`.
 Model : Str
 

--- a/examples/result.roc
+++ b/examples/result.roc
@@ -2,6 +2,8 @@ app [Model, init!, respond!] { pf: platform "../platform/main.roc" }
 
 import pf.Http exposing [Request, Response]
 
+# To run this example: check the README.md in this folder
+
 Model : {}
 
 init! : {} => Result Model []

--- a/examples/sleep.roc
+++ b/examples/sleep.roc
@@ -4,6 +4,8 @@ import pf.Stdout
 import pf.Http exposing [Request, Response]
 import pf.Sleep
 
+# To run this example: check the README.md in this folder
+
 Model : {}
 
 init! : {} => Result Model []

--- a/examples/sqlite.roc
+++ b/examples/sqlite.roc
@@ -5,6 +5,8 @@ import pf.Http exposing [Request, Response]
 import pf.Sqlite
 import pf.Env
 
+# To run this example: check the README.md in this folder
+
 Model : { stmt : Sqlite.Stmt }
 
 init! : {} => Result Model _

--- a/examples/temp-dir.roc
+++ b/examples/temp-dir.roc
@@ -4,6 +4,8 @@ import pf.Http exposing [Request, Response]
 import pf.Path
 import pf.Env
 
+# To run this example: check the README.md in this folder
+
 ## Returns the default temp dir
 ##
 ## !! requires --linker=legacy

--- a/examples/todos.roc
+++ b/examples/todos.roc
@@ -9,6 +9,8 @@ import pf.Url
 import pf.Utc
 import "todos.html" as todo_html : List U8
 
+# To run this example: check the README.md in this folder
+
 Model : {
     list_todos_stmt : Sqlite.Stmt,
     create_todo_stmt : Sqlite.Stmt,

--- a/platform/Dir.roc
+++ b/platform/Dir.roc
@@ -1,5 +1,4 @@
 module [
-    DirEntry,
     IOErr,
     list!,
     create!,
@@ -15,11 +14,6 @@ import InternalIOErr
 ##
 ## > This is the same as [`File.IOErr`](File#IOErr).
 IOErr : InternalIOErr.IOErr
-
-## Record which represents a directory
-##
-## > This is the same as [`Path.DirEntry`](Path#DirEntry).
-DirEntry : Path.DirEntry
 
 ## Lists the files and directories inside the directory.
 ##

--- a/platform/Host.roc
+++ b/platform/Host.roc
@@ -22,12 +22,21 @@ hosted Host
         tty_mode_canonical!,
         tty_mode_raw!,
         send_request!,
-        file_read_bytes!,
         file_delete!,
-        file_write_utf8!,
-        file_write_bytes!,
+        file_exists!,
+        file_read_bytes!,
         file_reader!,
         file_read_line!,
+        file_size_in_bytes!,
+        file_write_bytes!,
+        file_write_utf8!,
+        file_is_executable!,
+        file_is_readable!,
+        file_is_writable!,
+        file_time_accessed!,
+        file_time_modified!,
+        file_time_created!,
+        file_rename!,
         path_type!,
         posix_time!,
         tcp_connect!,
@@ -77,31 +86,39 @@ command_status! : InternalCmd.Command => Result I32 InternalIOErr.IOErrFromHost
 command_output! : InternalCmd.Command => InternalCmd.OutputFromHost
 
 # FILE
-file_write_bytes! : List U8, List U8 => Result {} InternalIOErr
-file_write_utf8! : List U8, Str => Result {} InternalIOErr
-file_delete! : List U8 => Result {} InternalIOErr
-file_read_bytes! : List U8 => Result (List U8) InternalIOErr
-
+file_write_bytes! : List U8, List U8 => Result {} InternalIOErr.IOErrFromHost
+file_write_utf8! : List U8, Str => Result {} InternalIOErr.IOErrFromHost
+file_delete! : List U8 => Result {} InternalIOErr.IOErrFromHost
+file_read_bytes! : List U8 => Result (List U8) InternalIOErr.IOErrFromHost
+file_size_in_bytes! : List U8 => Result U64 InternalIOErr.IOErrFromHost
+file_exists! : List U8 => Result Bool InternalIOErr.IOErrFromHost
+file_is_executable! : List U8 => Result Bool InternalIOErr.IOErrFromHost
+file_is_readable! : List U8 => Result Bool InternalIOErr.IOErrFromHost
+file_is_writable! : List U8 => Result Bool InternalIOErr.IOErrFromHost
+file_time_accessed! : List U8 => Result U128 InternalIOErr.IOErrFromHost
+file_time_modified! : List U8 => Result U128 InternalIOErr.IOErrFromHost
+file_time_created! : List U8 => Result U128 InternalIOErr.IOErrFromHost
+file_rename! : List U8, List U8 => Result {} InternalIOErr.IOErrFromHost
 FileReader := Box {}
 file_reader! : List U8, U64 => Result FileReader InternalIOErr
 file_read_line! : FileReader => Result (List U8) InternalIOErr
 
-dir_list! : List U8 => Result (List (List U8)) InternalIOErr
-dir_create! : List U8 => Result {} InternalIOErr
-dir_create_all! : List U8 => Result {} InternalIOErr
-dir_delete_empty! : List U8 => Result {} InternalIOErr
-dir_delete_all! : List U8 => Result {} InternalIOErr
+dir_list! : List U8 => Result (List (List U8)) InternalIOErr.IOErrFromHost
+dir_create! : List U8 => Result {} InternalIOErr.IOErrFromHost
+dir_create_all! : List U8 => Result {} InternalIOErr.IOErrFromHost
+dir_delete_empty! : List U8 => Result {} InternalIOErr.IOErrFromHost
+dir_delete_all! : List U8 => Result {} InternalIOErr.IOErrFromHost
 
-hard_link! : List U8 => Result {} InternalIOErr
-path_type! : List U8 => Result InternalPath.InternalPathType InternalIOErr
+hard_link! : List U8, List U8 => Result {} InternalIOErr.IOErrFromHost
+path_type! : List U8 => Result InternalPath.InternalPathType InternalIOErr.IOErrFromHost
 cwd! : {} => Result (List U8) {}
 temp_dir! : {} => List U8
 
 # STDIO
-stdout_line! : Str => Result {} InternalIOErr
-stdout_write! : Str => Result {} InternalIOErr
-stderr_line! : Str => Result {} InternalIOErr
-stderr_write! : Str => Result {} InternalIOErr
+stdout_line! : Str => Result {} InternalIOErr.IOErrFromHost
+stdout_write! : Str => Result {} InternalIOErr.IOErrFromHost
+stderr_line! : Str => Result {} InternalIOErr.IOErrFromHost
+stderr_write! : Str => Result {} InternalIOErr.IOErrFromHost
 
 # TCP
 send_request! : InternalHttp.RequestToAndFromHost => InternalHttp.ResponseToAndFromHost

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -42,7 +42,7 @@ init_for_host! = |_|
             _ = Stderr.line!(
                 """
 
-                Program exited with error:
+                Server `init!` failed with error:
 
                     ❌ ${Inspect.to_str(err)}
 

--- a/tests/file.roc
+++ b/tests/file.roc
@@ -1,0 +1,284 @@
+app [Model, init!, respond!] { 
+    pf: platform "../platform/main.roc",
+    json: "https://github.com/lukewilliamboswell/roc-json/releases/download/0.13.0/RqendgZw5e1RsQa3kFhgtnMP8efWoqGRsAvubx4-zus.tar.br",
+}
+
+import pf.Stdout
+import pf.Stderr
+import pf.File
+import pf.Cmd
+import json.Json
+import pf.Http exposing [Request, Response]
+
+Model : {}
+
+init! : {} => Result Model _
+init! = |{}|
+    when run_tests!({}) is
+        Ok(_) ->
+            cleanup_test_files!(FilesNeedToExist)
+        Err(err) ->
+            cleanup_test_files!(FilesMaybeExist)?
+            Err(Exit(1, "Test run failed:\n\t${Inspect.to_str(err)}"))
+
+run_tests! : {} => Result {} _
+run_tests! = |{}|
+    Stdout.line!("Testing some File functions...")?
+    Stdout.line!("This will create and manipulate test files in the current directory.")?
+    Stdout.line!("")?
+
+    # Test basic file operations
+    test_basic_file_operations!({})?
+    
+    # Test file type checking
+    test_file_type_checking!({})?
+    
+    # Test file reader with capacity
+    test_file_reader_with_capacity!({})?
+
+    # Test hard link creation
+    test_hard_link!({})?
+
+    # Test file rename
+    test_file_rename!({})?
+
+    # Test file exists
+    test_file_exists!({})?
+
+    Stdout.line!("\nI ran all file function tests.")
+
+test_basic_file_operations! : {} => Result {} _
+test_basic_file_operations! = |{}|
+    Stdout.line!("Testing File.write_bytes! and File.read_bytes!:")?
+
+    test_bytes = [72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33] # "Hello, World!" in bytes
+    File.write_bytes!(test_bytes, "test_bytes.txt")?
+
+    file_content_bytes = File.read_bytes!("test_bytes.txt")?
+    Stdout.line!("Bytes in test_bytes.txt: ${Inspect.to_str(file_content_bytes)}")?
+
+
+    Stdout.line!("\nTesting File.write!:")?
+
+    File.write!({ some: "json stuff" }, "test_write.json", Json.utf8)?
+    json_file_content = File.read_utf8!("test_write.json")?
+    Stdout.line!("Content of test_write.json: ${json_file_content}")?
+
+    Ok({})
+
+test_file_type_checking! : {} => Result {} _
+test_file_type_checking! = |{}|
+
+    Stdout.line!("\nTesting File.is_file!:")?
+    is_file_result = File.is_file!("test_bytes.txt")?
+    if is_file_result then
+        Stdout.line!("✓ test_bytes.txt is confirmed to be a file")?
+    else
+        Stderr.line!("✗ test_bytes.txt is not recognized as a file")?
+
+
+    Stdout.line!("\nTesting File.is_sym_link!:")?
+    is_symlink_one = File.is_sym_link!("test_bytes.txt")?
+    if is_symlink_one then
+        Stderr.line!("✗ test_bytes.txt is a symbolic link")?
+    else
+        Stdout.line!("✓ test_bytes.txt is not a symbolic link")?
+
+    Cmd.exec!("ln",["-s", "test_bytes.txt","test_symlink.txt"])?
+
+    is_symlink_two = File.is_sym_link!("test_symlink.txt")?
+    if is_symlink_two then
+        Stdout.line!("✓ test_symlink.txt is a symbolic link")?
+    else
+        Stderr.line!("✗ test_symlink.txt is not a symbolic link")?
+
+
+    Stdout.line!("\nTesting File.type!:")?
+
+    file_type_file = File.type!("test_bytes.txt")?
+    Stdout.line!("test_bytes.txt file type: ${Inspect.to_str(file_type_file)}")?
+
+    file_type_dir = File.type!(".")?
+    Stdout.line!(". file type: ${Inspect.to_str(file_type_dir)}")?
+
+    file_type_symlink = File.type!("test_symlink.txt")?
+    Stdout.line!("test_symlink.txt file type: ${Inspect.to_str(file_type_symlink)}")?
+
+    Ok({})
+
+test_file_reader_with_capacity! : {} => Result {} _
+test_file_reader_with_capacity! = |{}|
+    Stdout.line!("\nTesting File.open_reader_with_capacity!:")?
+    
+    # First, create a multi-line test file
+    multi_line_content = "First line\nSecond line\nThird line\n"
+    File.write_utf8!(multi_line_content, "test_multiline.txt")?
+    
+    # Open reader with custom capacity
+    reader_buf_size = 3
+    reader = File.open_reader_with_capacity!("test_multiline.txt", reader_buf_size)?
+    Stdout.line!("✓ Successfully opened reader with ${Num.to_str(reader_buf_size)} byte capacity")?
+    
+    # Read lines one by one
+    Stdout.line!("\nReading lines from file:")?
+    line1_bytes = File.read_line!(reader)?
+    line1_str = Str.from_utf8(line1_bytes) ? |_| LineOneInvalidUtf8
+    Stdout.line!("Line 1: ${line1_str}")?
+    
+    line2_bytes = File.read_line!(reader)?
+    line2_str = Str.from_utf8(line2_bytes) ? |_| LineTwoInvalidUtf8
+    Stdout.line!("Line 2: ${line2_str}")?
+
+    Ok({})
+
+test_hard_link! : {} => Result {} _
+test_hard_link! = |{}|
+    Stdout.line!("\nTesting File.hard_link!:")?
+    
+    # Create original file
+    File.write_utf8!("Original file content for hard link test", "test_original_file.txt")?
+    
+    # Create hard link
+    when File.hard_link!("test_original_file.txt", "test_link_to_original.txt") is
+        Ok({}) ->
+            Stdout.line!("✓ Successfully created hard link: test_link_to_original.txt")?
+
+            ls_li_output =
+                Cmd.new("ls")
+                |> Cmd.args(["-li", "test_original_file.txt", "test_link_to_original.txt"])
+                |> Cmd.output!()
+
+            ls_li_stdout_utf8 = Str.from_utf8(ls_li_output.stdout) ? |_| LsLiInvalidUtf8
+
+            inodes =
+                Str.split_on(ls_li_stdout_utf8, "\n")
+                |> List.map(|line| 
+                                Str.split_on(line, " ")
+                                |> List.take_first(1)
+                            )
+
+            first_inode = List.get(inodes, 0) ? |_| FirstInodeNotFound
+            second_inode = List.get(inodes, 1) ? |_| SecondInodeNotFound
+
+            Stdout.line!("Hard link inodes should be equal: ${Inspect.to_str(first_inode == second_inode)}")?
+            
+            # Verify both files exist and have same content
+            original_content = File.read_utf8!("test_original_file.txt")?
+            link_content = File.read_utf8!("test_link_to_original.txt")?
+            
+            if original_content == link_content then
+                Stdout.line!("✓ Hard link contains same content as original")
+            else
+                Stderr.line!("✗ Hard link content differs from original")
+        
+        Err(err) ->
+            Stderr.line!("✗ Hard link creation failed: ${Inspect.to_str(err)}")
+
+test_file_rename! : {} => Result {} _
+test_file_rename! = |{}|
+    Stdout.line!("\nTesting File.rename!:")?
+    
+    # Create original file
+    original_name = "test_rename_original.txt"
+    new_name = "test_rename_new.txt"
+    File.write_utf8!("Content for rename test", original_name)?
+    
+    # Rename the file
+    when File.rename!(original_name, new_name) is
+        Ok({}) ->
+            Stdout.line!("✓ Successfully renamed ${original_name} to ${new_name}")?
+            
+            # Verify original file no longer exists
+            original_exists_after = 
+                when File.is_file!(original_name) is
+                    Ok(exists) -> exists
+                    Err(_) -> Bool.false
+            
+            if original_exists_after then
+                Stderr.line!("✗ Original file ${original_name} still exists after rename")?
+            else
+                Stdout.line!("✓ Original file ${original_name} no longer exists")?
+            
+            # Verify new file exists and has correct content
+            new_exists = File.is_file!(new_name)?
+            if new_exists then
+                Stdout.line!("✓ Renamed file ${new_name} exists")?
+                
+                content = File.read_utf8!(new_name)?
+                if content == "Content for rename test" then
+                    Stdout.line!("✓ Renamed file has correct content")?
+                else
+                    Stderr.line!("✗ Renamed file has incorrect content")?
+            else
+                Stderr.line!("✗ Renamed file ${new_name} does not exist")?
+        
+        Err(err) ->
+            Stderr.line!("✗ File rename failed: ${Inspect.to_str(err)}")?
+    
+    Ok({})
+
+test_file_exists! : {} => Result {} _
+test_file_exists! = |{}|
+    Stdout.line!("\nTesting File.exists!:")?
+
+    # Test that a file that exists returns true
+    filename = "test_exists.txt"
+    File.write_utf8!("", filename)?
+
+    test_file_exists = File.exists!(filename) ? |err| FileExistsCheckFailed(err)
+
+    if test_file_exists then 
+        Stdout.line!("✓ File.exists! returns true for a file that exists")?
+    else
+        Stderr.line!("✗ File.exists! returned false for a file that exists")?
+
+    # Test that a file that does not exist returns false
+    File.delete!(filename)?
+
+    test_file_exists_after_delete = File.exists!(filename) ? |err| FileExistsCheckAfterDeleteFailed(err)
+
+    if test_file_exists_after_delete then
+        Stderr.line!("✗ File.exists! returned true for a file that does not exist")?
+    else
+        Stdout.line!("✓ File.exists! returns false for a file that does not exist")?
+
+    Ok({})
+
+cleanup_test_files! : [FilesNeedToExist, FilesMaybeExist] => Result {} _
+cleanup_test_files! = |files_requirement|
+    Stdout.line!("\nCleaning up test files...")?
+    
+    test_files = [
+        "test_bytes.txt",
+        "test_symlink.txt",
+        "test_write.json", 
+        "test_multiline.txt",
+        "test_original_file.txt",
+        "test_link_to_original.txt",
+        "test_rename_new.txt",
+    ]
+
+    delete_result = List.for_each_try!(
+        test_files,
+        |filename| File.delete!(filename)
+    )
+    
+    when files_requirement is
+        FilesNeedToExist ->
+            delete_result ? |err| FileDeletionFailed(err)
+        FilesMaybeExist ->
+            Ok({})?
+
+    Stdout.line!("✓ Deleted all files.")
+
+
+respond! : Request, Model => Result Response [ServerErr Str]_
+respond! = |_, _|
+
+    Ok(
+        {
+            status: 200,
+            headers: [],
+            body: Str.to_utf8("I am a test."),
+        },
+    )

--- a/tests/file.roc
+++ b/tests/file.roc
@@ -16,7 +16,8 @@ init! : {} => Result Model _
 init! = |{}|
     when run_tests!({}) is
         Ok(_) ->
-            cleanup_test_files!(FilesNeedToExist)
+            cleanup_test_files!(FilesNeedToExist)?
+            Err(Exit(0, "Ran all tests."))
         Err(err) ->
             cleanup_test_files!(FilesMaybeExist)?
             Err(Exit(1, "Test run failed:\n\t${Inspect.to_str(err)}"))

--- a/tests/path-test.roc
+++ b/tests/path-test.roc
@@ -1,0 +1,460 @@
+app [Model, init!, respond!] { 
+    pf: platform "../platform/main.roc",
+    json: "https://github.com/lukewilliamboswell/roc-json/releases/download/0.13.0/RqendgZw5e1RsQa3kFhgtnMP8efWoqGRsAvubx4-zus.tar.br",
+}
+
+import pf.Stdout
+import pf.Stderr
+import pf.Path
+import pf.Cmd
+import json.Json
+import pf.Http exposing [Request, Response]
+
+Model : {}
+
+init! : {} => Result Model _
+init! = |{}|
+    when run_tests!({}) is
+        Ok(_) ->
+            cleanup_test_files!(FilesNeedToExist)?
+            Err(Exit(0, "Ran all tests."))
+        Err(err) ->
+            cleanup_test_files!(FilesMaybeExist)?
+            Err(Exit(1, "Test run failed:\n\t${Inspect.to_str(err)}"))
+
+run_tests!: {} => Result {} _
+run_tests! = |{}|
+    Stdout.line!(
+        """
+        Testing Path functions...
+        This will create and manipulate test files and directories in the current directory.
+        
+        """
+    )?
+
+    # Test path creation
+    test_path_creation!({})?
+    
+    # Test file operations
+    test_file_operations!({})?
+    
+    # Test directory operations
+    test_directory_operations!({})?
+    
+    # Test hard link creation
+    test_hard_link!({})?
+
+    # Test file rename
+    test_path_rename!({})?
+
+    # Test path exists
+    test_path_exists!({})?
+
+    Stdout.line!("\nI ran all Path function tests.")
+
+test_path_creation! : {} => Result {} _
+test_path_creation! = |{}|
+    Stdout.line!("Testing Path.from_bytes and Path.with_extension:")?
+
+    # Test Path.from_bytes
+    path_bytes = [116, 101, 115, 116, 95, 112, 97, 116, 104] # "test_path" in bytes
+    path_from_bytes = Path.from_bytes(path_bytes)
+    expected_str = "test_path"
+    actual_str = Path.display(path_from_bytes)
+    
+    # Test Path.with_extension
+    base_path = Path.from_str("test_file")
+    path_with_ext = Path.with_extension(base_path, "txt")
+    
+    path_with_dot = Path.from_str("test_file.")
+    path_dot_ext = Path.with_extension(path_with_dot, "json")
+    
+    path_replace_ext = Path.from_str("test_file.old")
+    path_new_ext = Path.with_extension(path_replace_ext, "new")
+
+    Stdout.line!(
+        """
+        Created path from bytes: ${Path.display(path_from_bytes)}
+        Path.from_bytes result matches expected: ${Inspect.to_str(actual_str == expected_str)}
+        Path with extension: ${Path.display(path_with_ext)}
+        Extension added correctly: ${Inspect.to_str(Path.display(path_with_ext) == "test_file.txt")}
+        Path with dot and extension: ${Path.display(path_dot_ext)}
+        Extension after dot: ${Inspect.to_str(Path.display(path_dot_ext) == "test_file.json")}
+        Path with replaced extension: ${Path.display(path_new_ext)}
+        Extension replaced: ${Inspect.to_str(Path.display(path_new_ext) == "test_file.new")}
+        """
+    )?
+
+    Ok({})
+
+test_file_operations! : {} => Result {} _
+test_file_operations! = |{}|
+    Stdout.line!("\nTesting Path file operations:")?
+
+    # Test Path.write_bytes! and Path.read_bytes!
+    test_bytes = [72, 101, 108, 108, 111, 44, 32, 80, 97, 116, 104, 33] # "Hello, Path!" in bytes
+    bytes_path = Path.from_str("test_path_bytes.txt")
+    Path.write_bytes!(test_bytes, bytes_path)?
+    
+    # Verify file exists using ls
+    ls_output = Cmd.new("ls") |> Cmd.args(["-la", "test_path_bytes.txt"]) |> Cmd.output!()
+    ls_exit_code = ls_output.status ? |err| LsFailedToGetExitCode(err)
+    
+    read_bytes = Path.read_bytes!(bytes_path)?
+    
+    Stdout.line!(
+        """
+        test_path_bytes.txt exists: ${Inspect.to_str(ls_exit_code == 0)}
+        Bytes written: ${Inspect.to_str(test_bytes)}
+        Bytes read: ${Inspect.to_str(read_bytes)}
+        Bytes match: ${Inspect.to_str(test_bytes == read_bytes)}
+        """
+    )?
+
+    # Test Path.write_utf8! and Path.read_utf8!
+    utf8_content = "Hello from Path module! 🚀"
+    utf8_path = Path.from_str("test_path_utf8.txt")
+    Path.write_utf8!(utf8_content, utf8_path)?
+    
+    # Check file content with cat
+    cat_output = Cmd.new("cat") |> Cmd.args(["test_path_utf8.txt"]) |> Cmd.output!()
+    cat_stdout = Str.from_utf8(cat_output.stdout) ? |_| CatInvalidUtf8
+    
+    read_utf8 = Path.read_utf8!(utf8_path)?
+    
+    Stdout.line!(
+        """
+        File content via cat: ${cat_stdout}
+        UTF-8 written: ${utf8_content}
+        UTF-8 read: ${read_utf8}
+        UTF-8 content matches: ${Inspect.to_str(utf8_content == read_utf8)}
+        """
+    )?
+
+    # Test Path.write! with JSON encoding
+    json_data = { message: "Path test", numbers: [1, 2, 3] }
+    json_path = Path.from_str("test_path_json.json")
+    Path.write!(json_data, json_path, Json.utf8)?
+    
+    json_content = Path.read_utf8!(json_path)?
+    
+    # Verify it's valid JSON by checking it contains expected fields
+    contains_message = Str.contains(json_content, "\"message\"")
+    contains_numbers = Str.contains(json_content, "\"numbers\"")
+    
+    Stdout.line!(
+        """
+        JSON content: ${json_content}
+        JSON contains 'message' field: ${Inspect.to_str(contains_message)}
+        JSON contains 'numbers' field: ${Inspect.to_str(contains_numbers)}
+        """
+    )?
+
+    # Test Path.delete!
+    delete_path = Path.from_str("test_to_delete.txt")
+    Path.write_utf8!("This file will be deleted", delete_path)?
+    
+    # Verify file exists before deletion
+    ls_before = Cmd.new("ls") |> Cmd.args(["test_to_delete.txt"]) |> Cmd.output!() 
+
+    Path.delete!(delete_path) ? |err| DeleteFailed(err)
+    
+    # Verify file is gone after deletion
+    ls_after = Cmd.new("ls") |> Cmd.args(["test_to_delete.txt"]) |> Cmd.output!()
+    
+    Stdout.line!(
+        """
+        File exists before delete: ${Inspect.to_str(ls_before.status? == 0)}
+        File exists after delete: ${Inspect.to_str(ls_after.status? == 0)}
+        """
+    )?
+
+    Ok({})
+
+test_directory_operations! : {} => Result {} _
+test_directory_operations! = |{}|
+    Stdout.line!("\nTesting Path directory operations:")?
+
+    # Test Path.create_dir!
+    single_dir = Path.from_str("test_single_dir")
+    Path.create_dir!(single_dir)?
+    
+    # Verify directory exists
+    ls_dir = Cmd.new("ls") |> Cmd.args(["-ld", "test_single_dir"]) |> Cmd.output!()
+    ls_dir_stdout = Str.from_utf8(ls_dir.stdout) ? |_| LsDirInvalidUtf8
+    is_dir = Str.starts_with(ls_dir_stdout, "d")
+    
+    Stdout.line!(
+        """
+        Created directory: ${Str.trim_end(ls_dir_stdout)}
+        Is a directory: ${Inspect.to_str(is_dir)}\n
+        """
+    )?
+
+    # Test Path.create_all! (nested directories)
+    nested_dir = Path.from_str("test_parent/test_child/test_grandchild")
+    Path.create_all!(nested_dir)?
+    
+    # Verify nested structure with find
+    find_output = Cmd.new("find") |> Cmd.args(["test_parent", "-type", "d"]) |> Cmd.output!()
+    find_stdout = Str.from_utf8(find_output.stdout) ? |_| FindInvalidUtf8
+    
+    # Count directories created
+    dir_count = Str.split_on(find_stdout, "\n") |> List.len
+    
+    Stdout.line!(
+        """
+        Nested directory structure:
+        ${find_stdout}
+        Number of directories created: ${Num.to_str(dir_count - 1)}
+        """
+    )?
+
+    # Create some files in the directory for testing
+    Path.write_utf8!("File 1", Path.from_str("test_single_dir/file1.txt"))?
+    Path.write_utf8!("File 2", Path.from_str("test_single_dir/file2.txt"))?
+    Path.create_dir!(Path.from_str("test_single_dir/subdir"))?
+    
+    # List directory contents
+    ls_contents = Cmd.new("ls") |> Cmd.args(["-la", "test_single_dir"]) |> Cmd.output!()
+    ls_contents_stdout = Str.from_utf8(ls_contents.stdout) ? |_| LsContentsInvalidUtf8
+    
+    Stdout.line!(
+        """
+        Directory contents:
+        ${ls_contents_stdout}
+        """
+    )?
+
+    # Test Path.delete_empty!
+    empty_dir = Path.from_str("test_empty_dir")
+    Path.create_dir!(empty_dir)?
+    
+    # Verify it exists
+    ls_empty_before = Cmd.new("ls") |> Cmd.args(["-ld", "test_empty_dir"]) |> Cmd.output!()
+    
+    Path.delete_empty!(empty_dir)?
+    
+    # Verify it's gone
+    ls_empty_after = Cmd.new("ls") |> Cmd.args(["-ld", "test_empty_dir"]) |> Cmd.output!()
+    
+    Stdout.line!(
+        """
+        Empty dir exists before delete: ${Inspect.to_str(ls_empty_before.status? == 0)}
+        Empty dir exists after delete: ${Inspect.to_str(ls_empty_after.status? == 0)}
+        """
+    )?
+
+    # Test Path.delete_all!
+    # First show what we're about to delete
+    du_output = Cmd.new("du") |> Cmd.args(["-sh", "test_parent"]) |> Cmd.output!()
+    du_stdout = Str.from_utf8(du_output.stdout) ? |_| DuInvalidUtf8
+    
+    Path.delete_all!(Path.from_str("test_parent"))?
+    
+    # Verify it's gone
+    ls_parent_after = Cmd.new("ls") |> Cmd.args(["test_parent"]) |> Cmd.output!()
+    
+    Stdout.line!(
+        """
+        Size before delete_all: ${du_stdout}
+        Parent dir exists after delete_all: ${Inspect.to_str(ls_parent_after.status? == 0)}
+        """
+    )?
+
+    # Clean up other test directory
+    Path.delete_all!(single_dir)?
+
+    Ok({})
+
+test_hard_link! : {} => Result {} _
+test_hard_link! = |{}|
+    Stdout.line!("\nTesting Path.hard_link!:")?
+    
+    # Create original file
+    original_path = Path.from_str("test_path_original.txt")
+    Path.write_utf8!("Original content for Path hard link test", original_path)?
+    
+    # Get original file stats
+    stat_before = Cmd.new("stat") |> Cmd.args(["-c", "%h", "test_path_original.txt"]) |> Cmd.output!()
+    links_before = Str.from_utf8(stat_before.stdout) ? |_| StatBeforeInvalidUtf8
+    
+    # Create hard link
+    link_path = Path.from_str("test_path_hardlink.txt")
+    when Path.hard_link!(original_path, link_path) is
+        Ok({}) ->
+            # Get link count after
+            stat_after = Cmd.new("stat") |> Cmd.args(["-c", "%h", "test_path_original.txt"]) |> Cmd.output!()
+            links_after = Str.from_utf8(stat_after.stdout) ? |_| StatAfterInvalidUtf8
+
+            # Verify both files exist and have same content
+            original_content = Path.read_utf8!(original_path)?
+            link_content = Path.read_utf8!(link_path)?
+            
+            Stdout.line!(
+                """
+                Hard link count before: ${Str.trim(links_before)}
+                Hard link count after: ${Str.trim(links_after)}
+                Original content: ${original_content}
+                Link content: ${link_content}
+                Content matches: ${Inspect.to_str(original_content == link_content)}
+                """
+            )?
+
+            # Check inodes are the same
+            ls_li_output =
+                Cmd.new("ls")
+                |> Cmd.args(["-li", "test_path_original.txt", "test_path_hardlink.txt"])
+                |> Cmd.output!()
+
+            ls_li_stdout_utf8 = Str.from_utf8(ls_li_output.stdout) ? |_| LsLiInvalidUtf8
+
+            inodes =
+                Str.split_on(ls_li_stdout_utf8, "\n")
+                |> List.map(|line| 
+                                Str.split_on(line, " ")
+                                |> List.take_first(1)
+                            )
+
+            first_inode = List.get(inodes, 0) ? |_| FirstInodeNotFound
+            second_inode = List.get(inodes, 1) ? |_| SecondInodeNotFound
+
+            Stdout.line!(
+                """
+                Inode information:
+                ${ls_li_stdout_utf8}
+                First file inode: ${Inspect.to_str(first_inode)}
+                Second file inode: ${Inspect.to_str(second_inode)}
+                Inodes are equal: ${Inspect.to_str(first_inode == second_inode)}
+                """
+            )
+        
+        Err(err) ->
+            Stderr.line!("✗ Hard link creation failed: ${Inspect.to_str(err)}")
+
+test_path_rename! : {} => Result {} _
+test_path_rename! = |{}|
+    Stdout.line!("\nTesting Path.rename!:")?
+    
+    # Create original file
+    original_path = Path.from_str("test_path_rename_original.txt")
+    new_path = Path.from_str("test_path_rename_new.txt")
+    test_file_content = "Content for rename test."
+
+    Path.write_utf8!(test_file_content, original_path) ? |err| WriteOriginalFailed(err)
+    
+    # Rename the file
+    when Path.rename!(original_path, new_path) is
+        Ok({}) ->
+            original_file_exists_after =                                                                      
+                  when Path.is_file!(original_path) is                                                     
+                      Ok(exists) -> exists                                                                 
+                      Err(_) -> Bool.false
+            
+            if original_file_exists_after then
+                Stderr.line!("✗ Original file still exists after rename")?
+            else
+                Stdout.line!("✓ Original file no longer exists")?
+            
+            new_file_exists = Path.is_file!(new_path) ? |err| NewIsFileFailed(err)
+
+            if new_file_exists then
+                Stdout.line!("✓ Renamed file exists")?
+                
+                content = Path.read_utf8!(new_path) ? |err| NewFileReadFailed(err)
+
+                if content == test_file_content then
+                    Stdout.line!("✓ Renamed file has correct content")
+                else
+                    Stderr.line!("✗ Renamed file has incorrect content")
+            else
+                Stderr.line!("✗ Renamed file does not exist")
+        
+        Err(err) ->
+            Stderr.line!("✗ File rename failed: ${Inspect.to_str(err)}")
+
+test_path_exists! : {} => Result {} _
+test_path_exists! = |{}|
+    Stdout.line!("\nTesting Path.exists!:")?
+    
+    # Test that a file that exists returns true
+    filename = Path.from_str("test_path_exists.txt")
+    Path.write_utf8!("This file exists", filename)?
+
+    file_exists = Path.exists!(filename) ? |err| PathExistsCheckFailed(err)
+
+    if file_exists then 
+        Stdout.line!("✓ Path.exists! returns true for a file that exists")?
+    else
+        Stderr.line!("✗ Path.exists! returned false for a file that exists")?
+
+    # Test that a file that does not exist returns false
+    Path.delete!(filename)?
+
+    file_exists_after_delete = Path.exists!(filename) ? |err| PathExistsCheckAfterDeleteFailed(err)
+
+    if file_exists_after_delete then
+        Stderr.line!("✗ Path.exists! returned true for a file that does not exist")?
+    else
+        Stdout.line!("✓ Path.exists! returns false for a file that does not exist")?
+
+    Ok({})
+
+cleanup_test_files! : [FilesNeedToExist, FilesMaybeExist] => Result {} _
+cleanup_test_files! = |files_requirement|
+    Stdout.line!("\nCleaning up test files...")?
+    
+    test_files = [
+        "test_path_bytes.txt",
+        "test_path_utf8.txt",
+        "test_path_json.json",
+        "test_path_original.txt",
+        "test_path_hardlink.txt",
+        "test_path_rename_new.txt"
+    ]
+
+    # Show files before cleanup
+    ls_before_cleanup = Cmd.new("ls") |> Cmd.args(["-la"] |> List.concat(test_files)) |> Cmd.output!()
+    
+    if ls_before_cleanup.status? == 0 then
+        cleanup_stdout = Str.from_utf8(ls_before_cleanup.stdout) ? |_| CleanupInvalidUtf8
+        
+        Stdout.line!(
+            """
+            Files to clean up:
+            ${cleanup_stdout}
+            """
+        )?
+
+        delete_result = List.for_each_try!(test_files, |filename| 
+            Path.delete!(Path.from_str(filename))
+        )
+
+        when files_requirement is
+            FilesNeedToExist ->
+                delete_result ? |err| FileDeletionFailed(err)
+            FilesMaybeExist ->
+                Ok({})?
+        
+        # Verify cleanup
+        ls_after_cleanup = Cmd.new("ls") |> Cmd.args(test_files) |> Cmd.output!()
+        
+        Stdout.line!(
+            """
+            Files remaining after cleanup: ${Inspect.to_str(ls_after_cleanup.status? == 0)}
+            """
+        )
+    else
+        Stderr.line!("✗ Error listing files before cleanup: `ls -la ...` exited with non-zero exit code:\n\t${Inspect.to_str(ls_before_cleanup)}")
+
+
+respond! : Request, Model => Result Response [ServerErr Str]_
+respond! = |_, _|
+
+    Ok(
+        {
+            status: 200,
+            headers: [],
+            body: Str.to_utf8("I am a test."),
+        },
+    )


### PR DESCRIPTION
Need to check out this segfault:
```
❯ valgrind ./tests/file 
==117522== Memcheck, a memory error detector
==117522== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==117522== Using Valgrind-3.23.0 and LibVEX; rerun with -h for copyright info
==117522== Command: ./tests/file
==117522== 
Testing some File functions...
This will create and manipulate test files in the current directory.

Testing File.write_bytes! and File.read_bytes!:
Bytes in test_bytes.txt: [72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33]

Testing File.write!:
Content of test_write.json: {"some":"json stuff"}

Testing File.is_file!:
✓ test_bytes.txt is confirmed to be a file

Testing File.is_sym_link!:
✓ test_bytes.txt is not a symbolic link
✓ test_symlink.txt is a symbolic link

Testing File.type!:
test_bytes.txt file type: IsFile
. file type: IsDir
test_symlink.txt file type: IsSymLink

Testing File.open_reader_with_capacity!:
✓ Successfully opened reader with 3 byte capacity

Reading lines from file:
Line 1: First line

==117522== Invalid free() / delete / delete[] / realloc()
==117522==    at 0x4848BD4: free (in /nix/store/qy8niksnmmfd1zim8kdw020l53agbagd-valgrind-3.23.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==117522==    by 0x129A35: ??? (in /home/username/gitrepos/basic-webserver/tests/file)
==117522==    by 0x162A5C: ??? (roc_app:0)
==117522==    by 0x14D1FF: Host_file_read_line!_e95211bde2283defe545e72d738137b8d7082e1cb419ffde6603c1dfde96f (roc_app:0)
==117522==    by 0x1502C6: File_read_line!_8ce35b34d71cf4b9b0a07273d98ed25775d2f26838242d0ab84e6f1473c5fd0 (roc_app:0)
==117522==    by 0x157B58: #UserApp_test_file_reader_with_capacity!_be657528b3a4f3258b3c81b233ad26c5cc2b144c2fec6bbc1d25b911c78a6df (roc_app:0)
==117522==    by 0x13097A: #UserApp_run_tests!_4177a31efa70e26af66d5ac761b47ad9d238bd7f72f2fabeaaa15a961943487 (roc_app:0)
==117522==    by 0x15E875: #UserApp_init!_30fe2aeefb9e6a6c9b187470d1a66a216dd31d2ce213c14343daed4ac570 (roc_app:0)
==117522==    by 0x143E05: _init_for_host!_4c338574d6e8ce6a38c44e9aa2440d050fc925f9a5e674c38f9b97d8b1bf50 (roc_app:0)
==117522==    by 0x14410D: roc__init_for_host_1_exposed (roc_app:0)
==117522==    by 0x19F948: rust_main (in /home/username/gitrepos/basic-webserver/tests/file)
==117522==    by 0x488614D: (below main) (in /nix/store/0wydilnf1c9vznywsvxqnaing4wraaxp-glibc-2.39-52/lib/libc.so.6)
==117522==  Address 0x72f8000 is in a rw- anonymous segment
==117522== 
Line 2: Second line

```