### PR TITLE
remove error tip

### DIFF
--- a/platform/main.roc
+++ b/platform/main.roc
@@ -45,8 +45,6 @@ init_for_host! = |_|
 
                     ❌ ${Inspect.to_str(err)}
 
-                Tip: If you do not want to exit on this error, use `Result.map_err` to handle the error.
-                Docs for `Result.map_err`: <https://www.roc-lang.org/builtins/Result#map_err>
                 """,
             )
             Err(1)
@@ -75,8 +73,6 @@ respond_for_host! = |request, boxed_model|
 
                     ❌ ${Inspect.to_str(err)}
 
-                Tip: If you do not want to see this error, use `Result.map_err` to handle the error.
-                Docs for `Result.map_err`: <https://www.roc-lang.org/builtins/Result#map_err>
                 """,
             )
 


### PR DESCRIPTION
Given how often this tip is shown, I would like to try removing it to prevent it from distracting from the error.