### PR TITLE
Make request-body chunks seamless and remove global body state

### DIFF
--- a/examples/echo.roc
+++ b/examples/echo.roc
@@ -22,8 +22,16 @@ respond! = |req, _context| {
 
 	Stdout.line!("${time} ${Str.inspect(req.method())} ${req.target()}")
 		? |err| ServerErr("Failed to log request: ${Str.inspect(err)}")
-	body = req.body().with_limit(64 * 1024).read_all!()
-		? |err| ServerErr("Failed to read request body: ${Str.inspect(err)}")
+	body = if req.target() == "/first-chunk" {
+		match req.body().with_limit(64 * 1024).read!() {
+			Ok(Chunk(chunk)) => chunk
+			Ok(End) => []
+			Err(err) => return Err(ServerErr("Failed to read request body: ${Str.inspect(err)}"))
+		}
+	} else {
+		req.body().with_limit(64 * 1024).read_all!()
+			? |err| ServerErr("Failed to read request body: ${Str.inspect(err)}")
+	}
 	Ok(Server.respond(Response.from_status(200).with_body(body)))
 }
 

--- a/examples/ndjson-ingest.roc
+++ b/examples/ndjson-ingest.roc
@@ -1,0 +1,443 @@
+## Streams newline-delimited JSON events into SQLite in short, retry-safe
+## batches without materializing the complete HTTP request body.
+app [Context, program] {
+	pf: platform "https://github.com/roc-lang/basic-webserver/releases/download/0.14.0-rc1/GfM5qZLcKYGA9XD4V7u1S4RjWrdfws29Uz2m86C7bmUC.tar.zst",
+	http: "https://github.com/roc-lang/http/releases/download/1.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
+}
+
+import pf.Env
+import pf.Path
+import pf.Server
+import pf.Sqlite
+import http.Header
+import http.Response
+
+## Set `DB_PATH` to choose the SQLite database. Events have client-provided
+## stable IDs, so retrying a partially committed request does not duplicate
+## records.
+
+Context : Sqlite.Db
+
+Event : {
+	id : Str,
+	source : Str,
+	value : I64,
+}
+
+DecodedEvent : {
+	encoded_bytes : U64,
+	event : Event,
+}
+
+Decoder : {
+	line : List(U8),
+	line_number : U64,
+	max_line_bytes : U64,
+}
+
+IngestState : {
+	batch : List(DecodedEvent),
+	batch_bytes : U64,
+	committed : U64,
+	decoder : Decoder,
+}
+
+DecodeError : [
+	BlankLine(U64),
+	InvalidEvent(U64),
+	InvalidJsonLine(U64),
+	InvalidUtf8(U64),
+	LineTooLarge({ limit_bytes : U64, line_number : U64 }),
+	MissingFinalNewline(U64),
+]
+
+IngestError : [
+	DatabaseFailed({ committed : U64, detail : Str }),
+	DecodeFailed({ committed : U64, err : DecodeError }),
+]
+
+program = { init!, respond!, shutdown! }
+
+max_body_bytes : U64
+max_body_bytes = 32 * 1024 * 1024
+
+max_line_bytes : U64
+max_line_bytes = 64 * 1024
+
+max_batch_bytes : U64
+max_batch_bytes = 256 * 1024
+
+max_batch_records : U64
+max_batch_records = 100
+
+init! : () => Try({ config : Server.Config, context : Context }, [Exit(I64), ..])
+init! = || {
+	db_path = 
+		match Env.var!("DB_PATH") {
+			Ok(path) => Path.from_os_str(path)
+			Err(_) => Path.utf8("./examples/events.db")
+		}
+	db = Sqlite.open!(Sqlite.default_config(db_path)) ? |_| Exit(2)
+	ensure_schema!(db) ? |_| Exit(3)
+
+	config = 
+		Server.with_request_body_limits(
+			Server.default_config,
+			{
+				max_bytes: max_body_bytes,
+				chunk_bytes: Server.default_body_chunk_bytes,
+				buffered_chunks: Server.default_buffered_body_chunks,
+			},
+		)
+	Ok({ config, context: db })
+}
+
+respond! : Server.Request, Context => Try(Server.Outcome, [ServerErr(Str), ..])
+respond! = |request, db| {
+	response = 
+		match (request.method(), request.target()) {
+			(POST, "/events") => ingest_events!(db, request)
+			(GET, "/events/count") => event_count!(db)
+			_ => text_response(404, "Not found.")
+		}
+
+	Ok(Server.respond(response))
+}
+
+shutdown! : Server.ShutdownReason, Context => Try({}, [Exit(I64), ..])
+shutdown! = |_reason, _db| Ok({})
+
+ingest_events! : Sqlite.Db, Server.Request => Response
+ingest_events! = |db, request| {
+	if Bool.not(has_ndjson_content_type(request.headers())) {
+		return text_response(415, "Content-Type must be application/x-ndjson.")
+	}
+
+	initial : IngestState
+	initial = {
+		batch: [],
+		batch_bytes: 0,
+		committed: 0,
+		decoder: {
+			line: [],
+			line_number: 1,
+			max_line_bytes,
+		},
+	}
+
+	folded = 
+		request
+			.body()
+			.with_limit(max_body_bytes)
+			.fold_chunks!(initial, |state, chunk| ingest_chunk!(db, state, chunk))
+
+	state = 
+		match folded {
+			Ok(value) => value
+			Err(ChunkReadErr({ err, state: partial })) =>
+				return ingest_error_response(
+					400,
+					partial.committed,
+					"Request body failed: ${Str.inspect(err)}",
+				)
+			Err(ChunkStepErr(err)) =>
+				return ingest_error_response(status_for_ingest_error(err), committed_from_error(err), ingest_error_to_str(err))
+			}
+
+	match finish_decoder(state.decoder) {
+		Err(err) => ingest_error_response(400, state.committed, decode_error_to_str(err))
+		Ok({}) =>
+			match flush_batch!(db, state) {
+				Ok(final) => committed_response(200, final.committed)
+				Err(err) => ingest_error_response(503, state.committed, ingest_error_to_str(err))
+			}
+		}
+}
+
+ingest_chunk! : Sqlite.Db, IngestState, List(U8) => Try(IngestState, IngestError)
+ingest_chunk! = |db, state, chunk| {
+	decoded = decode_chunk(state.decoder, chunk)
+		? |err| DecodeFailed({ committed: state.committed, err })
+	with_decoder = { ..state, decoder: decoded.decoder }
+	add_events!(db, with_decoder, decoded.events)
+}
+
+add_events! : Sqlite.Db, IngestState, List(DecodedEvent) => Try(IngestState, IngestError)
+add_events! = |db, state, events|
+	match events {
+		[] => Ok(state)
+		[first, .. as rest] => {
+			ready = 
+				if state.batch.is_empty() {
+					state
+				} else if state.batch.len() >= max_batch_records or state.batch_bytes + first.encoded_bytes > max_batch_bytes {
+					flush_batch!(db, state)?
+				} else {
+					state
+				}
+			next = {
+				..ready,
+				batch: ready.batch.append(first),
+				batch_bytes: ready.batch_bytes + first.encoded_bytes,
+			}
+			flushed = 
+				if next.batch.len() >= max_batch_records or next.batch_bytes >= max_batch_bytes {
+					flush_batch!(db, next)?
+				} else {
+					next
+				}
+			add_events!(db, flushed, rest)
+		}
+	}
+
+flush_batch! : Sqlite.Db, IngestState => Try(IngestState, IngestError)
+flush_batch! = |db, state| {
+	if state.batch.is_empty() {
+		return Ok(state)
+	}
+
+	transaction = 
+		Sqlite.begin!(db, Immediate)
+			? |err| DatabaseFailed({ committed: state.committed, detail: Str.inspect(err) })
+	insert_batch!(transaction, state.batch)
+		? |err| DatabaseFailed({ committed: state.committed, detail: Str.inspect(err) })
+	transaction.commit!()
+		? |err| DatabaseFailed({ committed: state.committed, detail: Str.inspect(err) })
+
+	Ok({
+		..state,
+		batch: [],
+		batch_bytes: 0,
+		committed: state.committed + state.batch.len(),
+	})
+}
+
+insert_batch! : Sqlite.Transaction, List(DecodedEvent) => Try({}, Sqlite.QueryError)
+insert_batch! = |transaction, events|
+	match events {
+		[] => Ok({})
+		[{ event, encoded_bytes: _ }, .. as rest] => {
+			transaction.execute!({
+				query: \\INSERT INTO events (id, source, value)
+					\\VALUES (:id, :source, :value)
+					\\ON CONFLICT(id) DO NOTHING;
+				,
+				params: {
+					id: event.id,
+					source: event.source,
+					value: event.value,
+				},
+			})?
+			insert_batch!(transaction, rest)
+		}
+	}
+
+decode_chunk : Decoder, List(U8) -> Try({ decoder : Decoder, events : List(DecodedEvent) }, DecodeError)
+decode_chunk = |decoder, bytes| decode_bytes(decoder, bytes, [])
+
+decode_bytes : Decoder, List(U8), List(DecodedEvent) -> Try({ decoder : Decoder, events : List(DecodedEvent) }, DecodeError)
+decode_bytes = |decoder, bytes, events|
+	match bytes {
+		[] => Ok({ decoder, events })
+		[byte, .. as rest] =>
+			if byte == '\n' {
+				decoded = decode_line(decoder)?
+				decode_bytes(
+					{
+						..decoder,
+						line: [],
+						line_number: decoder.line_number + 1,
+					},
+					rest,
+					events.append(decoded),
+				)
+			} else if decoder.line.len() >= decoder.max_line_bytes {
+				Err(
+					LineTooLarge({
+						limit_bytes: decoder.max_line_bytes,
+						line_number: decoder.line_number,
+					}),
+				)
+			} else {
+				decode_bytes(
+					{ ..decoder, line: decoder.line.append(byte) },
+					rest,
+					events,
+				)
+			}
+		}
+
+decode_line : Decoder -> Try(DecodedEvent, DecodeError)
+decode_line = |decoder| {
+	line = 
+		match List.last(decoder.line) {
+			Ok('\r') => decoder.line.drop_last(1)
+			_ => decoder.line
+		}
+	if line.is_empty() {
+		return Err(BlankLine(decoder.line_number))
+	}
+
+	json = 
+		match Str.from_utf8(line) {
+			Ok(value) => value
+			Err(_) => return Err(InvalidUtf8(decoder.line_number))
+		}
+
+	parsed : Try(Event, [InvalidJson(Str), MissingRequiredField(Str)])
+	parsed = Json.parse(json)
+	event = 
+		match parsed {
+			Ok(value) => value
+			Err(_) => return Err(InvalidJsonLine(decoder.line_number))
+		}
+	if Str.is_empty(event.id) or Str.is_empty(event.source) {
+		Err(InvalidEvent(decoder.line_number))
+	} else {
+		Ok({
+			encoded_bytes: decoder.line.len() + 1,
+			event,
+		})
+	}
+}
+
+finish_decoder : Decoder -> Try({}, DecodeError)
+finish_decoder = |decoder|
+	if decoder.line.is_empty() {
+		Ok({})
+	} else {
+		Err(MissingFinalNewline(decoder.line_number))
+	}
+
+ensure_schema! : Sqlite.Db => Try({}, Sqlite.QueryError)
+ensure_schema! = |db|
+	Sqlite.execute!({
+		db,
+		query: \\CREATE TABLE IF NOT EXISTS events (
+			\\    id TEXT PRIMARY KEY,
+			\\    source TEXT NOT NULL,
+			\\    value INTEGER NOT NULL
+			\\);
+		,
+		params: {},
+	})
+
+event_count! : Sqlite.Db => Response
+event_count! = |db| {
+	result : Try({ count : I64 }, Sqlite.QueryError)
+	result = Sqlite.query!({
+		db,
+		query: "SELECT COUNT(*) AS count FROM events;",
+		params: {},
+		limits: Sqlite.default_query_limits,
+	})
+	match result {
+		Ok(row) =>
+			Response.from_status(200)
+				.with_headers([{ name: "Content-Type", value: "application/json; charset=utf-8" }])
+				.with_body(Str.to_utf8("{\"count\":${I64.to_str(row.count)}}"))
+		Err(err) => text_response(503, "Failed to query events: ${Str.inspect(err)}")
+	}
+}
+
+has_ndjson_content_type : List(Header.Header) -> Bool
+has_ndjson_content_type = |headers|
+	match headers {
+		[] => Bool.False
+		[{ name, value }, .. as rest] =>
+			if (name == "Content-Type" or name == "content-type") and value == "application/x-ndjson" {
+				Bool.True
+			} else {
+				has_ndjson_content_type(rest)
+			}
+		}
+
+status_for_ingest_error : IngestError -> U16
+status_for_ingest_error = |err|
+	match err {
+		DatabaseFailed(_) => 503
+		DecodeFailed(_) => 400
+	}
+
+committed_from_error : IngestError -> U64
+committed_from_error = |err|
+	match err {
+		DatabaseFailed({ committed, detail: _ }) => committed
+		DecodeFailed({ committed, err: _ }) => committed
+	}
+
+ingest_error_to_str : IngestError -> Str
+ingest_error_to_str = |ingest_err|
+	match ingest_err {
+		DatabaseFailed({ committed: _, detail }) => "Database batch failed: ${detail}"
+		DecodeFailed({ committed: _, err: decode_err }) => decode_error_to_str(decode_err)
+	}
+
+decode_error_to_str : DecodeError -> Str
+decode_error_to_str = |err|
+	match err {
+		BlankLine(line) => "Line ${U64.to_str(line)} is empty."
+		InvalidEvent(line) => "Line ${U64.to_str(line)} must have non-empty id and source fields."
+		InvalidJsonLine(line) => "Line ${U64.to_str(line)} is not a valid event JSON object."
+		InvalidUtf8(line) => "Line ${U64.to_str(line)} is not valid UTF-8."
+		LineTooLarge({ line_number, limit_bytes }) => "Line ${U64.to_str(line_number)} exceeds ${U64.to_str(limit_bytes)} bytes."
+		MissingFinalNewline(line) => "Line ${U64.to_str(line)} is missing its final newline."
+	}
+
+ingest_error_response : U16, U64, Str -> Response
+ingest_error_response = |status, committed, message|
+	Response.from_status(status)
+		.with_headers([{ name: "Content-Type", value: "application/json; charset=utf-8" }])
+		.with_body(Str.to_utf8(Json.to_str({ committed, error: message })))
+
+committed_response : U16, U64 -> Response
+committed_response = |status, committed|
+	Response.from_status(status)
+		.with_headers([{ name: "Content-Type", value: "application/json; charset=utf-8" }])
+		.with_body(Str.to_utf8("{\"committed\":${U64.to_str(committed)}}"))
+
+text_response : U16, Str -> Response
+text_response = |status, body|
+	Response.from_status(status)
+		.with_headers([{ name: "Content-Type", value: "text/plain; charset=utf-8" }])
+		.with_body(Str.to_utf8(body))
+
+expect {
+	first = Str.to_utf8("{\"id\":\"evt-1\",\"source\":\"caf").append(195)
+	second = [169].concat(Str.to_utf8("\",\"value\":1}\r\n{\"id\":\"evt-2\",\"source\":\"sensor\",\"value\":2}\n"))
+	initial = { line: [], line_number: 1, max_line_bytes: 1024 }
+
+	match decode_chunk(initial, first) {
+		Err(_) => Bool.False
+		Ok(partial) =>
+			match decode_chunk(partial.decoder, second) {
+				Err(_) => Bool.False
+				Ok(done) =>
+					done.events.map(|item| item.event.id) == ["evt-1", "evt-2"]
+						and done.decoder.line.is_empty()
+							and done.decoder.line_number == 3
+				}
+		}
+}
+
+expect {
+	line = Str.to_utf8("{\"id\":\"evt-1\",\"source\":\"sensor\",\"value\":1}")
+	exact = { line: [], line_number: 7, max_line_bytes: line.len() }
+	too_small = { line: [], line_number: 7, max_line_bytes: line.len() - 1 }
+
+	match decode_chunk(exact, line.append('\n')) {
+		Err(_) => Bool.False
+		Ok(result) =>
+			result.events.len() == 1
+				and decode_chunk(too_small, line) == Err(LineTooLarge({ limit_bytes: line.len() - 1, line_number: 7 }))
+		}
+}
+
+expect {
+	decoder = {
+		line: Str.to_utf8("{\"id\":\"evt-1\",\"source\":\"sensor\",\"value\":1}"),
+		line_number: 4,
+		max_line_bytes: 1024,
+	}
+	finish_decoder(decoder) == Err(MissingFinalNewline(4))
+}

--- a/examples/ndjson-ingest.roc
+++ b/examples/ndjson-ingest.roc
@@ -29,17 +29,80 @@ DecodedEvent : {
 	event : Event,
 }
 
-Decoder : {
+DecoderData : {
 	line : List(U8),
 	line_number : U64,
 	max_line_bytes : U64,
 }
 
-IngestState : {
+## Incremental NDJSON framing state. Each push returns the decoder to use for
+## the next transport chunk; finish rejects an unterminated final record.
+Decoder := [DecoderState(DecoderData)].{
+	init : U64 -> Decoder
+	init = |line_limit|
+		DecoderState({
+			line: [],
+			line_number: 1,
+			max_line_bytes: line_limit,
+		})
+
+	push : Decoder, List(U8) -> Try({ decoder : Decoder, events : List(DecodedEvent) }, DecodeError)
+	push = |DecoderState(data), bytes|
+		decode_bytes(data, bytes, [])
+			.map_ok(
+				|result| {
+					decoder: DecoderState(result.decoder),
+					events: result.events,
+				},
+			)
+
+	finish : Decoder -> Try({}, DecodeError)
+	finish = |DecoderState(data)|
+		if data.line.is_empty() {
+			Ok({})
+		} else {
+			Err(MissingFinalNewline(data.line_number))
+		}
+}
+
+IngestData : {
 	batch : List(DecodedEvent),
 	batch_bytes : U64,
 	committed : U64,
 	decoder : Decoder,
+}
+
+## Request-local ingestion state. push! may commit complete bounded batches;
+## finish! validates EOF and commits the final partial batch.
+Ingest := [IngestState(IngestData)].{
+	start : U64 -> Ingest
+	start = |line_limit|
+		IngestState({
+			batch: [],
+			batch_bytes: 0,
+			committed: 0,
+			decoder: Decoder.init(line_limit),
+		})
+
+	committed : Ingest -> U64
+	committed = |IngestState(data)| data.committed
+
+	push! : Ingest, Sqlite.Db, List(U8) => Try(Ingest, IngestError)
+	push! = |IngestState(data), db, chunk| {
+		decoded = data.decoder.push(chunk)
+			? |err| DecodeFailed({ committed: data.committed, err })
+		with_decoder = { ..data, decoder: decoded.decoder }
+		ingest_add_events!(with_decoder, db, decoded.events)
+			.map_ok(|next| IngestState(next))
+	}
+
+	finish! : Ingest, Sqlite.Db => Try(U64, IngestError)
+	finish! = |IngestState(data), db| {
+		data.decoder.finish()
+			? |err| DecodeFailed({ committed: data.committed, err })
+		final = ingest_flush!(data, db)?
+		Ok(final.committed)
+	}
 }
 
 DecodeError : [
@@ -56,6 +119,38 @@ IngestError : [
 	DecodeFailed({ committed : U64, err : DecodeError }),
 ]
 
+decode_error_to_str : DecodeError -> Str
+decode_error_to_str = |err|
+	match err {
+		BlankLine(line) => "Line ${U64.to_str(line)} is empty."
+		InvalidEvent(line) => "Line ${U64.to_str(line)} must have non-empty id and source fields."
+		InvalidJsonLine(line) => "Line ${U64.to_str(line)} is not a valid event JSON object."
+		InvalidUtf8(line) => "Line ${U64.to_str(line)} is not valid UTF-8."
+		LineTooLarge({ line_number, limit_bytes }) => "Line ${U64.to_str(line_number)} exceeds ${U64.to_str(limit_bytes)} bytes."
+		MissingFinalNewline(line) => "Line ${U64.to_str(line)} is missing its final newline."
+	}
+
+ingest_error_status : IngestError -> U16
+ingest_error_status = |err|
+	match err {
+		DatabaseFailed(_) => 503
+		DecodeFailed(_) => 400
+	}
+
+ingest_error_committed : IngestError -> U64
+ingest_error_committed = |err|
+	match err {
+		DatabaseFailed({ committed, detail: _ }) => committed
+		DecodeFailed({ committed, err: _ }) => committed
+	}
+
+ingest_error_to_str : IngestError -> Str
+ingest_error_to_str = |ingest_err|
+	match ingest_err {
+		DatabaseFailed({ committed: _, detail }) => "Database batch failed: ${detail}"
+		DecodeFailed({ committed: _, err }) => decode_error_to_str(err)
+	}
+
 program = { init!, respond!, shutdown! }
 
 max_body_bytes : U64
@@ -69,6 +164,122 @@ max_batch_bytes = 256 * 1024
 
 max_batch_records : U64
 max_batch_records = 100
+
+decode_bytes : DecoderData, List(U8), List(DecodedEvent) -> Try({ decoder : DecoderData, events : List(DecodedEvent) }, DecodeError)
+decode_bytes = |decoder, bytes, events|
+	match bytes {
+		[] => Ok({ decoder, events })
+		[byte, .. as rest] =>
+			if byte == '\n' {
+				decoded = decode_line(decoder)?
+				decode_bytes(
+					{
+						..decoder,
+						line: [],
+						line_number: decoder.line_number + 1,
+					},
+					rest,
+					events.append(decoded),
+				)
+			} else if decoder.line.len() >= decoder.max_line_bytes {
+				Err(
+					LineTooLarge({
+						limit_bytes: decoder.max_line_bytes,
+						line_number: decoder.line_number,
+					}),
+				)
+			} else {
+				decode_bytes(
+					{ ..decoder, line: decoder.line.append(byte) },
+					rest,
+					events,
+				)
+			}
+		}
+
+decode_line : DecoderData -> Try(DecodedEvent, DecodeError)
+decode_line = |decoder| {
+	line = 
+		match List.last(decoder.line) {
+			Ok('\r') => decoder.line.drop_last(1)
+			_ => decoder.line
+		}
+	if line.is_empty() {
+		return Err(BlankLine(decoder.line_number))
+	}
+
+	json = 
+		match Str.from_utf8(line) {
+			Ok(value) => value
+			Err(_) => return Err(InvalidUtf8(decoder.line_number))
+		}
+
+	parsed : Try(Event, [InvalidJson(Str), MissingRequiredField(Str)])
+	parsed = Json.parse(json)
+	event = 
+		match parsed {
+			Ok(value) => value
+			Err(_) => return Err(InvalidJsonLine(decoder.line_number))
+		}
+	if Str.is_empty(event.id) or Str.is_empty(event.source) {
+		Err(InvalidEvent(decoder.line_number))
+	} else {
+		Ok({
+			encoded_bytes: decoder.line.len() + 1,
+			event,
+		})
+	}
+}
+
+ingest_add_events! : IngestData, Sqlite.Db, List(DecodedEvent) => Try(IngestData, IngestError)
+ingest_add_events! = |ingest, db, events|
+	match events {
+		[] => Ok(ingest)
+		[first, .. as rest] => {
+			ready = 
+				if ingest.batch.is_empty() {
+					ingest
+				} else if ingest.batch.len() >= max_batch_records or ingest.batch_bytes + first.encoded_bytes > max_batch_bytes {
+					ingest_flush!(ingest, db)?
+				} else {
+					ingest
+				}
+			next = {
+				..ready,
+				batch: ready.batch.append(first),
+				batch_bytes: ready.batch_bytes + first.encoded_bytes,
+			}
+			flushed = 
+				if next.batch.len() >= max_batch_records or next.batch_bytes >= max_batch_bytes {
+					ingest_flush!(next, db)?
+				} else {
+					next
+				}
+			ingest_add_events!(flushed, db, rest)
+		}
+	}
+
+ingest_flush! : IngestData, Sqlite.Db => Try(IngestData, IngestError)
+ingest_flush! = |ingest, db| {
+	if ingest.batch.is_empty() {
+		return Ok(ingest)
+	}
+
+	transaction = 
+		Sqlite.begin!(db, Immediate)
+			? |err| DatabaseFailed({ committed: ingest.committed, detail: Str.inspect(err) })
+	insert_batch!(transaction, ingest.batch)
+		? |err| DatabaseFailed({ committed: ingest.committed, detail: Str.inspect(err) })
+	transaction.commit!()
+		? |err| DatabaseFailed({ committed: ingest.committed, detail: Str.inspect(err) })
+
+	Ok({
+		..ingest,
+		batch: [],
+		batch_bytes: 0,
+		committed: ingest.committed + ingest.batch.len(),
+	})
+}
 
 init! : () => Try({ config : Server.Config, context : Context }, [Exit(I64), ..])
 init! = || {
@@ -113,103 +324,29 @@ ingest_events! = |db, request| {
 		return text_response(415, "Content-Type must be application/x-ndjson.")
 	}
 
-	initial : IngestState
-	initial = {
-		batch: [],
-		batch_bytes: 0,
-		committed: 0,
-		decoder: {
-			line: [],
-			line_number: 1,
-			max_line_bytes,
-		},
-	}
-
 	folded = 
 		request
 			.body()
 			.with_limit(max_body_bytes)
-			.fold_chunks!(initial, |state, chunk| ingest_chunk!(db, state, chunk))
+			.fold_chunks!(
+				Ingest.start(max_line_bytes),
+				|ingest, chunk| ingest.push!(db, chunk),
+			)
 
-	state = 
-		match folded {
-			Ok(value) => value
-			Err(ChunkReadErr({ err, state: partial })) =>
-				return ingest_error_response(
-					400,
-					partial.committed,
-					"Request body failed: ${Str.inspect(err)}",
-				)
-			Err(ChunkStepErr(err)) =>
-				return ingest_error_response(status_for_ingest_error(err), committed_from_error(err), ingest_error_to_str(err))
-			}
-
-	match finish_decoder(state.decoder) {
-		Err(err) => ingest_error_response(400, state.committed, decode_error_to_str(err))
-		Ok({}) =>
-			match flush_batch!(db, state) {
-				Ok(final) => committed_response(200, final.committed)
-				Err(err) => ingest_error_response(503, state.committed, ingest_error_to_str(err))
+	match folded {
+		Err(ChunkReadErr({ err, state })) =>
+			ingest_error_response(
+				400,
+				state.committed(),
+				"Request body failed: ${Str.inspect(err)}",
+			)
+		Err(ChunkStepErr(err)) => ingest_failure_response(err)
+		Ok(ingest) =>
+			match ingest.finish!(db) {
+				Ok(committed) => committed_response(200, committed)
+				Err(err) => ingest_failure_response(err)
 			}
 		}
-}
-
-ingest_chunk! : Sqlite.Db, IngestState, List(U8) => Try(IngestState, IngestError)
-ingest_chunk! = |db, state, chunk| {
-	decoded = decode_chunk(state.decoder, chunk)
-		? |err| DecodeFailed({ committed: state.committed, err })
-	with_decoder = { ..state, decoder: decoded.decoder }
-	add_events!(db, with_decoder, decoded.events)
-}
-
-add_events! : Sqlite.Db, IngestState, List(DecodedEvent) => Try(IngestState, IngestError)
-add_events! = |db, state, events|
-	match events {
-		[] => Ok(state)
-		[first, .. as rest] => {
-			ready = 
-				if state.batch.is_empty() {
-					state
-				} else if state.batch.len() >= max_batch_records or state.batch_bytes + first.encoded_bytes > max_batch_bytes {
-					flush_batch!(db, state)?
-				} else {
-					state
-				}
-			next = {
-				..ready,
-				batch: ready.batch.append(first),
-				batch_bytes: ready.batch_bytes + first.encoded_bytes,
-			}
-			flushed = 
-				if next.batch.len() >= max_batch_records or next.batch_bytes >= max_batch_bytes {
-					flush_batch!(db, next)?
-				} else {
-					next
-				}
-			add_events!(db, flushed, rest)
-		}
-	}
-
-flush_batch! : Sqlite.Db, IngestState => Try(IngestState, IngestError)
-flush_batch! = |db, state| {
-	if state.batch.is_empty() {
-		return Ok(state)
-	}
-
-	transaction = 
-		Sqlite.begin!(db, Immediate)
-			? |err| DatabaseFailed({ committed: state.committed, detail: Str.inspect(err) })
-	insert_batch!(transaction, state.batch)
-		? |err| DatabaseFailed({ committed: state.committed, detail: Str.inspect(err) })
-	transaction.commit!()
-		? |err| DatabaseFailed({ committed: state.committed, detail: Str.inspect(err) })
-
-	Ok({
-		..state,
-		batch: [],
-		batch_bytes: 0,
-		committed: state.committed + state.batch.len(),
-	})
 }
 
 insert_batch! : Sqlite.Transaction, List(DecodedEvent) => Try({}, Sqlite.QueryError)
@@ -230,83 +367,6 @@ insert_batch! = |transaction, events|
 			})?
 			insert_batch!(transaction, rest)
 		}
-	}
-
-decode_chunk : Decoder, List(U8) -> Try({ decoder : Decoder, events : List(DecodedEvent) }, DecodeError)
-decode_chunk = |decoder, bytes| decode_bytes(decoder, bytes, [])
-
-decode_bytes : Decoder, List(U8), List(DecodedEvent) -> Try({ decoder : Decoder, events : List(DecodedEvent) }, DecodeError)
-decode_bytes = |decoder, bytes, events|
-	match bytes {
-		[] => Ok({ decoder, events })
-		[byte, .. as rest] =>
-			if byte == '\n' {
-				decoded = decode_line(decoder)?
-				decode_bytes(
-					{
-						..decoder,
-						line: [],
-						line_number: decoder.line_number + 1,
-					},
-					rest,
-					events.append(decoded),
-				)
-			} else if decoder.line.len() >= decoder.max_line_bytes {
-				Err(
-					LineTooLarge({
-						limit_bytes: decoder.max_line_bytes,
-						line_number: decoder.line_number,
-					}),
-				)
-			} else {
-				decode_bytes(
-					{ ..decoder, line: decoder.line.append(byte) },
-					rest,
-					events,
-				)
-			}
-		}
-
-decode_line : Decoder -> Try(DecodedEvent, DecodeError)
-decode_line = |decoder| {
-	line = 
-		match List.last(decoder.line) {
-			Ok('\r') => decoder.line.drop_last(1)
-			_ => decoder.line
-		}
-	if line.is_empty() {
-		return Err(BlankLine(decoder.line_number))
-	}
-
-	json = 
-		match Str.from_utf8(line) {
-			Ok(value) => value
-			Err(_) => return Err(InvalidUtf8(decoder.line_number))
-		}
-
-	parsed : Try(Event, [InvalidJson(Str), MissingRequiredField(Str)])
-	parsed = Json.parse(json)
-	event = 
-		match parsed {
-			Ok(value) => value
-			Err(_) => return Err(InvalidJsonLine(decoder.line_number))
-		}
-	if Str.is_empty(event.id) or Str.is_empty(event.source) {
-		Err(InvalidEvent(decoder.line_number))
-	} else {
-		Ok({
-			encoded_bytes: decoder.line.len() + 1,
-			event,
-		})
-	}
-}
-
-finish_decoder : Decoder -> Try({}, DecodeError)
-finish_decoder = |decoder|
-	if decoder.line.is_empty() {
-		Ok({})
-	} else {
-		Err(MissingFinalNewline(decoder.line_number))
 	}
 
 ensure_schema! : Sqlite.Db => Try({}, Sqlite.QueryError)
@@ -352,37 +412,9 @@ has_ndjson_content_type = |headers|
 			}
 		}
 
-status_for_ingest_error : IngestError -> U16
-status_for_ingest_error = |err|
-	match err {
-		DatabaseFailed(_) => 503
-		DecodeFailed(_) => 400
-	}
-
-committed_from_error : IngestError -> U64
-committed_from_error = |err|
-	match err {
-		DatabaseFailed({ committed, detail: _ }) => committed
-		DecodeFailed({ committed, err: _ }) => committed
-	}
-
-ingest_error_to_str : IngestError -> Str
-ingest_error_to_str = |ingest_err|
-	match ingest_err {
-		DatabaseFailed({ committed: _, detail }) => "Database batch failed: ${detail}"
-		DecodeFailed({ committed: _, err: decode_err }) => decode_error_to_str(decode_err)
-	}
-
-decode_error_to_str : DecodeError -> Str
-decode_error_to_str = |err|
-	match err {
-		BlankLine(line) => "Line ${U64.to_str(line)} is empty."
-		InvalidEvent(line) => "Line ${U64.to_str(line)} must have non-empty id and source fields."
-		InvalidJsonLine(line) => "Line ${U64.to_str(line)} is not a valid event JSON object."
-		InvalidUtf8(line) => "Line ${U64.to_str(line)} is not valid UTF-8."
-		LineTooLarge({ line_number, limit_bytes }) => "Line ${U64.to_str(line_number)} exceeds ${U64.to_str(limit_bytes)} bytes."
-		MissingFinalNewline(line) => "Line ${U64.to_str(line)} is missing its final newline."
-	}
+ingest_failure_response : IngestError -> Response
+ingest_failure_response = |err|
+	ingest_error_response(ingest_error_status(err), ingest_error_committed(err), ingest_error_to_str(err))
 
 ingest_error_response : U16, U64, Str -> Response
 ingest_error_response = |status, committed, message|
@@ -405,39 +437,49 @@ text_response = |status, body|
 expect {
 	first = Str.to_utf8("{\"id\":\"evt-1\",\"source\":\"caf").append(195)
 	second = [169].concat(Str.to_utf8("\",\"value\":1}\r\n{\"id\":\"evt-2\",\"source\":\"sensor\",\"value\":2}\n"))
-	initial = { line: [], line_number: 1, max_line_bytes: 1024 }
+	initial = Decoder.init(1024)
 
-	match decode_chunk(initial, first) {
+	match initial.push(first) {
 		Err(_) => Bool.False
 		Ok(partial) =>
-			match decode_chunk(partial.decoder, second) {
+			match partial.decoder.push(second) {
 				Err(_) => Bool.False
 				Ok(done) =>
-					done.events.map(|item| item.event.id) == ["evt-1", "evt-2"]
-						and done.decoder.line.is_empty()
-							and done.decoder.line_number == 3
+					match done.decoder.finish() {
+						Err(_) => Bool.False
+						Ok({}) => done.events.map(|item| item.event.id) == ["evt-1", "evt-2"]
+					}
 				}
 		}
 }
 
 expect {
 	line = Str.to_utf8("{\"id\":\"evt-1\",\"source\":\"sensor\",\"value\":1}")
-	exact = { line: [], line_number: 7, max_line_bytes: line.len() }
-	too_small = { line: [], line_number: 7, max_line_bytes: line.len() - 1 }
+	exact = Decoder.init(line.len())
+	too_small = Decoder.init(line.len() - 1)
 
-	match decode_chunk(exact, line.append('\n')) {
+	match exact.push(line.append('\n')) {
 		Err(_) => Bool.False
 		Ok(result) =>
-			result.events.len() == 1
-				and decode_chunk(too_small, line) == Err(LineTooLarge({ limit_bytes: line.len() - 1, line_number: 7 }))
+			match too_small.push(line) {
+				Err(LineTooLarge({ limit_bytes, line_number })) =>
+					result.events.len() == 1
+						and limit_bytes == line.len() - 1
+							and line_number == 1
+				_ => Bool.False
+			}
 		}
 }
 
 expect {
-	decoder = {
-		line: Str.to_utf8("{\"id\":\"evt-1\",\"source\":\"sensor\",\"value\":1}"),
-		line_number: 4,
-		max_line_bytes: 1024,
-	}
-	finish_decoder(decoder) == Err(MissingFinalNewline(4))
+	line = Str.to_utf8("{\"id\":\"evt-1\",\"source\":\"sensor\",\"value\":1}")
+
+	match Decoder.init(1024).push(line) {
+		Err(_) => Bool.False
+		Ok(partial) =>
+			match partial.decoder.finish() {
+				Err(MissingFinalNewline(line_number)) => line_number == 1
+				_ => Bool.False
+			}
+		}
 }

--- a/examples/ndjson-ingest.roc
+++ b/examples/ndjson-ingest.roc
@@ -1,7 +1,7 @@
 ## Streams newline-delimited JSON events into SQLite in short, retry-safe
 ## batches without materializing the complete HTTP request body.
 app [Context, program] {
-	pf: platform "https://github.com/roc-lang/basic-webserver/releases/download/0.14.0-rc1/GfM5qZLcKYGA9XD4V7u1S4RjWrdfws29Uz2m86C7bmUC.tar.zst",
+	pf: platform "../platform/main.roc",
 	http: "https://github.com/roc-lang/http/releases/download/1.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
 }
 

--- a/examples/sleep.roc
+++ b/examples/sleep.roc
@@ -28,9 +28,19 @@ init! = ||
 	})
 
 respond! : Server.Request, Context => Try(Server.Outcome, [ServerErr(Str), ..])
-respond! = |request, _context|
-	if request.target() == "/fast" {
+respond! = |request, _context| {
+	target = request.target()
+	if target == "/fast" {
 		Ok(Server.respond(Response.from_status(200).with_body(Str.to_utf8("Immediate response"))))
+	} else if target == "/body-fast" {
+		body = request.body().read_all!()
+			? |err| ServerErr("Failed to read request body: ${Str.inspect(err)}")
+		Ok(Server.respond(Response.from_status(200).with_body(body)))
+	} else if target == "/body-slow" {
+		body = request.body().read_all!()
+			? |err| ServerErr("Failed to read request body: ${Str.inspect(err)}")
+		Sleep.millis!(1000)
+		Ok(Server.respond(Response.from_status(200).with_body(body)))
 	} else {
 		Stdout.line!("Sleeping for 1 second...")
 			? |err| ServerErr("Failed to write to stdout: ${Str.inspect(err)}")
@@ -38,6 +48,7 @@ respond! = |request, _context|
 
 		Ok(Server.respond(Response.from_status(200).with_body(Str.to_utf8("Response delayed by 1 second"))))
 	}
+}
 
 shutdown! : Server.ShutdownReason, Context => Try({}, [Exit(I64), ..])
 shutdown! = |_reason, _context| Ok({})

--- a/platform/Host.roc
+++ b/platform/Host.roc
@@ -59,6 +59,8 @@ Host := [].{
 
 	TcpStream :: Box(U64)
 
+	RequestBody :: Box(U64)
+
 	RequestBodyRead : [Chunk(List(U8)), End]
 
 	RequestBodyErr : [
@@ -119,8 +121,8 @@ Host := [].{
 
 	http_send_request! : InternalHttp.OutboundRequestToHost => Try(InternalHttp.OutboundResponseFromHost, InternalHttp.SendErr)
 
-	request_body_read! : U64, U64 => Try(RequestBodyRead, RequestBodyErr)
-	request_body_read_all! : U64, U64 => Try(List(U8), RequestBodyErr)
+	request_body_read! : RequestBody, U64 => Try(RequestBodyRead, RequestBodyErr)
+	request_body_read_all! : RequestBody, U64 => Try(List(U8), RequestBodyErr)
 
 	path_type! : RawPath => Try(PathType, IOErr)
 

--- a/platform/InternalServer.roc
+++ b/platform/InternalServer.roc
@@ -1,4 +1,5 @@
 import Server
+import Host
 import http.Header
 import http.Method
 import http.Response
@@ -13,7 +14,7 @@ InternalServer :: [].{
 		method_ext : Str,
 		headers : List(HostHeader),
 		target : Str,
-		body_id : U64,
+		body_handle : Host.RequestBody,
 		body_limit_bytes : U64,
 		content_length_known : Bool,
 		content_length : U64,
@@ -78,13 +79,13 @@ InternalServer :: [].{
 	}
 
 	from_host_request : RequestFromHost -> Server.Request
-	from_host_request = |{ method, method_ext, headers, target, body_id, body_limit_bytes, content_length_known, content_length }|
+	from_host_request = |{ method, method_ext, headers, target, body_handle, body_limit_bytes, content_length_known, content_length }|
 		Server.Request.from_host(
 			from_host_method(method, method_ext),
 			headers.map(from_host_header),
 			target,
 			Server.Body.from_host(
-				body_id,
+				body_handle,
 				body_limit_bytes,
 				if content_length_known {
 					Known(content_length)

--- a/platform/Server.roc
+++ b/platform/Server.roc
@@ -471,7 +471,7 @@ Server :: [].{
 	Body := [
 		Body(
 			{
-				host_id : U64,
+				host : Host.RequestBody,
 				limit_bytes : U64,
 				content_length : [Unknown, Known(U64)],
 			},
@@ -494,9 +494,9 @@ Server :: [].{
 		to_inspect = |_| "Server.Body(<stream>)"
 
 		## Platform ABI conversion hook; not an application API.
-		from_host : U64, U64, [Unknown, Known(U64)] -> Body
-		from_host = |host_id, limit_bytes, content_length|
-			Body({ host_id, limit_bytes, content_length })
+		from_host : Host.RequestBody, U64, [Unknown, Known(U64)] -> Body
+		from_host = |host, limit_bytes, content_length|
+			Body({ host, limit_bytes, content_length })
 
 		## The maximum number of bytes this request body may deliver.
 		limit : Body -> U64
@@ -523,13 +523,13 @@ Server :: [].{
 		## once. Concurrent reads of one body return ConcurrentRead.
 		read! : Body => Try(Read, [RequestBodyErr(Err)])
 		read! = |Body(raw)|
-			Host.request_body_read!(raw.host_id, raw.limit_bytes).map_err(|err| RequestBodyErr(body_err_from_host(err)))
+			Host.request_body_read!(raw.host, raw.limit_bytes).map_err(|err| RequestBodyErr(body_err_from_host(err)))
 
 		## Read all remaining bytes while enforcing this body's current limit.
 		## Prefer read! for large or incrementally processed payloads.
 		read_all! : Body => Try(List(U8), [RequestBodyErr(Err)])
 		read_all! = |Body(raw)|
-			Host.request_body_read_all!(raw.host_id, raw.limit_bytes).map_err(|err| RequestBodyErr(body_err_from_host(err)))
+			Host.request_body_read_all!(raw.host, raw.limit_bytes).map_err(|err| RequestBodyErr(body_err_from_host(err)))
 	}
 
 	## An inbound server request. Its body is always streaming; use

--- a/platform/Server.roc
+++ b/platform/Server.roc
@@ -525,6 +525,21 @@ Server :: [].{
 		read! = |Body(raw)|
 			Host.request_body_read!(raw.host, raw.limit_bytes).map_err(|err| RequestBodyErr(body_err_from_host(err)))
 
+		## Read every remaining chunk sequentially and thread request-local state
+		## through an effectful step function. The first step error stops reading;
+		## returning from the handler then cancels any unread request bytes.
+		fold_chunks! : Body, state, (state, List(U8) => Try(state, err)) => Try(state, [ChunkReadErr({ err : Err, state : state }), ChunkStepErr(err)])
+		fold_chunks! = |body, state, step!|
+			match read!(body) {
+				Ok(Chunk(chunk)) =>
+					match step!(state, chunk) {
+						Ok(next) => fold_chunks!(body, next, step!)
+						Err(err) => Err(ChunkStepErr(err))
+					}
+				Ok(End) => Ok(state)
+				Err(RequestBodyErr(err)) => Err(ChunkReadErr({ err, state }))
+			}
+
 		## Read all remaining bytes while enforcing this body's current limit.
 		## Prefer read! for large or incrementally processed payloads.
 		read_all! : Body => Try(List(U8), [RequestBodyErr(Err)])

--- a/scripts/test_spec.json
+++ b/scripts/test_spec.json
@@ -642,6 +642,79 @@
       ]
     },
     {
+      "path": "examples/ndjson-ingest.roc",
+      "mode": "server",
+      "cases": [
+        {
+          "name": "streaming-events",
+          "env": {
+            "DB_PATH": "{temp}/events.db"
+          },
+          "requests": [
+            {
+              "method": "POST",
+              "target": "/events",
+              "headers": {
+                "Content-Type": "application/x-ndjson"
+              },
+              "body": "{\"id\":\"evt-1\",\"source\":\"sensor\",\"value\":1}\n{\"id\":\"evt-2\",\"source\":\"sensor\",\"value\":2}\n{\"id\":\"evt-3\",\"source\":\"sensor\",\"value\":3}\n",
+              "expect_body": "{\"committed\":3}"
+            },
+            {
+              "method": "GET",
+              "target": "/events/count",
+              "expect_body": "{\"count\":3}"
+            },
+            {
+              "raw": true,
+              "half_close": false,
+              "fragments": [
+                {
+                  "data": "POST /events HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/x-ndjson\r\nContent-Length: 44\r\nConnection: close\r\n\r\n{\"id\":\"raw-1\",\"source\":\"sen",
+                  "delay_ms": 10
+                },
+                {
+                  "data": "sor\",\"value\":9}\r",
+                  "delay_ms": 10
+                },
+                {
+                  "data": "\n"
+                }
+              ],
+              "response_contains": [
+                "HTTP/1.1 200 OK",
+                "{\"committed\":1}"
+              ]
+            },
+            {
+              "method": "POST",
+              "target": "/events",
+              "headers": {
+                "Content-Type": "application/x-ndjson"
+              },
+              "body": "{\"id\":\"evt-1\",\"source\":\"sensor\",\"value\":1}\n{\"id\":\"evt-4\",\"source\":\"sensor\",\"value\":4}\n",
+              "expect_body": "{\"committed\":2}"
+            },
+            {
+              "method": "GET",
+              "target": "/events/count",
+              "expect_body": "{\"count\":5}"
+            },
+            {
+              "method": "POST",
+              "target": "/events",
+              "headers": {
+                "Content-Type": "application/x-ndjson"
+              },
+              "body": "{\"id\":\"truncated\",\"source\":\"sensor\",\"value\":5}",
+              "status": 400,
+              "body_contains": ["missing its final newline", "\"committed\":0"]
+            }
+          ]
+        }
+      ]
+    },
+    {
       "path": "examples/server-lifecycle.roc",
       "mode": "server",
       "cases": [

--- a/scripts/test_spec.json
+++ b/scripts/test_spec.json
@@ -97,6 +97,12 @@
               "expect_body_hex": "00ff410a"
             },
             {
+              "method": "POST",
+              "target": "/first-chunk",
+              "body": "seamless response",
+              "expect_body": "seamless response"
+            },
+            {
               "raw": true,
               "half_close": false,
               "data_hex": "474554202f20485454502f312e310d0a486f73743a203132372e302e302e310d0a582d546573743a20ff0d0a436f6e6e656374696f6e3a20636c6f73650d0a0d0a",
@@ -106,9 +112,24 @@
               ]
             }
           ],
+          "concurrent_requests": [
+            {
+              "method": "POST",
+              "target": "/first-chunk",
+              "body": "first concurrent body",
+              "expect_body": "first concurrent body"
+            },
+            {
+              "method": "POST",
+              "target": "/first-chunk",
+              "body": "second concurrent body",
+              "expect_body": "second concurrent body"
+            }
+          ],
           "stdout_contains": [
             "POST /echo?kind=utf8",
-            "POST /binary"
+            "POST /binary",
+            "POST /first-chunk"
           ]
         }
       ]
@@ -486,13 +507,17 @@
           "http2_requests": [
             {
               "name": "slow",
-              "target": "/",
-              "expect_body": "Response delayed by 1 second"
+              "method": "POST",
+              "target": "/body-slow",
+              "body": "slow HTTP/2 body",
+              "expect_body": "slow HTTP/2 body"
             },
             {
               "name": "fast",
-              "target": "/fast",
-              "expect_body": "Immediate response"
+              "method": "POST",
+              "target": "/body-fast",
+              "body": "fast HTTP/2 body",
+              "expect_body": "fast HTTP/2 body"
             }
           ],
           "http2_completion_order": ["fast", "slow"],

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -155,6 +155,7 @@ pub(crate) fn initialize_roc_host() {
     // Generated Rust helpers release Roc allocations through this vtable,
     // while compiled Roc calls the exported symbols below. Both paths must
     // route opaque resource boxes through the same finalizer heaps.
+    host.roc_alloc = crate::roc_alloc::roc_alloc;
     host.roc_dealloc = routed_roc_dealloc;
     host.roc_realloc = routed_roc_realloc;
     ROC_HOST
@@ -178,7 +179,7 @@ pub(crate) fn roc_host() -> &'static RocHost {
 
 #[no_mangle]
 pub extern "C" fn roc_alloc(length: usize, alignment: usize) -> *mut c_void {
-    DefaultAllocators::roc_alloc(roc_host_ptr(), length, alignment)
+    crate::roc_alloc::roc_alloc(roc_host_ptr(), length, alignment)
 }
 
 pub(crate) extern "C" fn routed_roc_dealloc(
@@ -188,23 +189,28 @@ pub(crate) extern "C" fn routed_roc_dealloc(
 ) {
     use crate::host_resource::DeallocRoute;
 
-    for route_resource in [
-        crate::request_parts::route_dealloc,
-        crate::sqlite::route_resource_dealloc,
-        crate::file::route_resource_dealloc,
-        crate::tcp::route_resource_dealloc,
+    for (resource_kind, route_resource) in [
+        (
+            "request metadata",
+            crate::request_parts::route_dealloc as fn(*mut c_void) -> DeallocRoute,
+        ),
+        ("SQLite", crate::sqlite::route_resource_dealloc),
+        ("file reader", crate::file::route_resource_dealloc),
+        ("TCP stream", crate::tcp::route_resource_dealloc),
     ] {
         let route = route_resource(ptr);
         match route {
             DeallocRoute::NotOwned => {}
             DeallocRoute::Deallocated => return,
             DeallocRoute::Corrupt => {
-                eprintln!("fatal: invalid or duplicate host resource deallocation");
+                eprintln!(
+                    "fatal: invalid or duplicate {resource_kind} resource deallocation at {ptr:p}"
+                );
                 std::process::abort();
             }
         }
     }
-    DefaultAllocators::roc_dealloc(roc_host, ptr, alignment);
+    crate::roc_alloc::roc_dealloc(roc_host, ptr, alignment);
 }
 
 #[no_mangle]
@@ -229,7 +235,7 @@ pub(crate) extern "C" fn routed_roc_realloc(
         eprintln!("fatal: Roc attempted to reallocate an opaque host resource");
         std::process::abort();
     }
-    DefaultAllocators::roc_realloc(roc_host, ptr, new_length, alignment)
+    crate::roc_alloc::roc_realloc(roc_host, ptr, new_length, alignment)
 }
 
 #[no_mangle]

--- a/src/host_resource.rs
+++ b/src/host_resource.rs
@@ -7,7 +7,6 @@ use std::sync::Mutex;
 const TOKEN_INDEX_BITS: u32 = 16;
 const TOKEN_INDEX_MASK: u64 = (1_u64 << TOKEN_INDEX_BITS) - 1;
 const MAX_GENERATION: u64 = u64::MAX >> TOKEN_INDEX_BITS;
-const DEBUG_FREED_REFCOUNT: isize = 0xDEADBEEFDEADBEEFu64 as isize;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ReserveError {
@@ -154,32 +153,40 @@ impl<T> HostResourceHeap<T> {
     /// Route a Roc allocation-base pointer to this heap.
     pub(crate) fn route_dealloc(&self, ptr: *mut c_void) -> DeallocRoute {
         let Some(index) = self.base_index(ptr) else {
-            return if self.contains_address(ptr) {
-                DeallocRoute::Corrupt
-            } else {
-                DeallocRoute::NotOwned
-            };
+            if self.contains_address(ptr) {
+                let start = self.slots.as_ptr() as usize;
+                eprintln!(
+                    "host resource deallocation pointer is not a slot base: offset={}, stride={}",
+                    ptr as usize - start,
+                    core::mem::size_of::<ResourceSlot<T>>()
+                );
+                return DeallocRoute::Corrupt;
+            }
+            return DeallocRoute::NotOwned;
         };
         let slot = &self.slots[index];
         let mut state = self.lock_state();
         let refcount = slot.refcount.load(Ordering::Acquire);
-        // Roc's debug runtime poisons the final refcount immediately before it
-        // invokes the host deallocator. Optimized runtimes leave it at zero.
-        // Slot state still makes a second deallocation unambiguously corrupt.
         if state.slots[index] != SlotState::Live
-            || (refcount != 0 && refcount != DEBUG_FREED_REFCOUNT)
+            || !crate::roc_alloc::is_finalized_roc_refcount(refcount)
         {
             eprintln!(
-                "host resource deallocation invariant failed: index={index}, state={:?}, refcount={}",
+                "host resource slot {index} cannot be finalized: state={:?}, refcount={}",
                 state.slots[index], refcount
             );
             return DeallocRoute::Corrupt;
         }
         let token = unsafe { *slot.token.get() };
         let Some((token_index, generation)) = decode_token(token) else {
+            eprintln!("host resource slot {index} has an invalid lifecycle token");
             return DeallocRoute::Corrupt;
         };
         if token_index != index || state.generations[index] != generation {
+            eprintln!(
+                "host resource slot {index} token mismatch: token_index={token_index}, \
+                 token_generation={generation}, live_generation={}",
+                state.generations[index]
+            );
             return DeallocRoute::Corrupt;
         }
 
@@ -424,23 +431,6 @@ mod tests {
         let handle = heap.reserve().unwrap().insert(42);
         assert_eq!(unsafe { *heap.get(handle).unwrap() }, 42);
         assert_eq!(final_dealloc(&heap, handle), DeallocRoute::Deallocated);
-    }
-
-    #[test]
-    fn debug_runtime_refcount_poison_is_a_valid_final_deallocation() {
-        let heap = HostResourceHeap::<usize>::new(1);
-        let handle = heap.reserve().unwrap().insert(42);
-        let base = unsafe { handle.cast::<u8>().sub(core::mem::size_of::<isize>()) };
-        unsafe {
-            (*(base.cast::<AtomicIsize>())).store(DEBUG_FREED_REFCOUNT, Ordering::Release);
-        }
-
-        assert_eq!(heap.route_dealloc(base.cast()), DeallocRoute::Deallocated);
-        assert_eq!(
-            heap.route_dealloc(base.cast()),
-            DeallocRoute::Corrupt,
-            "slot state must still reject a duplicate debug deallocation"
-        );
     }
 
     #[test]

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -8,7 +8,7 @@ use crate::file_server::{
     full_body, CachePolicy, Disposition, FilePlan, FileRootSpec, FileService, NativeRouteKind,
     NativeRouteSpec, ServerResponse,
 };
-use crate::request_body::{clear_registry, install_registry, BodyRegistry, PumpError};
+use crate::request_body::{register as register_body, PumpError};
 use crate::request_parts::{request_target, RequestPartsBacking};
 use crate::roc_platform_abi::*;
 use crate::shutdown::{RequestTracker, ShutdownController, ShutdownReason};
@@ -272,7 +272,6 @@ unsafe impl Sync for RocContext {}
 struct ServerContext {
     config: Arc<RuntimeConfig>,
     roc_context: Arc<RocContext>,
-    bodies: Arc<BodyRegistry>,
     handlers: HandlerAdmission,
     requests: RequestTracker,
     shutdown: ShutdownController,
@@ -305,12 +304,10 @@ fn start_inner() -> i32 {
     };
 
     let roc_context = Arc::new(RocContext::new(raw_context));
-    let bodies = install_registry(config.body_buffered_chunks);
     let shutdown = ShutdownController::new();
     let context = ServerContext {
         config: Arc::new(config.clone()),
         roc_context: Arc::clone(&roc_context),
-        bodies,
         handlers: HandlerAdmission::new(config.max_handlers, config.max_queued_handlers),
         requests: RequestTracker::new(),
         shutdown: shutdown.clone(),
@@ -327,7 +324,6 @@ fn start_inner() -> i32 {
         }
     };
 
-    clear_registry();
     debug_assert_eq!(
         Arc::strong_count(&roc_context),
         1,
@@ -420,7 +416,7 @@ fn request_headers_are_utf8(headers: &hyper::HeaderMap) -> bool {
 
 fn request_to_roc(
     parts: hyper::http::request::Parts,
-    body_id: u64,
+    body_handle: *mut u64,
     body_limit: u64,
     declared_length: Option<u64>,
 ) -> ServerRequest {
@@ -428,7 +424,13 @@ fn request_to_roc(
     let backing = match RequestPartsBacking::new(parts) {
         Ok(backing) => backing,
         Err(parts) => {
-            return request_to_roc_copied(*parts, body_id, body_limit, declared_length, roc_host);
+            return request_to_roc_copied(
+                *parts,
+                body_handle,
+                body_limit,
+                declared_length,
+                roc_host,
+            );
         }
     };
     let method_tag = method_to_tag(backing.method());
@@ -459,7 +461,7 @@ fn request_to_roc(
     backing.install(backing_references);
 
     ServerRequest {
-        body_id,
+        body_handle,
         body_limit_bytes: body_limit,
         content_length: declared_length.unwrap_or_default(),
         headers,
@@ -472,7 +474,7 @@ fn request_to_roc(
 
 fn request_to_roc_copied(
     parts: hyper::http::request::Parts,
-    body_id: u64,
+    body_handle: *mut u64,
     body_limit: u64,
     declared_length: Option<u64>,
     roc_host: &RocHost,
@@ -501,7 +503,7 @@ fn request_to_roc_copied(
     let target = request_target(&parts);
 
     ServerRequest {
-        body_id,
+        body_handle,
         body_limit_bytes: body_limit,
         content_length: declared_length.unwrap_or_default(),
         headers,
@@ -581,6 +583,7 @@ fn outcome_from_roc(response: RocServerResponse) -> RocOutcome {
 }
 
 fn response_to_hyper(response: RocServerResponse) -> ServerResponse {
+    crate::request_body::validate_response_body(&response.body);
     let mut builder = hyper::Response::builder().status(response.status);
     for header in response.headers.as_slice() {
         builder = builder.header(header.name.as_str(), header.value.as_str());
@@ -693,8 +696,12 @@ async fn handle_req(
     let (parts, body) = request.into_parts();
     let file_method = parts.method.clone();
     let file_headers = parts.headers.clone();
-    let registration = context.bodies.register(context.config.body_max_bytes);
-    let body_id = registration.id;
+    let registration = register_body(
+        context.config.body_max_bytes,
+        context.config.body_buffered_chunks,
+        declared_length,
+        roc_host(),
+    );
     let stream = body
         .into_data_stream()
         .map(|frame| frame.map_err(request_body_error));
@@ -702,7 +709,7 @@ async fn handle_req(
     tokio::spawn(async move { registration.pump.run(stream, chunk_bytes).await });
 
     let body_limit = context.config.body_max_bytes;
-    let bodies = Arc::clone(&context.bodies);
+    let body_handle = registration.handle;
     let roc_context = Arc::clone(&context.roc_context);
     let handler_request = Arc::clone(&active_request);
     let handled = spawn_blocking(move || {
@@ -712,10 +719,15 @@ async fn handle_req(
         // context.
         let _active_request = handler_request;
         let _active_handler = active_handler;
-        let roc_request = request_to_roc(parts, body_id, body_limit, declared_length);
+        let roc_request = request_to_roc(
+            parts,
+            body_handle.retain_for_roc(),
+            body_limit,
+            declared_length,
+        );
         let request_context = roc_context.retain_for_request();
         let result = call_roc(roc_request, request_context);
-        bodies.expire(body_id);
+        body_handle.expire();
         result
     })
     .await;
@@ -740,7 +752,6 @@ async fn handle_req(
             internal_server_error("500 Internal Server Error")
         }
         Err(error) => {
-            context.bodies.expire(body_id);
             eprintln!("Recovered from calling Roc: {error:?}");
             internal_server_error("500 Internal Server Error")
         }
@@ -857,10 +868,9 @@ async fn run_server(context: ServerContext) -> ShutdownReason {
     .await;
 
     if drained.is_err() {
-        context.bodies.cancel_all();
         connections.abort_all();
         eprintln!(
-            "Graceful drain exceeded {:?}; request bodies were cancelled and connections aborted; forcing process exit without running the Roc shutdown hook",
+            "Graceful drain exceeded {:?}; connections were aborted; forcing process exit without running the Roc shutdown hook",
             context.config.drain_timeout
         );
 
@@ -939,6 +949,12 @@ async fn watch_signals(shutdown: ShutdownController) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn initialize_test_host() {
+        static INITIALIZE: std::sync::Once = std::sync::Once::new();
+        INITIALIZE.call_once(crate::abi::initialize_roc_host);
+    }
 
     #[test]
     fn method_tags_match_internal_server_contract() {
@@ -1008,8 +1024,7 @@ mod tests {
 
     #[tokio::test]
     async fn request_metadata_and_escaped_response_body_share_hyper_storage() {
-        static INITIALIZE: std::sync::Once = std::sync::Once::new();
-        INITIALIZE.call_once(crate::abi::initialize_roc_host);
+        initialize_test_host();
 
         let request = hyper::Request::builder()
             .method("PROPFIND")
@@ -1025,7 +1040,7 @@ mod tests {
             .collect();
         let (parts, _) = request.into_parts();
 
-        let roc_request = request_to_roc(parts, 1, 4096, None);
+        let roc_request = request_to_roc(parts, core::ptr::null_mut(), 4096, None);
         assert_eq!(crate::request_parts::active_backings(), 1);
         assert!(roc_request.target.is_seamless_slice());
         assert_eq!(roc_request.target.as_u8_ptr(), original_target_ptr);
@@ -1094,6 +1109,58 @@ mod tests {
             0,
             "Hyper's final Bytes drop must release the escaped Roc slice"
         );
+    }
+
+    struct DropOwner {
+        bytes: &'static [u8],
+        drops: Arc<AtomicUsize>,
+    }
+
+    impl AsRef<[u8]> for DropOwner {
+        fn as_ref(&self) -> &[u8] {
+            self.bytes
+        }
+    }
+
+    impl Drop for DropOwner {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    #[tokio::test]
+    async fn seamless_request_chunk_escapes_until_hyper_finishes_the_response() {
+        initialize_test_host();
+        let drops = Arc::new(AtomicUsize::new(0));
+        let bytes = Bytes::from_owner(DropOwner {
+            bytes: b"escaped body chunk",
+            drops: Arc::clone(&drops),
+        });
+        let original_ptr = bytes.as_ptr();
+        let response = RocServerResponse {
+            exit_code: 0,
+            body: crate::request_body::seamless_chunk_for_test(bytes),
+            file_download_name: RocStr::empty(),
+            file_relative: RocStr::empty(),
+            file_root_id: RocStr::empty(),
+            headers: RocList::empty(),
+            file_cache_max_age_seconds: 0,
+            status: 200,
+            file_cache_override: false,
+            file_cache_tag: 0,
+            file_disposition: 0,
+            kind: 0,
+            stop: false,
+        };
+
+        let response = response_to_hyper(response);
+        assert_eq!(drops.load(Ordering::Acquire), 0);
+        let transmitted = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(transmitted.as_ptr(), original_ptr);
+        assert_eq!(transmitted.as_ref(), b"escaped body chunk");
+        assert_eq!(drops.load(Ordering::Acquire), 0);
+        drop(transmitted);
+        assert_eq!(drops.load(Ordering::Acquire), 1);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ mod os_str;
 mod path;
 mod request_body;
 mod request_parts;
+mod roc_alloc;
 mod roc_platform_abi;
 mod shutdown;
 mod sqlite;
@@ -43,16 +44,20 @@ pub fn rust_main() -> i32 {
     let live_resources = sqlite::active_resources()
         + file::active_resources()
         + tcp::active_resources()
-        + request_parts::active_backings();
+        + request_parts::active_backings()
+        + request_body::metrics().active_bodies
+        + request_body::metrics().active_backings;
     if live_resources != 0 {
         eprintln!(
             "host resource lifecycle error: {live_resources} native resources remained after \
              shutdown (high-water marks: sqlite={}, file_readers={}, tcp_streams={}, \
-             request_backings={})",
+             request_backings={}, request_bodies={}, body_backings={})",
             sqlite::resource_high_water(),
             file::resource_high_water(),
             tcp::resource_high_water(),
             request_parts::high_water(),
+            request_body::metrics().body_high_water,
+            request_body::metrics().backing_high_water,
         );
         1
     } else {

--- a/src/request_body.rs
+++ b/src/request_body.rs
@@ -1,47 +1,53 @@
 //! Request-scoped, bounded transport between Hyper's asynchronous body stream
 //! and a synchronous Roc request worker.
 //!
-//! This module deliberately has no generated-ABI dependencies. The hosted
-//! functions can translate [`ReadResult`] and [`BodyError`] after the public
-//! Roc contract is finalized.
+//! The opaque Roc body capability directly owns [`BodyState`]. A server-held
+//! ARC reference expires it when the handler returns; hosted reads consume
+//! temporary ARC references supplied by Roc. Delivered chunks move into
+//! self-describing seamless allocations whose final Roc release drops the
+//! original [`Bytes`] owner.
 
-use crate::abi::roc_host;
 use crate::abi::{
     body_error, body_read_all_error, body_read_all_ok, body_read_chunk, body_read_end,
-    body_read_error, BodyReadAllResult, BodyReadError, BodyReadErrorTag, BodyReadResult,
+    body_read_error, roc_host, BodyReadAllResult, BodyReadError, BodyReadErrorTag, BodyReadResult,
     BodyTooLarge,
 };
-use crate::roc_platform_abi::{RocListWith, RocStr};
+use crate::roc_alloc::{self, AllocationKind};
+use crate::roc_platform_abi::{decref_box_with, incref_box, RocBox, RocHost, RocListWith, RocStr};
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, OnceLock, TryLockError};
+use std::sync::atomic::{AtomicIsize, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Mutex, TryLockError};
 use tokio::sync::{mpsc, watch};
 
-pub(crate) type BodyId = u64;
+const REQUEST_BODY_TOKEN: u64 = 0x5245_5142_4f44_5931;
+const SEAMLESS_SLICE_TAG: usize = 1;
 
-static BODY_REGISTRY: OnceLock<Mutex<Option<Arc<BodyRegistry>>>> = OnceLock::new();
+static RETAINED_PAYLOAD_BYTES: AtomicUsize = AtomicUsize::new(0);
+static SHARED_PAYLOAD_BYTES: AtomicUsize = AtomicUsize::new(0);
+static COPIED_PAYLOAD_BYTES: AtomicUsize = AtomicUsize::new(0);
 
-fn global_registry() -> &'static Mutex<Option<Arc<BodyRegistry>>> {
-    BODY_REGISTRY.get_or_init(|| Mutex::new(None))
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct BodyMetrics {
+    pub active_bodies: usize,
+    pub body_high_water: usize,
+    pub active_backings: usize,
+    pub backing_high_water: usize,
+    pub retained_payload_bytes: usize,
+    pub shared_payload_bytes: usize,
+    pub copied_payload_bytes: usize,
 }
 
-pub(crate) fn install_registry(channel_capacity: usize) -> Arc<BodyRegistry> {
-    let registry = Arc::new(BodyRegistry::new(channel_capacity));
-    *global_registry()
-        .lock()
-        .expect("request body global registry mutex poisoned") = Some(Arc::clone(&registry));
-    registry
-}
-
-pub(crate) fn clear_registry() {
-    if let Some(registry) = global_registry()
-        .lock()
-        .expect("request body global registry mutex poisoned")
-        .take()
-    {
-        registry.cancel_all();
+pub(crate) fn metrics() -> BodyMetrics {
+    let allocations = roc_alloc::counts();
+    BodyMetrics {
+        active_bodies: allocations.active_request_bodies,
+        body_high_water: allocations.request_body_high_water,
+        active_backings: allocations.active_seamless_backings,
+        backing_high_water: allocations.seamless_backing_high_water,
+        retained_payload_bytes: RETAINED_PAYLOAD_BYTES.load(Ordering::Acquire),
+        shared_payload_bytes: SHARED_PAYLOAD_BYTES.load(Ordering::Acquire),
+        copied_payload_bytes: COPIED_PAYLOAD_BYTES.load(Ordering::Acquire),
     }
 }
 
@@ -66,7 +72,7 @@ pub(crate) enum BodyError {
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum ReadResult {
-    Chunk(Vec<u8>),
+    Chunk(Bytes),
     End,
 }
 
@@ -90,6 +96,7 @@ struct BodyState {
     cancel_sender: watch::Sender<bool>,
     terminal: Mutex<Option<Terminal>>,
     hard_limit: u64,
+    declared_length: Option<u64>,
     narrow_limit: AtomicU64,
     delivered: AtomicU64,
 }
@@ -177,7 +184,7 @@ impl BodyState {
                         return Err(error);
                     }
                     self.delivered.store(received_at_least, Ordering::Release);
-                    return Ok(ReadResult::Chunk(bytes.to_vec()));
+                    return Ok(ReadResult::Chunk(bytes));
                 }
                 Some(PumpMessage::End) | None => {
                     self.set_terminal(Terminal::End);
@@ -211,19 +218,40 @@ impl BodyState {
         self.receive_with_limit(&mut receiver, requested_limit)
     }
 
-    fn read_all(&self, requested_limit: u64) -> Result<Vec<u8>, BodyError> {
+    fn read_all(
+        &self,
+        requested_limit: u64,
+        host: &RocHost,
+    ) -> Result<RocListWith<u8, false>, BodyError> {
         let mut receiver = self.lock_reader()?;
-        let mut bytes = Vec::new();
+        let effective_limit = self.effective_limit(requested_limit);
+        let already_delivered = self.delivered.load(Ordering::Acquire);
+        if already_delivered > effective_limit {
+            let error = BodyError::TooLarge {
+                limit_bytes: effective_limit,
+                received_at_least: already_delivered,
+            };
+            self.stop(Terminal::Error(error.clone()));
+            return Err(error);
+        }
+        let remaining_limit = effective_limit - already_delivered;
+        let capacity_hint = self
+            .declared_length
+            .map(|length| length.saturating_sub(already_delivered))
+            .unwrap_or(0)
+            .min(remaining_limit);
+        let mut output = RocBytesBuilder::new(capacity_hint, remaining_limit, host);
+
         loop {
             match self.receive_with_limit(&mut receiver, requested_limit)? {
-                ReadResult::Chunk(chunk) => bytes.extend_from_slice(&chunk),
-                ReadResult::End => return Ok(bytes),
+                ReadResult::Chunk(chunk) => output.extend(&chunk)?,
+                ReadResult::End => return Ok(output.finish()),
             }
         }
     }
 }
 
-/// The producer half of a registered body. Move this value into the Tokio task
+/// The producer half of one request body. Move this value into the Tokio task
 /// that owns `hyper::body::Incoming`.
 pub(crate) struct BodyPump {
     sender: mpsc::Sender<PumpMessage>,
@@ -306,136 +334,502 @@ impl BodyPump {
     }
 }
 
+#[repr(C)]
+struct BodyPayload {
+    token: u64,
+    state: BodyState,
+}
+
+fn body_box_header_bytes() -> usize {
+    core::mem::size_of::<usize>().max(core::mem::align_of::<u64>())
+}
+
+unsafe fn body_payload_from_base(base: *mut u8) -> *mut BodyPayload {
+    unsafe { base.add(body_box_header_bytes()).cast() }
+}
+
+unsafe fn drop_body_allocation(base: *mut u8) {
+    let payload = unsafe { body_payload_from_base(base) };
+    if unsafe { (*payload).token } != REQUEST_BODY_TOKEN {
+        eprintln!("fatal: request-body allocation token was overwritten");
+        std::process::abort();
+    }
+    let payload_ptr = payload.cast::<u8>();
+    let refcount = unsafe {
+        payload_ptr
+            .sub(core::mem::size_of::<isize>())
+            .cast::<AtomicIsize>()
+    };
+    if !roc_alloc::is_finalized_roc_refcount(unsafe { (*refcount).load(Ordering::Acquire) }) {
+        eprintln!("fatal: request-body finalizer ran before final Roc ARC release");
+        std::process::abort();
+    }
+    unsafe {
+        (*payload).state.stop(Terminal::Error(BodyError::Cancelled));
+        payload.drop_in_place();
+    }
+}
+
+unsafe fn body_state_from_handle(handle: *mut u64) -> &'static BodyState {
+    if handle.is_null() || !(handle as usize).is_multiple_of(core::mem::align_of::<u64>()) {
+        eprintln!("fatal: invalid request-body capability");
+        std::process::abort();
+    }
+    let base = unsafe { handle.cast::<u8>().sub(body_box_header_bytes()) };
+    unsafe {
+        roc_alloc::validate_host_owned(
+            base,
+            AllocationKind::RequestBody,
+            body_box_header_bytes() + core::mem::size_of::<BodyPayload>(),
+            core::mem::align_of::<BodyPayload>(),
+        );
+    }
+    let payload = handle.cast::<BodyPayload>();
+    if unsafe { (*payload).token } != REQUEST_BODY_TOKEN {
+        eprintln!("fatal: invalid request-body capability token");
+        std::process::abort();
+    }
+    let refcount = unsafe {
+        handle
+            .cast::<u8>()
+            .sub(core::mem::size_of::<isize>())
+            .cast::<AtomicIsize>()
+    };
+    if unsafe { (*refcount).load(Ordering::Acquire) } <= 0 {
+        eprintln!("fatal: stale request-body capability");
+        std::process::abort();
+    }
+    unsafe { &(*payload).state }
+}
+
+/// One owned native reference to a request-scoped body capability.
+pub(crate) struct BodyHandle {
+    raw: *mut u64,
+    host: *const RocHost,
+}
+
+// SAFETY: the allocation has atomic Roc ARC, and BodyState synchronizes every
+// field that may be accessed by the pump and synchronous reader threads.
+unsafe impl Send for BodyHandle {}
+unsafe impl Sync for BodyHandle {}
+
+impl Clone for BodyHandle {
+    fn clone(&self) -> Self {
+        unsafe { incref_box(self.raw.cast(), 1) };
+        Self {
+            raw: self.raw,
+            host: self.host,
+        }
+    }
+}
+
+impl BodyHandle {
+    fn state(&self) -> &BodyState {
+        unsafe { body_state_from_handle(self.raw) }
+    }
+
+    /// Retain and transfer one independent Roc reference into Server.Request.
+    pub(crate) fn retain_for_roc(&self) -> *mut u64 {
+        unsafe { incref_box(self.raw.cast(), 1) };
+        self.raw
+    }
+
+    pub(crate) fn expire(&self) {
+        self.state()
+            .stop(Terminal::Error(BodyError::RequestFinished));
+    }
+
+    #[cfg(test)]
+    fn cancel(&self) {
+        self.state().stop(Terminal::Error(BodyError::Cancelled));
+    }
+
+    #[cfg(test)]
+    fn read(&self, requested_limit: u64) -> Result<ReadResult, BodyError> {
+        self.state().read(requested_limit)
+    }
+
+    #[cfg(test)]
+    fn read_all(&self, requested_limit: u64) -> Result<RocListWith<u8, false>, BodyError> {
+        self.state()
+            .read_all(requested_limit, unsafe { &*self.host })
+    }
+}
+
+impl Drop for BodyHandle {
+    fn drop(&mut self) {
+        unsafe {
+            decref_box_with(
+                self.raw.cast() as RocBox,
+                core::mem::align_of::<u64>(),
+                false,
+                None,
+                &*self.host,
+            );
+        }
+    }
+}
+
 pub(crate) struct BodyRegistration {
-    pub(crate) id: BodyId,
+    pub(crate) handle: BodyHandle,
     pub(crate) pump: BodyPump,
 }
 
-/// Owns all bodies whose Roc request handlers are still active.
-pub(crate) struct BodyRegistry {
-    next_id: AtomicU64,
-    bodies: Mutex<HashMap<BodyId, Arc<BodyState>>>,
+pub(crate) fn register(
+    hard_limit: u64,
     channel_capacity: usize,
-}
+    declared_length: Option<u64>,
+    host: &'static RocHost,
+) -> BodyRegistration {
+    assert!(
+        channel_capacity > 0,
+        "request body channel capacity must be nonzero"
+    );
+    let (sender, receiver) = mpsc::channel(channel_capacity);
+    let (cancel_sender, cancelled) = watch::channel(false);
+    let state = BodyState {
+        receiver: Mutex::new(receiver),
+        wake_sender: sender.clone(),
+        cancel_sender,
+        terminal: Mutex::new(None),
+        hard_limit,
+        declared_length,
+        narrow_limit: AtomicU64::new(hard_limit),
+        delivered: AtomicU64::new(0),
+    };
 
-impl BodyRegistry {
-    pub(crate) fn new(channel_capacity: usize) -> Self {
-        assert!(
-            channel_capacity > 0,
-            "request body channel capacity must be nonzero"
-        );
-        Self {
-            next_id: AtomicU64::new(1),
-            bodies: Mutex::new(HashMap::new()),
-            channel_capacity,
-        }
-    }
-
-    pub(crate) fn register(&self, hard_limit: u64) -> BodyRegistration {
-        let id = self
-            .next_id
-            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |id| id.checked_add(1))
-            .expect("request body ID space exhausted");
-        let (sender, receiver) = mpsc::channel(self.channel_capacity);
-        let (cancel_sender, cancelled) = watch::channel(false);
-        let state = Arc::new(BodyState {
-            receiver: Mutex::new(receiver),
-            wake_sender: sender.clone(),
-            cancel_sender,
-            terminal: Mutex::new(None),
-            hard_limit,
-            narrow_limit: AtomicU64::new(hard_limit),
-            delivered: AtomicU64::new(0),
+    let payload_offset = body_box_header_bytes();
+    let allocation_size = payload_offset
+        .checked_add(core::mem::size_of::<BodyPayload>())
+        .expect("request body allocation size overflow");
+    let allocation_alignment = core::mem::align_of::<BodyPayload>()
+        .max(core::mem::align_of::<usize>())
+        .max(core::mem::align_of::<u64>());
+    let base = unsafe {
+        roc_alloc::allocate_host_owned(
+            allocation_size,
+            allocation_alignment,
+            AllocationKind::RequestBody,
+            drop_body_allocation,
+        )
+    };
+    let payload = unsafe { body_payload_from_base(base) };
+    let payload_bytes = payload.cast::<u8>();
+    let refcount = unsafe {
+        payload_bytes
+            .sub(core::mem::size_of::<isize>())
+            .cast::<AtomicIsize>()
+    };
+    unsafe {
+        refcount.write(AtomicIsize::new(1));
+        payload.write(BodyPayload {
+            token: REQUEST_BODY_TOKEN,
+            state,
         });
-        let old = self
-            .bodies
-            .lock()
-            .expect("request body registry mutex poisoned")
-            .insert(id, state);
-        debug_assert!(old.is_none());
-
-        BodyRegistration {
-            id,
-            pump: BodyPump {
-                sender,
-                cancelled,
-                hard_limit,
-            },
-        }
     }
 
-    fn get(&self, id: BodyId) -> Result<Arc<BodyState>, BodyError> {
-        self.bodies
-            .lock()
-            .expect("request body registry mutex poisoned")
-            .get(&id)
-            .cloned()
-            .ok_or(BodyError::RequestFinished)
-    }
-
-    pub(crate) fn read(&self, id: BodyId, requested_limit: u64) -> Result<ReadResult, BodyError> {
-        self.get(id)?.read(requested_limit)
-    }
-
-    pub(crate) fn read_all(&self, id: BodyId, requested_limit: u64) -> Result<Vec<u8>, BodyError> {
-        self.get(id)?.read_all(requested_limit)
-    }
-
-    pub(crate) fn expire(&self, id: BodyId) {
-        if let Some(state) = self
-            .bodies
-            .lock()
-            .expect("request body registry mutex poisoned")
-            .remove(&id)
-        {
-            state.stop(Terminal::Error(BodyError::RequestFinished));
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn cancel(&self, id: BodyId) {
-        if let Some(state) = self
-            .bodies
-            .lock()
-            .expect("request body registry mutex poisoned")
-            .remove(&id)
-        {
-            state.stop(Terminal::Error(BodyError::Cancelled));
-        }
-    }
-
-    pub(crate) fn cancel_all(&self) {
-        let states: Vec<_> = self
-            .bodies
-            .lock()
-            .expect("request body registry mutex poisoned")
-            .drain()
-            .map(|(_, state)| state)
-            .collect();
-        for state in states {
-            state.stop(Terminal::Error(BodyError::Cancelled));
-        }
-    }
-
-    #[cfg(test)]
-    fn len(&self) -> usize {
-        self.bodies
-            .lock()
-            .expect("request body registry mutex poisoned")
-            .len()
+    BodyRegistration {
+        handle: BodyHandle {
+            raw: payload.cast::<u64>(),
+            host,
+        },
+        pump: BodyPump {
+            sender,
+            cancelled,
+            hard_limit,
+        },
     }
 }
 
-fn current_registry() -> Result<Arc<BodyRegistry>, BodyError> {
-    global_registry()
-        .lock()
-        .expect("request body global registry mutex poisoned")
-        .clone()
-        .ok_or(BodyError::RequestFinished)
+struct OwnedBodyArgument {
+    raw: *mut u64,
+    host: &'static RocHost,
+}
+
+impl OwnedBodyArgument {
+    fn new(raw: *mut u64, host: &'static RocHost) -> Self {
+        // Validate immediately while this hosted argument owns a live Roc ref.
+        let _ = unsafe { body_state_from_handle(raw) };
+        Self { raw, host }
+    }
+
+    fn state(&self) -> &BodyState {
+        unsafe { body_state_from_handle(self.raw) }
+    }
+}
+
+impl Drop for OwnedBodyArgument {
+    fn drop(&mut self) {
+        unsafe {
+            decref_box_with(
+                self.raw.cast(),
+                core::mem::align_of::<u64>(),
+                false,
+                None,
+                self.host,
+            );
+        }
+    }
+}
+
+#[repr(C)]
+struct BytesBacking {
+    bytes: Bytes,
+    original_ptr: *const u8,
+    original_len: usize,
+}
+
+unsafe fn drop_seamless_bytes(base: *mut u8) {
+    let owner_ptr = unsafe { base.add(core::mem::size_of::<isize>()) };
+    let refcount = base.cast::<AtomicIsize>();
+    if !roc_alloc::is_finalized_roc_refcount(unsafe { (*refcount).load(Ordering::Acquire) }) {
+        eprintln!("fatal: seamless Bytes finalizer ran before final Roc ARC release");
+        std::process::abort();
+    }
+    let owner = owner_ptr.cast::<BytesBacking>();
+    let retained = unsafe { (*owner).original_len };
+    if unsafe { (*owner).bytes.as_ptr() } != unsafe { (*owner).original_ptr }
+        || unsafe { (*owner).bytes.len() } != retained
+    {
+        eprintln!("fatal: immutable seamless Bytes owner metadata changed");
+        std::process::abort();
+    }
+    unsafe { owner.drop_in_place() };
+    let previous = RETAINED_PAYLOAD_BYTES.fetch_sub(retained, Ordering::AcqRel);
+    if previous < retained {
+        eprintln!("fatal: seamless retained-byte accounting underflow");
+        std::process::abort();
+    }
+}
+
+fn seamless_chunk(bytes: Bytes) -> RocListWith<u8, false> {
+    if bytes.is_empty() {
+        return RocListWith::empty();
+    }
+    assert!(
+        core::mem::align_of::<BytesBacking>() <= core::mem::align_of::<usize>(),
+        "Bytes backing alignment exceeds Roc ARC word alignment"
+    );
+    let payload_ptr = bytes.as_ptr().cast_mut();
+    let payload_len = bytes.len();
+    let allocation_size = core::mem::size_of::<isize>()
+        .checked_add(core::mem::size_of::<BytesBacking>())
+        .expect("seamless Bytes allocation size overflow");
+    let base = unsafe {
+        roc_alloc::allocate_host_owned(
+            allocation_size,
+            core::mem::align_of::<usize>(),
+            AllocationKind::SeamlessBytes,
+            drop_seamless_bytes,
+        )
+    };
+    let owner_ptr = unsafe { base.add(core::mem::size_of::<isize>()) };
+    unsafe {
+        base.cast::<AtomicIsize>().write(AtomicIsize::new(1));
+        owner_ptr.cast::<BytesBacking>().write(BytesBacking {
+            bytes,
+            original_ptr: payload_ptr,
+            original_len: payload_len,
+        });
+    }
+    RETAINED_PAYLOAD_BYTES.fetch_add(payload_len, Ordering::AcqRel);
+    SHARED_PAYLOAD_BYTES.fetch_add(payload_len, Ordering::AcqRel);
+
+    let result = RocListWith {
+        elements: payload_ptr,
+        length: payload_len,
+        capacity_or_alloc_ptr: (owner_ptr as usize) | SEAMLESS_SLICE_TAG,
+    };
+    validate_seamless_range(&result);
+    result
+}
+
+#[cfg(test)]
+pub(crate) fn seamless_chunk_for_test(bytes: Bytes) -> RocListWith<u8, false> {
+    seamless_chunk(bytes)
+}
+
+fn validate_seamless_range(list: &RocListWith<u8, false>) {
+    if list.is_empty() {
+        return;
+    }
+    if !list.is_seamless_slice() {
+        eprintln!("fatal: request-body chunk was not represented as a seamless list");
+        std::process::abort();
+    }
+    let owner_address = list.capacity_or_alloc_ptr & !SEAMLESS_SLICE_TAG;
+    let owner_ptr = owner_address as *mut BytesBacking;
+    let base = unsafe { owner_ptr.cast::<u8>().sub(core::mem::size_of::<isize>()) };
+    unsafe {
+        roc_alloc::validate_host_owned(
+            base,
+            AllocationKind::SeamlessBytes,
+            core::mem::size_of::<isize>() + core::mem::size_of::<BytesBacking>(),
+            core::mem::align_of::<usize>(),
+        );
+    }
+    let owner = unsafe { &*owner_ptr };
+    let backing_start = owner.original_ptr as usize;
+    let backing_end = backing_start
+        .checked_add(owner.original_len)
+        .unwrap_or_else(|| {
+            eprintln!("fatal: seamless Bytes backing range overflow");
+            std::process::abort();
+        });
+    let slice_start = list.elements as usize;
+    let slice_end = slice_start.checked_add(list.length).unwrap_or_else(|| {
+        eprintln!("fatal: seamless request-body slice range overflow");
+        std::process::abort();
+    });
+    if slice_start < backing_start || slice_end > backing_end {
+        eprintln!("fatal: seamless request-body slice escapes its Bytes backing");
+        std::process::abort();
+    }
+}
+
+/// Validate the allocation and bounds of a seamless byte list returned by Roc.
+pub(crate) fn validate_response_body(list: &RocListWith<u8, false>) {
+    if list.is_empty() || !list.is_seamless_slice() {
+        return;
+    }
+    let allocation_ptr = (list.capacity_or_alloc_ptr & !SEAMLESS_SLICE_TAG) as *mut u8;
+    let refcount = unsafe {
+        &*allocation_ptr
+            .sub(core::mem::size_of::<isize>())
+            .cast::<AtomicIsize>()
+    };
+    if refcount.load(Ordering::Acquire) == 0 {
+        // Roc static data is immutable for the process lifetime and does not
+        // have a host allocation header to validate.
+        return;
+    }
+    let base = unsafe { allocation_ptr.sub(core::mem::size_of::<isize>()) };
+    if crate::request_parts::contains_address(base.cast()) {
+        crate::request_parts::validate_seamless_range(allocation_ptr, list.elements, list.length);
+        return;
+    }
+    match unsafe { roc_alloc::allocation_kind(base) } {
+        AllocationKind::SeamlessBytes => validate_seamless_range(list),
+        AllocationKind::Ordinary => unsafe {
+            roc_alloc::validate_range(base, list.elements, list.length);
+        },
+        AllocationKind::RequestBody => {
+            eprintln!("fatal: response bytes referred to a request-body capability allocation");
+            std::process::abort();
+        }
+    }
+}
+
+struct RocBytesBuilder<'a> {
+    base: *mut u8,
+    length: usize,
+    capacity: usize,
+    maximum_capacity: usize,
+    host: &'a RocHost,
+}
+
+impl<'a> RocBytesBuilder<'a> {
+    fn new(capacity_hint: u64, maximum_capacity: u64, host: &'a RocHost) -> Self {
+        let target_maximum = usize::try_from(maximum_capacity).unwrap_or(usize::MAX);
+        let initial = usize::try_from(capacity_hint)
+            .unwrap_or(usize::MAX)
+            .min(target_maximum);
+        let mut result = Self {
+            base: core::ptr::null_mut(),
+            length: 0,
+            capacity: 0,
+            maximum_capacity: target_maximum,
+            host,
+        };
+        if initial != 0 {
+            result.reserve_exact(initial);
+        }
+        result
+    }
+
+    fn reserve_exact(&mut self, capacity: usize) {
+        assert!(capacity <= self.maximum_capacity);
+        let header_bytes = core::mem::size_of::<isize>();
+        let allocation_size = header_bytes
+            .checked_add(capacity)
+            .expect("Roc request-body list allocation size overflow");
+        unsafe {
+            if self.base.is_null() {
+                self.base = self
+                    .host
+                    .alloc(core::mem::align_of::<usize>(), allocation_size)
+                    .cast();
+                self.base.cast::<AtomicIsize>().write(AtomicIsize::new(1));
+            } else {
+                self.base = self
+                    .host
+                    .realloc(
+                        self.base.cast(),
+                        core::mem::align_of::<usize>(),
+                        allocation_size,
+                    )
+                    .cast();
+            }
+        }
+        self.capacity = capacity;
+    }
+
+    fn extend(&mut self, bytes: &[u8]) -> Result<(), BodyError> {
+        let required = self
+            .length
+            .checked_add(bytes.len())
+            .unwrap_or(self.maximum_capacity.saturating_add(1));
+        if required > self.maximum_capacity {
+            return Err(BodyError::TooLarge {
+                limit_bytes: self.maximum_capacity as u64,
+                received_at_least: required as u64,
+            });
+        }
+        if required > self.capacity {
+            let doubled = self.capacity.saturating_mul(2).max(1);
+            self.reserve_exact(required.max(doubled).min(self.maximum_capacity));
+        }
+        unsafe {
+            self.base
+                .add(core::mem::size_of::<isize>() + self.length)
+                .copy_from_nonoverlapping(bytes.as_ptr(), bytes.len());
+        }
+        self.length = required;
+        COPIED_PAYLOAD_BYTES.fetch_add(bytes.len(), Ordering::AcqRel);
+        Ok(())
+    }
+
+    fn finish(mut self) -> RocListWith<u8, false> {
+        if self.length == 0 {
+            return RocListWith::empty();
+        }
+        let data = unsafe { self.base.add(core::mem::size_of::<isize>()) };
+        let result = RocListWith {
+            elements: data,
+            length: self.length,
+            capacity_or_alloc_ptr: self
+                .capacity
+                .checked_shl(1)
+                .expect("Roc list capacity does not fit shifted representation"),
+        };
+        self.base = core::ptr::null_mut();
+        result
+    }
+}
+
+impl Drop for RocBytesBuilder<'_> {
+    fn drop(&mut self) {
+        if !self.base.is_null() {
+            unsafe {
+                self.host
+                    .dealloc(self.base.cast(), core::mem::align_of::<usize>());
+            }
+        }
+    }
 }
 
 fn to_host_error(error: BodyError) -> BodyReadError {
-    let roc_host = roc_host();
+    let host = roc_host();
     match error {
         BodyError::TooLarge {
             limit_bytes,
@@ -453,7 +847,7 @@ fn to_host_error(error: BodyError) -> BodyReadError {
         }
         BodyError::InvalidBody(detail) => body_error(
             BodyReadErrorTag::InvalidBody,
-            Some(RocStr::from_str(&detail, roc_host)),
+            Some(RocStr::from_str(&detail, host)),
             None,
         ),
         BodyError::RequestFinished => body_error(BodyReadErrorTag::RequestFinished, None, None),
@@ -463,22 +857,26 @@ fn to_host_error(error: BodyError) -> BodyReadError {
 }
 
 #[no_mangle]
-pub extern "C" fn hosted_request_body_read(id: u64, requested_limit: u64) -> BodyReadResult {
-    match current_registry().and_then(|registry| registry.read(id, requested_limit)) {
-        Ok(ReadResult::Chunk(bytes)) => {
-            body_read_chunk(unsafe { RocListWith::<u8, false>::from_slice(&bytes, roc_host()) })
-        }
+pub extern "C" fn hosted_request_body_read(
+    handle: *mut u64,
+    requested_limit: u64,
+) -> BodyReadResult {
+    let body = OwnedBodyArgument::new(handle, roc_host());
+    match body.state().read(requested_limit) {
+        Ok(ReadResult::Chunk(bytes)) => body_read_chunk(seamless_chunk(bytes)),
         Ok(ReadResult::End) => body_read_end(),
         Err(error) => body_read_error(to_host_error(error)),
     }
 }
 
 #[no_mangle]
-pub extern "C" fn hosted_request_body_read_all(id: u64, requested_limit: u64) -> BodyReadAllResult {
-    match current_registry().and_then(|registry| registry.read_all(id, requested_limit)) {
-        Ok(bytes) => {
-            body_read_all_ok(unsafe { RocListWith::<u8, false>::from_slice(&bytes, roc_host()) })
-        }
+pub extern "C" fn hosted_request_body_read_all(
+    handle: *mut u64,
+    requested_limit: u64,
+) -> BodyReadAllResult {
+    let body = OwnedBodyArgument::new(handle, roc_host());
+    match body.state().read_all(requested_limit, roc_host()) {
+        Ok(bytes) => body_read_all_ok(bytes),
         Err(error) => body_read_all_error(to_host_error(error)),
     }
 }
@@ -486,29 +884,33 @@ pub extern "C" fn hosted_request_body_read_all(id: u64, requested_limit: u64) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::roc_platform_abi::{make_roc_host, RocHost};
     use futures::stream;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
     use std::thread;
     use std::time::{Duration, Instant};
+
+    fn test_host() -> &'static RocHost {
+        let mut host = make_roc_host(core::ptr::null_mut());
+        host.roc_alloc = roc_alloc::roc_alloc;
+        host.roc_dealloc = roc_alloc::roc_dealloc;
+        host.roc_realloc = roc_alloc::roc_realloc;
+        Box::leak(Box::new(host))
+    }
 
     fn bytes(value: &'static [u8]) -> Result<Bytes, PumpError> {
         Ok(Bytes::from_static(value))
     }
 
-    fn read_on_thread(
-        registry: Arc<BodyRegistry>,
-        id: BodyId,
-        limit: u64,
-    ) -> Result<ReadResult, BodyError> {
-        thread::spawn(move || registry.read(id, limit))
-            .join()
-            .expect("reader thread panicked")
+    fn new_registration(hard_limit: u64, declared_length: Option<u64>) -> BodyRegistration {
+        register(hard_limit, 1, declared_length, test_host())
     }
 
-    fn wait_until_reader_is_blocking(registry: &BodyRegistry, id: BodyId) {
-        let state = registry.get(id).expect("registered body missing");
+    fn wait_until_reader_is_blocking(handle: &BodyHandle) {
         let deadline = Instant::now() + Duration::from_secs(1);
         loop {
-            match state.receiver.try_lock() {
+            match handle.state().receiver.try_lock() {
                 Err(TryLockError::WouldBlock) => return,
                 Err(TryLockError::Poisoned(_)) => panic!("reader mutex poisoned"),
                 Ok(guard) => drop(guard),
@@ -517,10 +919,21 @@ mod tests {
                 Instant::now() < deadline,
                 "reader did not begin blocking within one second"
             );
-            // Avoid repeatedly reacquiring the mutex before the new reader
-            // thread gets a scheduling turn.
             thread::sleep(Duration::from_millis(1));
         }
+    }
+
+    fn owned_list_bytes(list: RocListWith<u8, false>, host: &RocHost) -> Vec<u8> {
+        let result = list.as_slice().to_vec();
+        unsafe { list.decref(host) };
+        result
+    }
+
+    fn read_on_thread(handle: &BodyHandle, requested_limit: u64) -> Result<ReadResult, BodyError> {
+        let handle = handle.clone();
+        thread::spawn(move || handle.read(requested_limit))
+            .join()
+            .expect("reader thread panicked")
     }
 
     async fn pump_and_read_all(
@@ -528,12 +941,15 @@ mod tests {
         requested_limit: u64,
         frames: Vec<Result<Bytes, PumpError>>,
         chunk_size: usize,
+        declared_length: Option<u64>,
     ) -> Result<Vec<u8>, BodyError> {
-        let registry = Arc::new(BodyRegistry::new(1));
-        let registration = registry.register(hard_limit);
-        let id = registration.id;
-        let reader_registry = Arc::clone(&registry);
-        let reader = thread::spawn(move || reader_registry.read_all(id, requested_limit));
+        let registration = new_registration(hard_limit, declared_length);
+        let reader_handle = registration.handle.clone();
+        let reader = thread::spawn(move || {
+            reader_handle
+                .read_all(requested_limit)
+                .map(|list| owned_list_bytes(list, unsafe { &*reader_handle.host }))
+        });
         registration
             .pump
             .run(stream::iter(frames), chunk_size)
@@ -542,28 +958,24 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn exact_hard_limit_succeeds() {
-        let result = pump_and_read_all(5, 5, vec![bytes(b"abc"), bytes(b"de")], 2).await;
-        assert_eq!(result, Ok(b"abcde".to_vec()));
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn one_byte_over_hard_limit_fails() {
-        let result = pump_and_read_all(5, 5, vec![bytes(b"abc"), bytes(b"def")], 8).await;
+    async fn limits_and_fragmented_read_all_are_preserved() {
         assert_eq!(
-            result,
+            pump_and_read_all(5, 5, vec![bytes(b"abc"), bytes(b"de")], 2, Some(5),).await,
+            Ok(b"abcde".to_vec())
+        );
+        assert_eq!(
+            pump_and_read_all(5, 5, vec![bytes(b"abc"), bytes(b"def")], 8, None,).await,
             Err(BodyError::TooLarge {
                 limit_bytes: 5,
                 received_at_least: 6,
             })
         );
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn zero_limit_accepts_empty_and_rejects_any_data() {
-        assert_eq!(pump_and_read_all(0, 0, vec![], 8).await, Ok(Vec::new()));
         assert_eq!(
-            pump_and_read_all(0, 0, vec![bytes(b"x")], 8).await,
+            pump_and_read_all(0, 0, vec![], 8, None).await,
+            Ok(Vec::new())
+        );
+        assert_eq!(
+            pump_and_read_all(0, 0, vec![bytes(b"x")], 8, None).await,
             Err(BodyError::TooLarge {
                 limit_bytes: 0,
                 received_at_least: 1,
@@ -572,49 +984,15 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn narrowed_limit_is_enforced_across_frames() {
-        let result = pump_and_read_all(100, 4, vec![bytes(b"abc"), bytes(b"de")], 8).await;
-        assert_eq!(
-            result,
-            Err(BodyError::TooLarge {
-                limit_bytes: 4,
-                received_at_least: 5,
-            })
-        );
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn partial_read_then_read_all_returns_the_remainder() {
-        let registry = Arc::new(BodyRegistry::new(1));
-        let registration = registry.register(100);
-        let id = registration.id;
-        let reader_registry = Arc::clone(&registry);
+    async fn narrowed_limits_and_chunk_splitting_remain_stable() {
+        let registration = new_registration(100, None);
+        let reader_handle = registration.handle.clone();
         let reader = thread::spawn(move || {
             assert_eq!(
-                reader_registry.read(id, 100),
-                Ok(ReadResult::Chunk(b"ab".to_vec()))
+                reader_handle.read(3),
+                Ok(ReadResult::Chunk(Bytes::from_static(b"ab")))
             );
-            reader_registry.read_all(id, 100)
-        });
-        registration
-            .pump
-            .run(stream::iter(vec![bytes(b"abcdef")]), 2)
-            .await;
-        assert_eq!(reader.join().unwrap(), Ok(b"cdef".to_vec()));
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn a_limit_cannot_be_widened_after_a_narrow_read() {
-        let registry = Arc::new(BodyRegistry::new(1));
-        let registration = registry.register(100);
-        let id = registration.id;
-        let reader_registry = Arc::clone(&registry);
-        let reader = thread::spawn(move || {
-            assert_eq!(
-                reader_registry.read(id, 3),
-                Ok(ReadResult::Chunk(b"ab".to_vec()))
-            );
-            reader_registry.read(id, 100)
+            reader_handle.read(100)
         });
         registration
             .pump
@@ -627,20 +1005,17 @@ mod tests {
                 received_at_least: 4,
             })
         );
-    }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn narrowing_below_already_delivered_bytes_fails_immediately() {
-        let registry = Arc::new(BodyRegistry::new(1));
-        let registration = registry.register(100);
-        let id = registration.id;
-        let reader_registry = Arc::clone(&registry);
+        let registration = new_registration(100, None);
+        let reader_handle = registration.handle.clone();
         let reader = thread::spawn(move || {
             assert_eq!(
-                reader_registry.read(id, 100),
-                Ok(ReadResult::Chunk(b"abcdef".to_vec()))
+                reader_handle.read(100),
+                Ok(ReadResult::Chunk(Bytes::from_static(b"abcdef")))
             );
-            reader_registry.read_all(id, 3)
+            reader_handle
+                .read_all(3)
+                .map(|list| owned_list_bytes(list, unsafe { &*reader_handle.host }))
         });
         registration
             .pump
@@ -653,18 +1028,13 @@ mod tests {
                 received_at_least: 6,
             })
         );
-    }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn empty_frames_are_ignored_and_frames_are_split() {
-        let registry = Arc::new(BodyRegistry::new(1));
-        let registration = registry.register(100);
-        let id = registration.id;
-        let reader_registry = Arc::clone(&registry);
+        let registration = new_registration(100, None);
+        let reader_handle = registration.handle.clone();
         let reader = thread::spawn(move || {
             let mut chunks = Vec::new();
             loop {
-                match reader_registry.read(id, 100).unwrap() {
+                match reader_handle.read(100).unwrap() {
                     ReadResult::Chunk(chunk) => chunks.push(chunk),
                     ReadResult::End => return chunks,
                 }
@@ -676,31 +1046,47 @@ mod tests {
             .await;
         assert_eq!(
             reader.join().unwrap(),
-            vec![b"abc".to_vec(), b"def".to_vec(), b"g".to_vec()]
+            vec![
+                Bytes::from_static(b"abc"),
+                Bytes::from_static(b"def"),
+                Bytes::from_static(b"g"),
+            ]
         );
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn end_is_stable_across_repeated_reads() {
-        let registry = Arc::new(BodyRegistry::new(1));
-        let registration = registry.register(10);
-        let id = registration.id;
+    async fn partial_read_then_read_all_returns_the_remainder() {
+        let registration = new_registration(100, Some(6));
+        let reader_handle = registration.handle.clone();
+        let reader = thread::spawn(move || {
+            assert_eq!(
+                reader_handle.read(100),
+                Ok(ReadResult::Chunk(Bytes::from_static(b"ab")))
+            );
+            let list = reader_handle.read_all(100).unwrap();
+            owned_list_bytes(list, unsafe { &*reader_handle.host })
+        });
+        registration
+            .pump
+            .run(stream::iter(vec![bytes(b"abcdef")]), 2)
+            .await;
+        assert_eq!(reader.join().unwrap(), b"cdef");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn end_and_source_errors_are_stable() {
+        let registration = new_registration(10, None);
         registration.pump.run(stream::empty(), 4).await;
         assert_eq!(
-            read_on_thread(Arc::clone(&registry), id, 10),
+            read_on_thread(&registration.handle, 10),
             Ok(ReadResult::End)
         );
         assert_eq!(
-            read_on_thread(Arc::clone(&registry), id, 10),
+            read_on_thread(&registration.handle, 10),
             Ok(ReadResult::End)
         );
-    }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn source_errors_are_typed_and_stable() {
-        let registry = Arc::new(BodyRegistry::new(1));
-        let registration = registry.register(10);
-        let id = registration.id;
+        let registration = new_registration(10, None);
         registration
             .pump
             .run(
@@ -709,70 +1095,57 @@ mod tests {
             )
             .await;
         let expected = Err(BodyError::InvalidBody("bad frame".into()));
-        assert_eq!(read_on_thread(Arc::clone(&registry), id, 10), expected);
-        let expected = Err(BodyError::InvalidBody("bad frame".into()));
-        assert_eq!(read_on_thread(Arc::clone(&registry), id, 10), expected);
-    }
+        assert_eq!(read_on_thread(&registration.handle, 10), expected);
+        assert_eq!(
+            read_on_thread(&registration.handle, 10),
+            Err(BodyError::InvalidBody("bad frame".into()))
+        );
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn client_disconnect_is_preserved() {
-        let result = pump_and_read_all(10, 10, vec![Err(PumpError::ClientDisconnected)], 4).await;
-        assert_eq!(result, Err(BodyError::ClientDisconnected));
-    }
-
-    #[test]
-    fn stale_ids_fail_without_touching_another_body() {
-        let registry = BodyRegistry::new(1);
-        let first = registry.register(10);
-        registry.expire(first.id);
-        let second = registry.register(10);
-        assert_ne!(first.id, second.id);
-        assert_eq!(registry.read(first.id, 10), Err(BodyError::RequestFinished));
-        registry.expire(second.id);
+        let registration = new_registration(10, None);
+        registration
+            .pump
+            .run(stream::iter(vec![Err(PumpError::ClientDisconnected)]), 4)
+            .await;
+        assert_eq!(
+            read_on_thread(&registration.handle, 10),
+            Err(BodyError::ClientDisconnected)
+        );
     }
 
     #[test]
-    fn expiry_wakes_a_blocked_reader() {
-        let registry = Arc::new(BodyRegistry::new(1));
-        let registration = registry.register(10);
-        let id = registration.id;
-        let reader_registry = Arc::clone(&registry);
-        let reader = thread::spawn(move || reader_registry.read(id, 10));
-        wait_until_reader_is_blocking(&registry, id);
-        registry.expire(id);
-        assert_eq!(reader.join().unwrap(), Err(BodyError::RequestFinished));
-    }
-
-    #[test]
-    fn cancellation_wakes_a_blocked_reader() {
-        let registry = Arc::new(BodyRegistry::new(1));
-        let registration = registry.register(10);
-        let id = registration.id;
-        let reader_registry = Arc::clone(&registry);
-        let reader = thread::spawn(move || reader_registry.read(id, 10));
-        wait_until_reader_is_blocking(&registry, id);
-        registry.cancel(id);
-        assert_eq!(reader.join().unwrap(), Err(BodyError::Cancelled));
+    fn expiry_and_cancellation_wake_blocked_readers() {
+        for (cancel, expected) in [
+            (false, BodyError::RequestFinished),
+            (true, BodyError::Cancelled),
+        ] {
+            let registration = new_registration(10, None);
+            let reader_handle = registration.handle.clone();
+            let reader = thread::spawn(move || reader_handle.read(10));
+            wait_until_reader_is_blocking(&registration.handle);
+            if cancel {
+                registration.handle.cancel();
+            } else {
+                registration.handle.expire();
+            }
+            assert_eq!(reader.join().unwrap(), Err(expected));
+        }
     }
 
     #[test]
     fn a_second_simultaneous_reader_is_rejected() {
-        let registry = Arc::new(BodyRegistry::new(1));
-        let registration = registry.register(10);
-        let id = registration.id;
-        let first_registry = Arc::clone(&registry);
-        let first = thread::spawn(move || first_registry.read(id, 10));
-        wait_until_reader_is_blocking(&registry, id);
-        assert_eq!(registry.read(id, 10), Err(BodyError::ConcurrentRead));
-        registry.cancel(id);
+        let registration = new_registration(10, None);
+        let first_handle = registration.handle.clone();
+        let first = thread::spawn(move || first_handle.read(10));
+        wait_until_reader_is_blocking(&registration.handle);
+        assert_eq!(registration.handle.read(10), Err(BodyError::ConcurrentRead));
+        registration.handle.cancel();
         assert_eq!(first.join().unwrap(), Err(BodyError::Cancelled));
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn bounded_channel_backpressures_the_pump() {
-        let registry = Arc::new(BodyRegistry::new(1));
-        let registration = registry.register(100);
-        let id = registration.id;
+    async fn bounded_channel_backpressures_and_cancellation_stops_the_pump() {
+        let registration = new_registration(100, None);
+        let handle = registration.handle;
         let pump = tokio::spawn(
             registration
                 .pump
@@ -781,48 +1154,151 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(10)).await;
         assert!(!pump.is_finished());
         assert_eq!(
-            read_on_thread(Arc::clone(&registry), id, 100),
-            Ok(ReadResult::Chunk(b"a".to_vec()))
+            thread::spawn({
+                let handle = handle.clone();
+                move || handle.read(100)
+            })
+            .join()
+            .unwrap(),
+            Ok(ReadResult::Chunk(Bytes::from_static(b"a")))
         );
-        registry.cancel(id);
+        handle.cancel();
         tokio::time::timeout(Duration::from_secs(1), pump)
             .await
             .expect("cancelled pump did not stop")
             .expect("pump task panicked");
-    }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn cancellation_stops_a_pump_waiting_for_network_input() {
-        let registry = BodyRegistry::new(1);
-        let registration = registry.register(100);
-        let id = registration.id;
-        let pump = tokio::spawn(registration.pump.run(stream::pending(), 8));
-        tokio::task::yield_now().await;
-        registry.cancel(id);
+        let registration = new_registration(100, None);
+        let handle = registration.handle;
+        let pump = tokio::spawn(registration.pump.run(stream::pending(), 1));
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(!pump.is_finished());
+        handle.cancel();
         tokio::time::timeout(Duration::from_secs(1), pump)
             .await
-            .expect("cancelled pending pump did not stop")
+            .expect("cancelled network wait did not stop")
             .expect("pump task panicked");
     }
 
-    #[test]
-    fn cancel_all_wakes_every_reader_and_clears_the_registry() {
-        let registry = Arc::new(BodyRegistry::new(1));
-        let first = registry.register(10);
-        let second = registry.register(10);
-        let readers: Vec<_> = [first.id, second.id]
-            .into_iter()
-            .map(|id| {
-                let registry = Arc::clone(&registry);
-                thread::spawn(move || registry.read(id, 10))
+    #[tokio::test(flavor = "current_thread")]
+    async fn concurrent_bodies_keep_independent_state() {
+        let first = new_registration(100, Some(5));
+        let second = new_registration(100, Some(6));
+        let first_handle = first.handle.clone();
+        let second_handle = second.handle.clone();
+        let first_reader = thread::spawn(move || {
+            owned_list_bytes(first_handle.read_all(100).unwrap(), unsafe {
+                &*first_handle.host
             })
-            .collect();
-        wait_until_reader_is_blocking(&registry, first.id);
-        wait_until_reader_is_blocking(&registry, second.id);
-        registry.cancel_all();
-        assert_eq!(registry.len(), 0);
-        for reader in readers {
-            assert_eq!(reader.join().unwrap(), Err(BodyError::Cancelled));
+        });
+        let second_reader = thread::spawn(move || {
+            owned_list_bytes(second_handle.read_all(100).unwrap(), unsafe {
+                &*second_handle.host
+            })
+        });
+
+        tokio::join!(
+            first.pump.run(stream::iter(vec![bytes(b"first")]), 2),
+            second.pump.run(stream::iter(vec![bytes(b"second")]), 2),
+        );
+        assert_eq!(first_reader.join().unwrap(), b"first");
+        assert_eq!(second_reader.join().unwrap(), b"second");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn split_chunk_keeps_the_original_bytes_pointer() {
+        let original = Bytes::from_static(b"0123456789");
+        let sliced = original.slice(3..8);
+        let expected_ptr = sliced.as_ptr();
+        let registration = new_registration(100, Some(5));
+        let reader_handle = registration.handle.clone();
+        let reader = thread::spawn(move || reader_handle.read(100).unwrap());
+        registration
+            .pump
+            .run(stream::iter(vec![Ok(sliced)]), 100)
+            .await;
+        let ReadResult::Chunk(chunk) = reader.join().unwrap() else {
+            panic!("expected chunk");
+        };
+        assert_eq!(chunk.as_ptr(), expected_ptr);
+        let list = seamless_chunk(chunk);
+        assert_eq!(list.elements, expected_ptr.cast_mut());
+        unsafe { list.decref(test_host()) };
+    }
+
+    struct DropOwner {
+        bytes: &'static [u8],
+        drops: Arc<AtomicUsize>,
+    }
+
+    impl AsRef<[u8]> for DropOwner {
+        fn as_ref(&self) -> &[u8] {
+            self.bytes
         }
+    }
+
+    impl Drop for DropOwner {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    #[test]
+    fn seamless_chunk_and_derived_slice_drop_owner_exactly_once() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let bytes = Bytes::from_owner(DropOwner {
+            bytes: b"abcdef",
+            drops: Arc::clone(&drops),
+        });
+        let list = seamless_chunk(bytes);
+        unsafe { list.incref(1) };
+        let derived = RocListWith {
+            elements: unsafe { list.elements.add(2) },
+            length: 3,
+            capacity_or_alloc_ptr: list.capacity_or_alloc_ptr,
+        };
+        validate_seamless_range(&derived);
+        unsafe { list.decref(test_host()) };
+        assert_eq!(drops.load(Ordering::Acquire), 0);
+        assert_eq!(derived.as_slice(), b"cde");
+        unsafe { derived.decref(test_host()) };
+        assert_eq!(drops.load(Ordering::Acquire), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn read_all_copies_each_fragment_directly_into_the_roc_list() {
+        let before = COPIED_PAYLOAD_BYTES.load(Ordering::Acquire);
+        let result = pump_and_read_all(
+            32,
+            32,
+            vec![bytes(b"abc"), bytes(b"def"), bytes(b"ghi")],
+            3,
+            Some(9),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result, b"abcdefghi");
+        assert!(
+            COPIED_PAYLOAD_BYTES.load(Ordering::Acquire) >= before + result.len(),
+            "instrumentation must observe each direct payload copy"
+        );
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn partial_read_all_allocation_is_released_on_error() {
+        let mut output = RocBytesBuilder::new(0, 3, test_host());
+        output.extend(b"abc").unwrap();
+        let allocation = output.base;
+        assert!(roc_alloc::debug_is_live(allocation));
+        assert_eq!(
+            output.extend(b"d"),
+            Err(BodyError::TooLarge {
+                limit_bytes: 3,
+                received_at_least: 4,
+            })
+        );
+        drop(output);
+        assert!(!roc_alloc::debug_is_live(allocation));
     }
 }

--- a/src/request_parts.rs
+++ b/src/request_parts.rs
@@ -139,6 +139,44 @@ pub(crate) fn contains_address(ptr: *const c_void) -> bool {
         .is_some_and(|heap| heap.contains_address(ptr))
 }
 
+pub(crate) fn validate_seamless_range(
+    allocation_ptr: *mut u8,
+    range_ptr: *const u8,
+    range_length: usize,
+) {
+    let resource = unsafe {
+        request_parts()
+            .get(allocation_ptr.cast::<u64>())
+            .unwrap_or_else(|_| {
+                eprintln!("fatal: stale request metadata seamless allocation");
+                std::process::abort();
+            })
+    };
+    let range_start = range_ptr as usize;
+    let range_end = range_start.checked_add(range_length).unwrap_or_else(|| {
+        eprintln!("fatal: request metadata seamless range overflow");
+        std::process::abort();
+    });
+    let contains = |bytes: &[u8]| {
+        let start = bytes.as_ptr() as usize;
+        let Some(end) = start.checked_add(bytes.len()) else {
+            return false;
+        };
+        start <= range_start && range_end <= end
+    };
+    let parts = &resource.parts;
+    let valid = contains(parts.method.as_str().as_bytes())
+        || contains(request_target(parts).as_bytes())
+        || parts
+            .headers
+            .iter()
+            .any(|(name, value)| contains(name.as_str().as_bytes()) || contains(value.as_bytes()));
+    if !valid {
+        eprintln!("fatal: seamless response slice escapes its request metadata backing");
+        std::process::abort();
+    }
+}
+
 pub(crate) fn active_backings() -> usize {
     REQUEST_PARTS.get().map_or(0, HostResourceHeap::active)
 }

--- a/src/roc_alloc.rs
+++ b/src/roc_alloc.rs
@@ -1,0 +1,561 @@
+//! Host-owned allocation protocol for ordinary Roc allocations and immutable
+//! seamless backings.
+//!
+//! Every allocation has a self-describing header immediately before the
+//! pointer visible to Roc's allocator ABI. Ordinary allocations have no
+//! finalizer. Host-owned allocations carry an immutable kind and finalizer, so
+//! final Roc ARC release can destroy their native owner without a registry.
+
+use core::alloc::Layout;
+use core::ffi::c_void;
+use core::ptr::NonNull;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::roc_platform_abi::RocHost;
+
+const ALLOCATION_MAGIC: u64 = 0x524f_4341_4c4c_4f43;
+const DEAD_ALLOCATION_MAGIC: u64 = 0x4445_4144_414c_4c4f;
+const ALLOCATION_VERSION: u32 = 1;
+const HEADER_CANARY: u64 = 0xa110_cafe_fade_1680;
+#[cfg(debug_assertions)]
+const TAIL_CANARY: u64 = 0xb0d1_cafe_fade_1680;
+const ROC_DEBUG_REFCOUNT_POISON: isize = if core::mem::size_of::<usize>() == 8 {
+    0xdead_beef_dead_beef_u64 as isize
+} else {
+    0xdead_beef_u32 as isize
+};
+
+#[cfg(debug_assertions)]
+const TAIL_BYTES: usize = core::mem::size_of::<u64>();
+#[cfg(not(debug_assertions))]
+const TAIL_BYTES: usize = 0;
+
+pub(crate) type AllocationDrop = unsafe fn(*mut u8);
+
+pub(crate) fn is_finalized_roc_refcount(value: isize) -> bool {
+    value == 0 || value == ROC_DEBUG_REFCOUNT_POISON
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub(crate) enum AllocationKind {
+    Ordinary = 1,
+    RequestBody = 2,
+    SeamlessBytes = 3,
+}
+
+impl AllocationKind {
+    fn from_raw(raw: u32) -> Option<Self> {
+        match raw {
+            1 => Some(Self::Ordinary),
+            2 => Some(Self::RequestBody),
+            3 => Some(Self::SeamlessBytes),
+            _ => None,
+        }
+    }
+}
+
+#[repr(C)]
+struct AllocationHeader {
+    magic: u64,
+    header_canary: u64,
+    requested_size: usize,
+    total_size: usize,
+    prefix_size: usize,
+    requested_alignment: usize,
+    drop_fn: Option<AllocationDrop>,
+    version: u32,
+    kind: u32,
+}
+
+const _: () = assert!(core::mem::size_of::<AllocationHeader>()
+    .is_multiple_of(core::mem::align_of::<AllocationHeader>()));
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct AllocationCounts {
+    pub active_request_bodies: usize,
+    pub request_body_high_water: usize,
+    pub active_seamless_backings: usize,
+    pub seamless_backing_high_water: usize,
+}
+
+static ACTIVE_REQUEST_BODIES: AtomicUsize = AtomicUsize::new(0);
+static REQUEST_BODY_HIGH_WATER: AtomicUsize = AtomicUsize::new(0);
+static ACTIVE_SEAMLESS_BACKINGS: AtomicUsize = AtomicUsize::new(0);
+static SEAMLESS_BACKING_HIGH_WATER: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(debug_assertions)]
+#[derive(Clone, Copy)]
+struct DebugAllocation {
+    kind: AllocationKind,
+    requested_size: usize,
+    requested_alignment: usize,
+}
+
+#[cfg(debug_assertions)]
+fn debug_allocations(
+) -> &'static std::sync::Mutex<std::collections::HashMap<usize, DebugAllocation>> {
+    use std::sync::{Mutex, OnceLock};
+
+    static LIVE: OnceLock<Mutex<std::collections::HashMap<usize, DebugAllocation>>> =
+        OnceLock::new();
+    LIVE.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+}
+
+fn fatal(message: &str) -> ! {
+    eprintln!("fatal: Roc allocation invariant failed: {message}");
+    std::process::abort();
+}
+
+fn checked_add(left: usize, right: usize, context: &str) -> usize {
+    left.checked_add(right).unwrap_or_else(|| fatal(context))
+}
+
+fn normalized_alignment(alignment: usize) -> usize {
+    let alignment = alignment
+        .max(core::mem::align_of::<usize>())
+        .max(core::mem::align_of::<AllocationHeader>());
+    if !alignment.is_power_of_two() {
+        fatal("alignment is not a power of two");
+    }
+    alignment
+}
+
+fn round_up(value: usize, alignment: usize) -> usize {
+    let mask = alignment - 1;
+    checked_add(value, mask, "allocation prefix overflow") & !mask
+}
+
+fn update_high_water(active: &AtomicUsize, high_water: &AtomicUsize) {
+    let current = active.fetch_add(1, Ordering::AcqRel) + 1;
+    let mut observed = high_water.load(Ordering::Acquire);
+    while current > observed {
+        match high_water.compare_exchange_weak(
+            observed,
+            current,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => break,
+            Err(next) => observed = next,
+        }
+    }
+}
+
+fn allocated(kind: AllocationKind) {
+    match kind {
+        AllocationKind::Ordinary => {}
+        AllocationKind::RequestBody => {
+            update_high_water(&ACTIVE_REQUEST_BODIES, &REQUEST_BODY_HIGH_WATER);
+        }
+        AllocationKind::SeamlessBytes => {
+            update_high_water(&ACTIVE_SEAMLESS_BACKINGS, &SEAMLESS_BACKING_HIGH_WATER);
+        }
+    }
+}
+
+fn deallocated(kind: AllocationKind) {
+    let active = match kind {
+        AllocationKind::Ordinary => return,
+        AllocationKind::RequestBody => &ACTIVE_REQUEST_BODIES,
+        AllocationKind::SeamlessBytes => &ACTIVE_SEAMLESS_BACKINGS,
+    };
+    let previous = active.fetch_sub(1, Ordering::AcqRel);
+    if previous == 0 {
+        fatal("host-owned allocation accounting underflow");
+    }
+}
+
+#[cfg(debug_assertions)]
+fn debug_register(
+    user_ptr: *mut u8,
+    kind: AllocationKind,
+    requested_size: usize,
+    requested_alignment: usize,
+) {
+    let old = debug_allocations()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(
+            user_ptr as usize,
+            DebugAllocation {
+                kind,
+                requested_size,
+                requested_alignment,
+            },
+        );
+    if old.is_some() {
+        fatal("duplicate live allocation address");
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn debug_register(
+    _user_ptr: *mut u8,
+    _kind: AllocationKind,
+    _requested_size: usize,
+    _requested_alignment: usize,
+) {
+}
+
+#[cfg(debug_assertions)]
+fn debug_lookup(user_ptr: *mut u8) -> DebugAllocation {
+    debug_allocations()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&(user_ptr as usize))
+        .copied()
+        .unwrap_or_else(|| fatal("foreign or duplicate deallocation"))
+}
+
+#[cfg(debug_assertions)]
+fn debug_remove(user_ptr: *mut u8) -> DebugAllocation {
+    debug_allocations()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(&(user_ptr as usize))
+        .unwrap_or_else(|| fatal("foreign or duplicate deallocation"))
+}
+
+unsafe fn header_from_user(user_ptr: *mut u8) -> *mut AllocationHeader {
+    unsafe { user_ptr.sub(core::mem::size_of::<AllocationHeader>()) }.cast::<AllocationHeader>()
+}
+
+unsafe fn validate_header(
+    user_ptr: *mut u8,
+    supplied_alignment: Option<usize>,
+) -> *mut AllocationHeader {
+    if user_ptr.is_null() {
+        fatal("null allocation pointer");
+    }
+
+    #[cfg(debug_assertions)]
+    let recorded = debug_lookup(user_ptr);
+
+    let header_ptr = unsafe { header_from_user(user_ptr) };
+    let header = unsafe { &*header_ptr };
+    if header.magic != ALLOCATION_MAGIC {
+        fatal("bad allocation magic");
+    }
+    if header.version != ALLOCATION_VERSION {
+        fatal("unsupported allocation header version");
+    }
+    if header.header_canary != HEADER_CANARY {
+        fatal("allocation header canary was overwritten");
+    }
+    let kind =
+        AllocationKind::from_raw(header.kind).unwrap_or_else(|| fatal("invalid allocation kind"));
+    let alignment = normalized_alignment(header.requested_alignment);
+    if alignment != header.requested_alignment || (user_ptr as usize) & (alignment - 1) != 0 {
+        fatal("allocation alignment metadata is invalid");
+    }
+    if supplied_alignment.is_some_and(|value| normalized_alignment(value) != alignment) {
+        fatal("deallocation alignment does not match allocation");
+    }
+    if header.prefix_size < core::mem::size_of::<AllocationHeader>()
+        || header.prefix_size % alignment != 0
+    {
+        fatal("allocation-base recovery metadata is invalid");
+    }
+    let expected_total = checked_add(
+        checked_add(
+            header.prefix_size,
+            header.requested_size,
+            "allocation size overflow",
+        ),
+        TAIL_BYTES,
+        "allocation tail size overflow",
+    );
+    if header.total_size != expected_total {
+        fatal("allocation size metadata is invalid");
+    }
+    if kind == AllocationKind::Ordinary && header.drop_fn.is_some() {
+        fatal("ordinary allocation unexpectedly has a finalizer");
+    }
+    if kind != AllocationKind::Ordinary && header.drop_fn.is_none() {
+        fatal("host-owned allocation is missing its finalizer");
+    }
+
+    #[cfg(debug_assertions)]
+    {
+        if recorded.kind != kind
+            || recorded.requested_size != header.requested_size
+            || recorded.requested_alignment != header.requested_alignment
+        {
+            fatal("live-allocation ledger disagrees with allocation metadata");
+        }
+        let tail = unsafe { user_ptr.add(header.requested_size).cast::<u64>() };
+        if unsafe { tail.read_unaligned() } != TAIL_CANARY {
+            fatal("allocation tail canary was overwritten");
+        }
+    }
+
+    header_ptr
+}
+
+unsafe fn allocate(
+    requested_size: usize,
+    requested_alignment: usize,
+    kind: AllocationKind,
+    drop_fn: Option<AllocationDrop>,
+) -> *mut u8 {
+    if (kind == AllocationKind::Ordinary) != drop_fn.is_none() {
+        fatal("allocation kind/finalizer mismatch");
+    }
+    let alignment = normalized_alignment(requested_alignment);
+    let prefix_size = round_up(core::mem::size_of::<AllocationHeader>(), alignment);
+    let total_size = checked_add(
+        checked_add(prefix_size, requested_size, "allocation size overflow"),
+        TAIL_BYTES,
+        "allocation tail size overflow",
+    );
+    let layout = Layout::from_size_align(total_size, alignment)
+        .unwrap_or_else(|_| fatal("invalid allocation layout"));
+    let base = unsafe { std::alloc::alloc(layout) };
+    let base = NonNull::new(base).unwrap_or_else(|| fatal("out of memory"));
+    let user_ptr = unsafe { base.as_ptr().add(prefix_size) };
+    let header_ptr = unsafe { header_from_user(user_ptr) };
+    unsafe {
+        header_ptr.write(AllocationHeader {
+            magic: ALLOCATION_MAGIC,
+            header_canary: HEADER_CANARY,
+            requested_size,
+            total_size,
+            prefix_size,
+            requested_alignment: alignment,
+            drop_fn,
+            version: ALLOCATION_VERSION,
+            kind: kind as u32,
+        });
+    }
+    #[cfg(debug_assertions)]
+    unsafe {
+        user_ptr
+            .add(requested_size)
+            .cast::<u64>()
+            .write_unaligned(TAIL_CANARY);
+    }
+    debug_register(user_ptr, kind, requested_size, alignment);
+    allocated(kind);
+    user_ptr
+}
+
+/// Allocate a self-describing host-owned Roc allocation.
+///
+/// # Safety
+/// `drop_fn` must correctly destroy the initialized payload at the returned
+/// pointer, and the caller must initialize it before Roc can release it.
+pub(crate) unsafe fn allocate_host_owned(
+    requested_size: usize,
+    requested_alignment: usize,
+    kind: AllocationKind,
+    drop_fn: AllocationDrop,
+) -> *mut u8 {
+    if kind == AllocationKind::Ordinary {
+        fatal("host-owned allocation cannot use the ordinary kind");
+    }
+    unsafe { allocate(requested_size, requested_alignment, kind, Some(drop_fn)) }
+}
+
+/// Validate a host-owned allocation before interpreting its payload.
+///
+/// # Safety
+/// `user_ptr` must be a live pointer supplied by the opaque Roc capability
+/// whose ARC reference the caller currently owns.
+pub(crate) unsafe fn validate_host_owned(
+    user_ptr: *mut u8,
+    expected_kind: AllocationKind,
+    minimum_size: usize,
+    expected_alignment: usize,
+) {
+    let header = unsafe { &*validate_header(user_ptr, None) };
+    if AllocationKind::from_raw(header.kind) != Some(expected_kind) {
+        fatal("opaque allocation has the wrong kind");
+    }
+    if header.requested_size < minimum_size {
+        fatal("opaque allocation is smaller than its representation");
+    }
+    if header.requested_alignment < normalized_alignment(expected_alignment) {
+        fatal("opaque allocation alignment is too small");
+    }
+}
+
+/// Return the immutable allocation kind for a live allocator-base pointer.
+///
+/// # Safety
+/// `user_ptr` must identify a live allocation owned by this allocator.
+pub(crate) unsafe fn allocation_kind(user_ptr: *mut u8) -> AllocationKind {
+    let header = unsafe { &*validate_header(user_ptr, None) };
+    AllocationKind::from_raw(header.kind).unwrap_or_else(|| fatal("invalid allocation kind"))
+}
+
+/// Validate a byte range against an ordinary allocation.
+///
+/// # Safety
+/// `user_ptr` must identify a live allocation owned by this allocator.
+pub(crate) unsafe fn validate_range(user_ptr: *mut u8, range_ptr: *const u8, range_length: usize) {
+    let header = unsafe { &*validate_header(user_ptr, None) };
+    if AllocationKind::from_raw(header.kind) != Some(AllocationKind::Ordinary) {
+        fatal("ordinary allocation range check used with a host-owned allocation");
+    }
+    let allocation_start = user_ptr as usize;
+    let allocation_end = allocation_start
+        .checked_add(header.requested_size)
+        .unwrap_or_else(|| fatal("allocation range overflow"));
+    let range_start = range_ptr as usize;
+    let range_end = range_start
+        .checked_add(range_length)
+        .unwrap_or_else(|| fatal("seamless slice range overflow"));
+    if range_start < allocation_start || range_end > allocation_end {
+        fatal("seamless slice escapes its ordinary backing allocation");
+    }
+}
+
+pub(crate) fn counts() -> AllocationCounts {
+    AllocationCounts {
+        active_request_bodies: ACTIVE_REQUEST_BODIES.load(Ordering::Acquire),
+        request_body_high_water: REQUEST_BODY_HIGH_WATER.load(Ordering::Acquire),
+        active_seamless_backings: ACTIVE_SEAMLESS_BACKINGS.load(Ordering::Acquire),
+        seamless_backing_high_water: SEAMLESS_BACKING_HIGH_WATER.load(Ordering::Acquire),
+    }
+}
+
+#[cfg(all(test, debug_assertions))]
+pub(crate) fn debug_is_live(user_ptr: *mut u8) -> bool {
+    debug_allocations()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .contains_key(&(user_ptr as usize))
+}
+
+pub(crate) extern "C" fn roc_alloc(
+    _roc_host: *mut RocHost,
+    length: usize,
+    alignment: usize,
+) -> *mut c_void {
+    unsafe { allocate(length, alignment, AllocationKind::Ordinary, None).cast() }
+}
+
+pub(crate) extern "C" fn roc_dealloc(_roc_host: *mut RocHost, ptr: *mut c_void, alignment: usize) {
+    let user_ptr = ptr.cast::<u8>();
+    let (layout, base, kind, drop_fn) = unsafe {
+        let header = &mut *validate_header(user_ptr, Some(alignment));
+        #[cfg(debug_assertions)]
+        {
+            debug_remove(user_ptr);
+        }
+        let layout = Layout::from_size_align(header.total_size, header.requested_alignment)
+            .unwrap_or_else(|_| fatal("invalid deallocation layout"));
+        let base = user_ptr.sub(header.prefix_size);
+        let kind = AllocationKind::from_raw(header.kind)
+            .unwrap_or_else(|| fatal("invalid allocation kind"));
+        let drop_fn = header.drop_fn;
+        header.magic = DEAD_ALLOCATION_MAGIC;
+        (layout, base, kind, drop_fn)
+    };
+
+    if let Some(finalize) = drop_fn {
+        unsafe { finalize(user_ptr) };
+    }
+    deallocated(kind);
+    unsafe { std::alloc::dealloc(base, layout) };
+}
+
+pub(crate) extern "C" fn roc_realloc(
+    _roc_host: *mut RocHost,
+    ptr: *mut c_void,
+    new_length: usize,
+    alignment: usize,
+) -> *mut c_void {
+    let old_user_ptr = ptr.cast::<u8>();
+    unsafe {
+        let header = &mut *validate_header(old_user_ptr, Some(alignment));
+        if AllocationKind::from_raw(header.kind) != Some(AllocationKind::Ordinary) {
+            fatal("Roc attempted to reallocate immutable host-owned backing");
+        }
+        #[cfg(debug_assertions)]
+        {
+            debug_remove(old_user_ptr);
+        }
+
+        let old_layout = Layout::from_size_align(header.total_size, header.requested_alignment)
+            .unwrap_or_else(|_| fatal("invalid reallocation layout"));
+        let prefix_size = header.prefix_size;
+        let requested_alignment = header.requested_alignment;
+        let new_total_size = checked_add(
+            checked_add(prefix_size, new_length, "reallocation size overflow"),
+            TAIL_BYTES,
+            "reallocation tail size overflow",
+        );
+        let old_base = old_user_ptr.sub(prefix_size);
+        let new_base = std::alloc::realloc(old_base, old_layout, new_total_size);
+        let new_base = NonNull::new(new_base).unwrap_or_else(|| fatal("out of memory"));
+        let new_user_ptr = new_base.as_ptr().add(prefix_size);
+        let new_header = &mut *header_from_user(new_user_ptr);
+        new_header.requested_size = new_length;
+        new_header.total_size = new_total_size;
+        new_header.magic = ALLOCATION_MAGIC;
+        #[cfg(debug_assertions)]
+        new_user_ptr
+            .add(new_length)
+            .cast::<u64>()
+            .write_unaligned(TAIL_CANARY);
+        debug_register(
+            new_user_ptr,
+            AllocationKind::Ordinary,
+            new_length,
+            requested_alignment,
+        );
+        new_user_ptr.cast()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static FINALIZED: AtomicUsize = AtomicUsize::new(0);
+
+    unsafe fn finalize_word(ptr: *mut u8) {
+        assert_eq!(unsafe { ptr.cast::<usize>().read() }, 42);
+        FINALIZED.fetch_add(1, Ordering::AcqRel);
+    }
+
+    #[test]
+    fn ordinary_allocation_reallocates_and_preserves_bytes() {
+        unsafe {
+            let ptr = roc_alloc(core::ptr::null_mut(), 4, 4).cast::<u8>();
+            ptr.copy_from_nonoverlapping([1, 2, 3, 4].as_ptr(), 4);
+            let ptr = roc_realloc(core::ptr::null_mut(), ptr.cast(), 12, 4).cast::<u8>();
+            assert_eq!(core::slice::from_raw_parts(ptr, 4), &[1, 2, 3, 4]);
+            roc_dealloc(core::ptr::null_mut(), ptr.cast(), 4);
+        }
+    }
+
+    #[test]
+    fn host_owned_allocation_runs_its_embedded_finalizer_once() {
+        FINALIZED.store(0, Ordering::Release);
+        unsafe {
+            let ptr = allocate_host_owned(
+                core::mem::size_of::<usize>(),
+                core::mem::align_of::<usize>(),
+                AllocationKind::SeamlessBytes,
+                finalize_word,
+            );
+            ptr.cast::<usize>().write(42);
+            validate_host_owned(
+                ptr,
+                AllocationKind::SeamlessBytes,
+                core::mem::size_of::<usize>(),
+                core::mem::align_of::<usize>(),
+            );
+            roc_dealloc(
+                core::ptr::null_mut(),
+                ptr.cast(),
+                core::mem::align_of::<usize>(),
+            );
+        }
+        assert_eq!(FINALIZED.load(Ordering::Acquire), 1);
+    }
+}

--- a/src/roc_platform_abi.rs
+++ b/src/roc_platform_abi.rs
@@ -1472,14 +1472,14 @@ const _: () = assert!(core::mem::size_of::<AnonStructFf6f93028827ced0>() == 44, 
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(core::mem::align_of::<AnonStructFf6f93028827ced0>() == 4, "AnonStructFf6f93028827ced0 alignment mismatch");
 
-/// Element type for __AnonStruct_9618161a745c1367
+/// Element type for __AnonStruct_9bfbda88f35e6056
 #[cfg(target_pointer_width = "32")]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStruct9618161a745c1367 {
-    pub body_id: u64,
+pub struct AnonStruct9bfbda88f35e6056 {
     pub body_limit_bytes: u64,
     pub content_length: u64,
+    pub body_handle: *mut u64,
     pub headers: RocList<AnonStruct82a96c5d55d63488>,
     pub method_ext: RocStr,
     pub target: RocStr,
@@ -1487,14 +1487,14 @@ pub struct AnonStruct9618161a745c1367 {
     pub method: u8,
 }
 
-/// Element type for __AnonStruct_9618161a745c1367
+/// Element type for __AnonStruct_9bfbda88f35e6056
 #[cfg(not(target_pointer_width = "32"))]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStruct9618161a745c1367 {
-    pub body_id: u64,
+pub struct AnonStruct9bfbda88f35e6056 {
     pub body_limit_bytes: u64,
     pub content_length: u64,
+    pub body_handle: *mut u64,
     pub headers: RocList<AnonStruct82a96c5d55d63488>,
     pub method_ext: RocStr,
     pub target: RocStr,
@@ -1503,13 +1503,13 @@ pub struct AnonStruct9618161a745c1367 {
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<AnonStruct9618161a745c1367>() == 104, "AnonStruct9618161a745c1367 size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStruct9bfbda88f35e6056>() == 104, "AnonStruct9bfbda88f35e6056 size mismatch");
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::align_of::<AnonStruct9618161a745c1367>() == 8, "AnonStruct9618161a745c1367 alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStruct9bfbda88f35e6056>() == 8, "AnonStruct9bfbda88f35e6056 alignment mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::size_of::<AnonStruct9618161a745c1367>() == 64, "AnonStruct9618161a745c1367 size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStruct9bfbda88f35e6056>() == 64, "AnonStruct9bfbda88f35e6056 size mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::align_of::<AnonStruct9618161a745c1367>() == 8, "AnonStruct9618161a745c1367 alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStruct9bfbda88f35e6056>() == 8, "AnonStruct9bfbda88f35e6056 alignment mismatch");
 
 /// Element type for __AnonStruct_aeceb9ea017a78f4
 #[cfg(target_pointer_width = "32")]
@@ -5821,22 +5821,22 @@ const _: () = assert!(core::mem::size_of::<HostPathTypeArgs>() == 28, "HostPathT
 const _: () = assert!(core::mem::align_of::<HostPathTypeArgs>() == 4, "HostPathTypeArgs alignment mismatch");
 
 /// Arguments for Host.request_body_read!
-/// Roc signature: U64, U64 => Try([Chunk(List(U8)), End], [Cancelled, ClientDisconnected, ConcurrentRead, InvalidBody(Str), RequestFinished, TooLarge({ limit_bytes : U64, received_at_least : U64 })])
+/// Roc signature: Host.RequestBody, U64 => Try([Chunk(List(U8)), End], [Cancelled, ClientDisconnected, ConcurrentRead, InvalidBody(Str), RequestFinished, TooLarge({ limit_bytes : U64, received_at_least : U64 })])
 /// Refcounted fields are owned by the hosted function.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct HostRequestBodyReadArgs {
-    pub arg0: u64,
+    pub arg0: *mut u64,
     pub arg1: u64,
 }
 
 /// Arguments for Host.request_body_read_all!
-/// Roc signature: U64, U64 => Try(List(U8), [Cancelled, ClientDisconnected, ConcurrentRead, InvalidBody(Str), RequestFinished, TooLarge({ limit_bytes : U64, received_at_least : U64 })])
+/// Roc signature: Host.RequestBody, U64 => Try(List(U8), [Cancelled, ClientDisconnected, ConcurrentRead, InvalidBody(Str), RequestFinished, TooLarge({ limit_bytes : U64, received_at_least : U64 })])
 /// Refcounted fields are owned by the hosted function.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct HostRequestBodyReadAllArgs {
-    pub arg0: u64,
+    pub arg0: *mut u64,
     pub arg1: u64,
 }
 
@@ -6229,7 +6229,7 @@ pub type InitForHostOk = AnonStruct9d4feaaa75529fdc;
 pub type InitForHostOkConfig = AnonStructAeeb7f2cfe80f10;
 pub type InitForHostOkConfigFileRoots = AnonStruct3b01e35488cb00dc;
 pub type InitForHostOkConfigNativeRoutes = AnonStructFf6f93028827ced0;
-pub type RespondForHostArg0 = AnonStruct9618161a745c1367;
+pub type RespondForHostArg0 = AnonStruct9bfbda88f35e6056;
 pub type RespondForHostArg0Headers = AnonStruct82a96c5d55d63488;
 pub type RespondForHost = AnonStructAeceb9ea017a78f4;
 pub type RespondForHostHeaders = AnonStruct82a96c5d55d63488;
@@ -8664,13 +8664,14 @@ impl AnonStructFf6f93028827ced0 {
     }
 }
 
-impl AnonStruct9618161a745c1367 {
+impl AnonStruct9bfbda88f35e6056 {
     /// Recursively decrement Roc-owned fields.
     ///
     /// # Safety
     /// `self` must own one live Roc reference for each refcounted field.
     pub unsafe fn decref(self, roc_host: &RocHost) {
         let value = self;
+        unsafe { decref_box_with(value.body_handle as RocBox, core::mem::align_of::<u64>(), false, None, roc_host); }
         {
             let list = value.headers;
             if list.has_one_ref() {
@@ -8692,6 +8693,7 @@ impl AnonStruct9618161a745c1367 {
     /// be balanced by later decrefs.
     pub unsafe fn incref(self, amount: isize) {
         let value = self;
+        unsafe { incref_box(value.body_handle as RocBox, amount); }
         unsafe { value.headers.incref(amount); }
         unsafe { value.method_ext.incref(amount); }
         unsafe { value.target.incref(amount); }
@@ -8945,12 +8947,12 @@ unsafe extern "C" {
     pub fn hosted_path_type(arg0: HostPathTypeArgs) -> HostPathTypeResult;
 
     /// Hosted symbol for Host.request_body_read!
-    /// Roc signature: U64, U64 => Try([Chunk(List(U8)), End], [Cancelled, ClientDisconnected, ConcurrentRead, InvalidBody(Str), RequestFinished, TooLarge({ limit_bytes : U64, received_at_least : U64 })])
-    pub fn hosted_request_body_read(arg0: u64, arg1: u64) -> HostRequestBodyReadResult;
+    /// Roc signature: Host.RequestBody, U64 => Try([Chunk(List(U8)), End], [Cancelled, ClientDisconnected, ConcurrentRead, InvalidBody(Str), RequestFinished, TooLarge({ limit_bytes : U64, received_at_least : U64 })])
+    pub fn hosted_request_body_read(arg0: *mut u64, arg1: u64) -> HostRequestBodyReadResult;
 
     /// Hosted symbol for Host.request_body_read_all!
-    /// Roc signature: U64, U64 => Try(List(U8), [Cancelled, ClientDisconnected, ConcurrentRead, InvalidBody(Str), RequestFinished, TooLarge({ limit_bytes : U64, received_at_least : U64 })])
-    pub fn hosted_request_body_read_all(arg0: u64, arg1: u64) -> HostRequestBodyReadAllResult;
+    /// Roc signature: Host.RequestBody, U64 => Try(List(U8), [Cancelled, ClientDisconnected, ConcurrentRead, InvalidBody(Str), RequestFinished, TooLarge({ limit_bytes : U64, received_at_least : U64 })])
+    pub fn hosted_request_body_read_all(arg0: *mut u64, arg1: u64) -> HostRequestBodyReadAllResult;
 
     /// Hosted symbol for Host.sleep_millis!
     /// Roc signature: U64 => {}
@@ -9174,7 +9176,7 @@ unsafe extern "C" {
     pub fn roc_init_for_host() -> InitForHostResult;
 
     /// Entrypoint: respond_for_host!
-    pub fn roc_respond_for_host(arg0: AnonStruct9618161a745c1367, arg1: RocBox) -> AnonStructAeceb9ea017a78f4;
+    pub fn roc_respond_for_host(arg0: AnonStruct9bfbda88f35e6056, arg1: RocBox) -> AnonStructAeceb9ea017a78f4;
 
     /// Entrypoint: shutdown_for_host!
     pub fn roc_shutdown_for_host(arg0: AnonStruct628b43fd33b27733, arg1: RocBox) -> ShutdownForHostResult;


### PR DESCRIPTION
Closes #168.

## Summary

- replace numeric body IDs and the process-global body registry with request-scoped opaque `Box(U64)` capabilities whose ARC allocation directly owns the synchronized body state
- return `Server.Body.read!` chunks as seamless `List(U8)` views over the original `bytes::Bytes` payload, with self-describing owner metadata that drops the native backing exactly once on final Roc release
- route ordinary and host-owned allocations through a self-describing allocator protocol with kind/alignment/size validation, immutable-backing realloc rejection, debug canaries and a debug-only live ledger
- build fragmented `read_all!` results directly in the eventual Roc allocation, using validated content length only as a bounded capacity hint
- validate escaped response ranges and preserve request metadata/body backing ownership through asynchronous Hyper transmission
- add `Server.Body.fold_chunks!`, a Roc-only convenience that reads chunks sequentially and explicitly threads request-local state through an effectful step
- add a realistic NDJSON-to-SQLite ingestion example with nominal `Decoder` and `Ingest` state machines, bounded body, line, chunk, and batch memory; UTF-8 and JSON validation across arbitrary chunk boundaries; short transactions between reads; client IDs for retry safety; and partial-commit reporting
- add allocation/copy metrics, shutdown leak checks, focused ownership/error/concurrency tests, parser boundary tests, and compiled-Roc HTTP/1.1 plus HTTP/2 body-isolation coverage

## Design

The host owns bounded transport and opaque body lifetime. The Roc handler owns request-local framing, decoding, validation, and batching. SQLite owns durable facts. `fold_chunks!` invokes the step once per received chunk with the previous state and uses its returned state for the next chunk; it does not create another handler or require global coordination. The NDJSON example expresses that coordination through nominal `Decoder` and `Ingest` values with associated `push!` and `finish!` methods, and never holds a database transaction while waiting for the next body chunk.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --locked --lib --tests -- -D warnings`
- `cargo test --locked --lib` (91 passed)
- `cargo test --locked --lib --release` (90 passed)
- `roc fmt --check platform examples`
- `roc test target/memcheck-spec/apps/ndjson-ingest.roc` (216 passed across the staged package graph)
- `ROC=... ROC_SRC=... python3 scripts/regenerate_glue.py --check`
- `python3 scripts/build.py --all` (x64musl and arm64musl)
- `python3 scripts/test.py --operation memcheck --roc <pinned-zig-roc>` (all 25 compiled-Roc runtime cases passed under Memcheck)