### PR TITLE
Refresh README and contributor guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,56 +1,174 @@
 # Contributing
 
-## Code of Conduct
+Thanks for helping improve `basic-webserver`. Questions and early design
+discussions are welcome in the [Roc Zulip chat](https://roc.zulipchat.com).
 
-We are committed to providing a friendly, safe and welcoming environment for all. Make sure to take a look at the Code of Conduct!
+## Before making a change
 
-## Tips
+Read [`design.md`](design.md) first. It is the authoritative description of the
+platform's intended architecture, ownership boundaries, supported scope, and
+non-goals. The implementation is still moving toward that design, so existing
+code is not evidence that a conflicting architecture is intentional.
 
-AGENTS.md is the place to find common commands and useful info. Handy for humans and AI agents.
+Keep application policy in Roc, durable mutable state in SQLite or an external
+service, and bounded transport or operating-system resources in typed host
+subsystems. If a request conflicts with the design, call out the conflict
+instead of adding a workaround or silently expanding the platform's scope.
 
-## Verification
+`design.md` records enduring what and why. Put implementation plans, migration
+status, and temporary constraints in code, focused documentation, issues, or
+pull requests.
 
-Use a recent Zig-based `roc` compiler on `PATH`, then run:
+Prefer simple solutions and a single source of truth where practical. Keep
+repository automation in `scripts/` and write it in portable Python; extend an
+existing entry point when the responsibility fits, and add a new script only
+for a distinct reusable workflow.
+
+## Prerequisites
+
+- A recent Zig-based `roc` compiler on `PATH`. Build it from a Roc source
+  checkout with `zig build roc`. The old Rust-based compiler is unsupported.
+- The Rust toolchain declared in [`rust-toolchain.toml`](rust-toolchain.toml).
+  Rustup selects it automatically.
+- Python 3. Repository automation uses only the Python standard library.
+- Native build tools for your operating system. Windows host builds require
+  MSVC and the Windows SDK.
+
+The CI action in [`.github/actions/setup-roc`](.github/actions/setup-roc/action.yml)
+records the exact Roc nightly used by the repository.
+
+## Build and run locally
+
+Build the native host library:
 
 ```sh
 python scripts/build.py
+```
+
+Then run an example:
+
+```sh
+roc examples/hello-web.roc
+```
+
+The server listens on <http://127.0.0.1:8000> by default. Build one explicit
+target with `python scripts/build.py --target TARGET`, or every target
+buildable from the current host with `python scripts/build.py --all`. Linux
+builds the two musl targets; macOS builds the macOS and musl targets. The
+`x64win` host inputs must be built on Windows.
+
+## Verify a change
+
+The normal local checks are:
+
+```sh
+cargo fmt --all -- --check
+cargo test --locked
 python scripts/test.py
 ```
 
-The test driver checks, tests, builds, and exercises every active `.roc`
-example and test, including a web-server smoke test. Files ending in
-`.todoroc` are migration backlog and cause the release check to fail.
+Run `python scripts/build.py` first whenever the Rust host has changed or the
+native host library is absent.
 
-Build a specific host target with `python scripts/build.py --target TARGET`. The five
-release targets are `x64mac`, `arm64mac`, `x64musl`, `arm64musl`, and
-`x64win`. Windows inputs must be built on Windows. Release CI assembles all
-five targets and verifies the resulting bundle on macOS, Linux, and Windows.
+`scripts/test.py` validates its own harness, formats and checks Roc sources,
+runs Roc tests, builds every active `examples/*.roc` application, and executes
+the cases in [`scripts/test_spec.json`](scripts/test_spec.json). Normal server
+cases use the real HTTP listener, including HTTP/2 coverage. The runner uses
+only Python's standard library and applies the same expectations on Linux,
+macOS, and Windows.
 
-## Release packages
+Files ending in `.todoroc` are intentionally skipped migration backlog.
+Active `.roc` examples must pass the suite on every supported operating system.
 
-After all target inputs exist under `platform/targets`, create the same package
-used by release CI with:
+For a focused application build after building the host:
+
+```sh
+roc build examples/hello-web.roc
+```
+
+CI also checks every Linux example under Valgrind Memcheck. On x86-64 Linux
+with Valgrind installed, run the same lane with:
+
+```sh
+python scripts/test.py --operation memcheck
+```
+
+## Add or change examples
+
+Keep examples realistic. Prefer adding a case to an existing useful example,
+or add a new example that demonstrates a real platform use case instead of a
+test-only Roc application.
+
+Every active `examples/*.roc` application must have exactly one entry in
+`scripts/test_spec.json`. Platform-specific skips are exceptional: each skip
+must include a concrete reason and a GitHub tracking issue URL. The validator
+rejects platform-specific expected results.
+
+## Generated Rust glue
+
+Changes to the `hosted` or `provides` blocks in `platform/main.roc` require
+regenerating `src/roc_platform_abi.rs`. The compiler and `RustGlue.roc` must
+come from the matching revision recorded in `scripts/regenerate_glue.py`.
+
+```sh
+ROC_SRC=/path/to/roc python scripts/regenerate_glue.py
+ROC_SRC=/path/to/roc python scripts/regenerate_glue.py --check
+```
+
+`ROC_GLUE_SPEC=/path/to/RustGlue.roc` can be used instead of `ROC_SRC`.
+
+## Generate API documentation
+
+Generate and serve the same platform API documentation published for `main`:
+
+```sh
+roc docs platform/main.roc --serve
+```
+
+Open the local URL printed by Roc. The default output directory without
+`--serve` is `generated-docs/`.
+
+## Benchmarking
+
+The repository includes a representative server and a load client that support
+HTTP/1.1 and HTTP/2:
+
+```sh
+roc build scripts/perf/app.roc --opt=speed --output=target/perf-server
+./target/perf-server
+```
+
+In another terminal:
+
+```sh
+cargo run --locked --release --features local-load-test --bin local-load -- --protocol http1 --duration 30
+```
+
+Use `--help` to see concurrency, connection, route-mix, and HTTP/2 options.
+Prefer separate machines for the server and load generator. Record server
+limits, protocol, concurrency, throughput, errors, and tail latency so results
+are explainable and reproducible.
+
+## Release validation
+
+Source validation without building runtime artifacts is available separately:
+
+```sh
+python scripts/test.py --operation validate
+```
+
+Release CI builds all target host inputs, creates one platform bundle, has each
+compiler host cross-build every target from that bundle, and runs every
+independently produced artifact set on its native target.
+
+After all declared target inputs have been assembled under `platform/targets`,
+create a release-format package with:
 
 ```sh
 python scripts/bundle.py --output-dir dist
 ```
 
-The bundler fails if any declared target input is missing or the unpacked
-platform exceeds Roc's 100 MiB transitive dependency limit. Linux host
-archives are stripped by the build script to stay below that limit. It also
-includes the committed musl/libunwind notices and generates complete Rust
-dependency license texts from the exact packages in `Cargo.lock`.
-
-Release follow-up pull requests commit versioned documentation under `www/`.
-The shared `roc-lang/release-package` actions snapshot, index, validate, and
-preserve those versions; Pages deployments add a freshly generated `/main`.
-
-## How to generate docs?
-
-You can generate the documentation locally and then start a web server to host your files.
-
-```bash
-roc docs examples/hello-web.roc --serve
-```
-
-Open the printed local URL in your browser.
+The bundler validates target completeness and Roc's transitive dependency size
+limit, then includes the required notices and exact Rust dependency licenses.
+The release workflow assembles Windows, macOS, and Linux inputs before invoking
+it.

--- a/README.md
+++ b/README.md
@@ -3,19 +3,135 @@
 [roc_badge]: https://img.shields.io/endpoint?url=https%3A%2F%2Fpastebin.com%2Fraw%2FcFzuCCd7
 [roc_link]: https://github.com/roc-lang/roc
 
-:book: docs: [0.13.1](https://roc-lang.github.io/basic-webserver/0.13.1/), [0.13.0](https://roc-lang.github.io/basic-webserver/0.13.0/), [main branch](https://roc-lang.github.io/basic-webserver/main/)
+Documentation: [0.14.0-rc1](https://roc-lang.github.io/basic-webserver/0.14.0-rc1/), [main](https://roc-lang.github.io/basic-webserver/main/)
 
-:eyes: examples: [0.13.1](https://github.com/roc-lang/basic-webserver/tree/0.13.1/examples), [0.13.0](https://github.com/roc-lang/basic-webserver/tree/0.13.0/examples), [main branch](https://github.com/roc-lang/basic-webserver/tree/main/examples)
+Examples: [0.14.0-rc1](https://github.com/roc-lang/basic-webserver/tree/0.14.0-rc1/examples), [main](https://github.com/roc-lang/basic-webserver/tree/main/examples)
 
-# Basic Web Server for [Roc](https://www.roc-lang.org/)
+# Basic Web Server for Roc
 
-A webserver [platform](https://www.roc-lang.org/platforms) with a simple interface.
+`basic-webserver` is a cross-platform [Roc platform](https://www.roc-lang.org/platforms)
+for conventional HTTP request/response applications. It is designed for JSON
+and HTML APIs, SQLite-backed applications, server-rendered forms, webhooks,
+bounded uploads, and small services deployed behind a reverse proxy.
 
-:racing_car: basic-webserver uses Rust's high-performance [hyper](https://hyper.rs) and [tokio](https://tokio.rs) libraries to execute your Roc function on incoming requests.
+The Rust host uses [Hyper](https://hyper.rs) and [Tokio](https://tokio.rs).
+Applications provide three functions:
+
+- `init!` validates startup configuration and returns `Server.Config` plus an
+  immutable application context;
+- `respond!` handles each request, potentially concurrently with other
+  handlers; and
+- `shutdown!` runs once after the server has stopped accepting and draining
+  work.
+
+Durable mutable state belongs in SQLite or an external service. The platform
+does not route requests through a global mutable application model.
+
+> `main` and the 0.14 release candidates target Roc's new Zig-based compiler.
+> The old Rust-based compiler is not supported.
+
+## Quick start
+
+Save the following as `hello.roc`, then run `roc hello.roc` and open
+<http://127.0.0.1:8000>.
+
+```roc
+app [Context, program] {
+	pf: platform "https://github.com/roc-lang/basic-webserver/releases/download/0.14.0-rc1/GfM5qZLcKYGA9XD4V7u1S4RjWrdfws29Uz2m86C7bmUC.tar.zst",
+	http: "https://github.com/roc-lang/http/releases/download/1.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
+}
+
+import pf.Server
+import http.Response
+
+Context : {}
+
+program = { init!, respond!, shutdown! }
+
+init! : () => Try({ config : Server.Config, context : Context }, [Exit(I64), ..])
+init! = || Ok({ config: Server.default_config, context: {} })
+
+respond! : Server.Request, Context => Try(Server.Outcome, [ServerErr(Str), ..])
+respond! = |_request, _context|
+	Ok(
+		Server.respond(
+			Response.from_status(200)
+				.with_headers([{ name: "Content-Type", value: "text/html; charset=utf-8" }])
+				.with_body(Str.to_utf8("<b>Hello from Roc!</b>")),
+		),
+	)
+
+shutdown! : Server.ShutdownReason, Context => Try({}, [Exit(I64), ..])
+shutdown! = |_reason, _context| Ok({})
+```
+
+`Server.default_config` listens only on `127.0.0.1:8000`. Use
+`Server.Config.with_listen` to choose another address. See
+[`examples/`](https://github.com/roc-lang/basic-webserver/tree/main/examples)
+for request bodies, forms, SQLite, outbound HTTP, commands, files, TCP, and
+error handling.
+
+## Runtime contract
+
+The defaults are finite so overload has deliberate behavior:
+
+| Resource | Default |
+| --- | ---: |
+| Active connections | 256 |
+| Concurrent Roc handlers | 32 |
+| Queued handlers | 64 |
+| Request body | 1 MiB |
+| Request body chunk | 64 KiB |
+| Buffered body chunks per request | 1 |
+| Graceful request drain | 30 seconds |
+| Shutdown hook | 10 seconds |
+
+When every handler and queue slot is occupied, new requests receive HTTP 503.
+Applications can change these limits with the `Server.Config` builders and can
+narrow an individual body limit with `request.body().with_limit(...)`.
+
+The listener accepts HTTP/1.1 and cleartext prior-knowledge HTTP/2. It does not
+terminate TLS or perform public protocol negotiation; production deployments
+normally put a reverse proxy or load balancer in front. Ordinary responses are
+complete in-memory values, while request bodies can be consumed as bounded
+streams.
+
+Every handler receives an owned reference to the immutable context produced by
+`init!`. `StopAfter` outcomes and OS termination signals begin graceful
+shutdown. The host stops accepting work, drains active handlers within the
+configured deadline, and then invokes `shutdown!`. A drain or hook timeout
+forces exit because it is unsafe to destroy context still used by Roc code.
+
+An error returned by `respond!` is inspected and logged with request context,
+then converted to a generic HTTP 500 response. Errors from `init!` and
+`shutdown!` are logged before the process exits. A Roc `crash` exits the whole
+server process.
+
+## Platform facilities
+
+The platform exposes typed modules for:
+
+- bounded inbound request bodies and server lifecycle;
+- pooled outbound HTTP and HTTPS requests;
+- pooled SQLite connections, transactions, and prepared statements;
+- finite command execution with time and output limits;
+- filesystem, environment, path, stdout/stderr, TCP, time, and sleep effects;
+- HTML construction, URL handling, and multipart form parsing.
+
+Outbound HTTP calls default to a 30-second total deadline and an 8 MiB response
+body. At most 64 calls run and 256 wait for admission. The shared client pools
+connections, performs no hidden retries, and uses WebPKI roots for HTTPS.
+
+Commands execute an exact program and argument list without shell expansion.
+They default to a 30-second deadline and 1 MiB each of captured stdout and
+stderr. At most eight commands run and 32 wait for admission.
+
+The generated [API documentation](https://roc-lang.github.io/basic-webserver/main/)
+contains the complete types, builders, limits, and error tags.
 
 ## Supported targets
 
-The platform builds and runs on these targets in CI:
+The platform builds and runs these targets in CI:
 
 | Roc target | Operating system | Architecture |
 | --- | --- | --- |
@@ -25,160 +141,11 @@ The platform builds and runs on these targets in CI:
 | `arm64musl` | Linux (musl) | ARM64 |
 | `x64win` | Windows | x86-64 |
 
-Other targets are not currently supported. In particular, Windows support is
-x86-64 only.
-
-## Host runtime behavior
-
-These current host-level constraints matter when designing a production
-server:
-
-- The server accepts HTTP/1 connections only. It does not terminate TLS; put a
-  reverse proxy or load balancer in front when HTTPS is required.
-- Request bodies are bounded streams. The defaults allow at most 1 MiB per
-  request, deliver chunks no larger than 64 KiB, and buffer one chunk between
-  Hyper and Roc. Applications can narrow a request's limit with
-  `request.body().with_limit(...)`. Responses are currently complete in-memory
-  bodies; response streaming is not yet available.
-- Request handlers run concurrently on Tokio's blocking thread pool. Every
-  handler receives an owned reference to the same immutable application
-  context. Durable mutable state belongs in SQLite or an external service, so
-  requests do not pass through a global application-state coordinator.
-- `init!` returns the server configuration and immutable context. On SIGINT,
-  SIGTERM, or an application `StopAfter` outcome, the host stops accepting new
-  connections, drains active work up to the configured timeout, cancels
-  outstanding body streams when that timeout expires, and calls `shutdown!`
-  once with the context after a successful drain. If the drain deadline or
-  shutdown-hook deadline expires, the host forces exit with status 1; a drain
-  timeout cannot safely run `shutdown!` while a Roc handler may still be using
-  the context. A second OS termination signal also forces exit.
-- Outbound requests require validated `Url` values in the convenience APIs and
-  report typed DNS, connection, TLS, exchange, response-body, cancellation,
-  timeout, saturation, response-limit, and invalid-response failures. Calls
-  default to a 30-second total deadline and an 8 MiB response body; `Http.Config`
-  can narrow or replace those values. At most 64 calls run and 256 wait for
-  admission. The shared client preserves connection pooling and HTTP keep-alive
-  but performs no hidden request retries. HTTPS uses WebPKI roots; custom trust
-  stores are not currently configurable.
-- Commands run an exact executable with an argument list; no shell parsing or
-  expansion occurs. They inherit the working directory and environment unless
-  the command clears its environment. Calls default to a 30-second total
-  deadline, with 1 MiB each for captured stdout and stderr. At most eight child
-  processes run and 32 wait for admission. Timeout and output-limit cleanup
-  terminates the process tree (Unix process groups and Windows Job Objects),
-  waits for the direct child, and returns a typed error.
-- A Roc `crash` exits the entire server process. Any error returned from
-  `respond!` is inspected and logged with request context, then converted to a
-  generic HTTP 500 response. Prefer semantic application tags that retain the
-  underlying error; use `ServerErr(Str)` when a custom message is more useful.
-- `init!` and `shutdown!` errors are inspected and logged before the process
-  exits with status 1. Use semantic tags for ordinary failures and reserve
-  `Exit(code)` for deliberately choosing a process exit status.
-
-## Example
-
-Run this example server with `roc examples/hello-web.roc` and go to
-`http://localhost:8000` in your browser. Set `Server.Config.listen` in `init!`
-to choose another interface or port.
-
-```roc
-app [Context, program] {
-    pf: platform "https://github.com/roc-lang/basic-webserver/releases/download/<version>/<hash>.tar.zst",
-    http: "https://github.com/roc-lang/http/releases/download/1.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
-}
-
-import pf.Server
-import pf.Utc
-import pf.Stdout
-import http.Response
-
-Context : { greeting : Str }
-
-program = { init!, respond!, shutdown! }
-
-init! : () => Try({ config : Server.Config, context : Context }, [Exit(I64), ..])
-init! = || Ok({ config: Server.default_config, context: { greeting: "Hello from server" } })
-
-respond! : Server.Request, Context => Try(Server.Outcome, [ServerErr(Str), ..])
-respond! = |req, context| {
-    millis = Utc.to_millis_since_epoch(Utc.now!())
-
-    Stdout.line!("${millis.to_str()} ${Str.inspect(req.method())} ${req.target()}")
-        ? |err| ServerErr("Failed to log request: ${Str.inspect(err)}")
-
-    response =
-        Response.from_status(200)
-        .with_headers([{ name: "Content-Type", value: "text/html; charset=utf-8" }])
-        .with_body(Str.to_utf8("<b>${context.greeting}</b>"))
-
-    Ok(Server.respond(response))
-}
-
-shutdown! : Server.ShutdownReason, Context => Try({}, [Exit(I64), ..])
-shutdown! = |_, _context| Ok({})
-```
-
+Other targets are not currently supported.
 
 ## Contributing
 
-If you'd like to contribute, check out our [group chat](https://roc.zulipchat.com) and let us know what you're thinking, we're friendly!
-
-## Running Locally
-
-If you have cloned this repository and want to run the examples without using a packaged release, build the platform first:
-
-```sh
-python scripts/build.py
-```
-
-Then run examples with `roc examples/hello-web.roc`.
-
-Use `python scripts/build.py --target <target>` to build a specific host library, or
-`python scripts/build.py --all` to build every target supported by the current host OS
-(the Linux targets on Linux; the macOS and Linux targets on macOS). Windows host inputs
-must be built on Windows. Release packages use `.tar.zst` assets.
-
-Run the complete local verification suite with:
-
-```sh
-python scripts/test.py
-```
-
-The suite uses Python's standard library to format, check, test, and build each
-active example, then drives its real HTTP listener using the cases in
-`scripts/test_spec.json`. The same cases and expected results run on Linux,
-macOS, and Windows; it does not require Expect or curl.
-
-Release validation bundles the current platform once, including the host inputs
-for every supported Roc target. Five compiler-host jobs consume that exact
-bundle and each cross-build all active examples for every target. Five fresh
-native runner jobs download and execute every independently produced binary set
-for their target. Artifact manifests bind each set to its compiler host, target,
-example sources, and test specification, ensuring the runtime suite exercises
-all uploaded cross-build outputs rather than silently rebuilding them.
-
-To build a release-format package after assembling all target inputs, run
-`python scripts/bundle.py --output-dir dist`. Windows inputs must be built on a
-Windows host; the release workflow combines them with the macOS and Linux
-inputs automatically.
-
-## Benchmarking
-
-Basic webserver should have decent performance due to being built on top of Rust's [hyper](https://hyper.rs).
-That said, it has a few known issues that hurt performance:
-1. We do [extra data copying on every request](https://github.com/roc-lang/basic-webserver/issues/23).
-2. Until roc has effect interpreters, basic-webserver can only do blocking io for effects. To work around this, every request is spawned in a blocking thread.
-
-That said, running benchmarks and debugging performance is still a great idea. It can help improve both Roc and basic-webserver.
-
-Lots of load generators exist. Generally, it is advised to use one that avoids [coordinated omission](https://www.youtube.com/watch?v=lJ8ydIuPFeU).
-A trusted generator that fits this criteria is [wrk2](https://github.com/giltene/wrk2) (sadly doesn't work on Apple Silicon).
-
-If you are benchmarking on a single machine, you can use the `TOKIO_WORKER_THREADS` environment variable to limit parallelism of the webserver.
-
-> Note: When benchmarking, it is best to run the load generator and the webserver on different machines.
-
-When benchmarking on a single 8 core machine with `wrk2`, these commands could be used (simply tune connections `-c` and rate `-R`):
-1. Optimized build: `roc build --opt=speed my-webserver.roc`
-2. Launch server with 4 cores: `TOKIO_WORKER_THREADS=4 ./my-webserver`
-3. Generate load with 4 cores: `wrk -t4 -c100 -d30s -R2000 http://127.0.0.1:8000`
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, verification, testing,
+documentation, benchmarking, generated glue, and release workflows. Questions
+and early design discussions are welcome in the [Roc Zulip
+chat](https://roc.zulipchat.com).


### PR DESCRIPTION
## Summary

- update the README for the 0.14 release candidate and Zig-based compiler
- document the current lifecycle, HTTP/2 support, bounded runtime defaults, and platform facilities
- expand contributor guidance for design boundaries, local verification, specs, generated glue, docs, benchmarks, and releases
- replace stale release, API, and benchmarking instructions with verified commands

## Validation

- python3 scripts/test.py --operation validate
- roc fmt --check target/spec/readme/readme.roc
- roc docs platform/main.roc --output=target/docs-check
- cargo run --locked --release --features local-load-test --bin local-load -- --help