### PR TITLE
Add native static and authorized file responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,10 +45,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
 
 [[package]]
 name = "cc"
@@ -73,7 +103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -87,6 +117,17 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "futures"
@@ -334,6 +375,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +424,18 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -452,8 +533,10 @@ name = "roc_host"
 version = "0.0.1"
 dependencies = [
  "bytes",
+ "cap-primitives",
  "futures",
  "http-body-util",
+ "httpdate",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -470,6 +553,29 @@ name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
+]
 
 [[package]]
 name = "rustls"
@@ -685,6 +791,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +812,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -765,6 +886,16 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,11 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(no_roc_std_helpers)"] }
 libc = "=0.2.172"
 libsqlite3-sys = { version = "=0.33.0", features = ["bundled"] }
 bytes = "=1.11.1"
+cap-primitives = "=4.0.2"
 futures = "=0.3.31"
 hyper = { version = "=1.6.0", features = ["http1", "http2", "client", "server"] }
 http-body-util = "=0.1.3"
+httpdate = "=1.0.3"
 hyper-util = { version = "=0.1.12", features = ["tokio", "client", "client-legacy", "server", "server-auto", "http1", "http2"] }
 # Outbound HTTP client TLS stack (Http.send!). `ring` is the rustls crypto
 # backend, and WebPKI roots keep the static host self-contained for Roc linking.

--- a/examples/static-files.roc
+++ b/examples/static-files.roc
@@ -1,0 +1,84 @@
+## Serves public assets without entering Roc and authorizes one attachment in Roc.
+app [Context, program] {
+	pf: platform "../platform/main.roc",
+	http: "https://github.com/roc-lang/http/releases/download/1.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
+}
+
+import pf.Path
+import pf.Server
+import pf.Stdout
+import http.Response
+
+Context : {
+	downloads : Server.FileRoot,
+	report : Server.RelativeFile,
+}
+
+program = { init!, respond!, shutdown! }
+
+init! : () => Try({ config : Server.Config, context : Context }, [Exit(I64), ..])
+init! = || {
+	assets = Server.file_root_with_cache({
+		id: "assets",
+		path: Path.utf8("assets"),
+		cache: Server.public_for(3600),
+	})
+	downloads = Server.file_root({
+		id: "downloads",
+		path: Path.utf8("downloads"),
+	})
+	report = 
+		Server.relative_file("reports/annual report.txt")
+			.map_err(|_| Exit(1))?
+	favicon = 
+		Server.relative_file("favicon.ico")
+			.map_err(|_| Exit(1))?
+
+	config = 
+		Server.default_config
+			.with_file_roots([assets, downloads])
+			.with_native_routes([
+				Server.static_mount({ at: "/assets", files: assets }),
+				Server.static_file({ at: "/favicon.ico", files: assets, relative: favicon }),
+			])
+
+	Ok({
+		config,
+		context: { downloads, report },
+	})
+}
+
+respond! : Server.Request, Context => Try(Server.Outcome, [ServerErr(Str), ..])
+respond! = |request, context| {
+	target = request.target()
+	Stdout.line!("Roc handled ${target}")
+		? |err| ServerErr("Failed to log request: ${Str.inspect(err)}")
+
+	if target == "/download?token=secret" {
+		Ok(
+			Server.file_response_with({
+				files: context.downloads,
+				relative: context.report,
+				disposition: Server.attachment("annual report.txt"),
+				cache: Server.override_cache(Server.no_store),
+			}),
+		)
+	} else if target == "/download" {
+		Ok(
+			Server.respond(
+				Response.from_status(403)
+					.with_body(Str.to_utf8("Download denied")),
+			),
+		)
+	} else {
+		Ok(
+			Server.respond(
+				Response.from_status(404)
+					.with_body(Str.to_utf8("Roc fallback")),
+			),
+		)
+	}
+}
+
+shutdown! : Server.ShutdownReason, Context => Try({}, [Exit(I64), ..])
+shutdown! = |_reason, _context| Ok({})

--- a/platform/InternalServer.roc
+++ b/platform/InternalServer.roc
@@ -25,6 +25,14 @@ InternalServer :: [].{
 		body : List(U8),
 		stop : Bool,
 		exit_code : I64,
+		kind : U8,
+		file_root_id : Str,
+		file_relative : Str,
+		file_disposition : U8,
+		file_download_name : Str,
+		file_cache_override : Bool,
+		file_cache_tag : U8,
+		file_cache_max_age_seconds : U32,
 	}
 
 	ConfigToHost : {
@@ -38,6 +46,30 @@ InternalServer :: [].{
 		max_connections : U32,
 		max_handlers : U16,
 		max_queued_handlers : U16,
+		file_roots : List(
+			{
+				id : Str,
+				path_tag : U8,
+				path_utf8 : Str,
+				path_unix_bytes : List(U8),
+				path_windows_u16s : List(U16),
+				cache_tag : U8,
+				cache_max_age_seconds : U32,
+			},
+		),
+		native_routes : List(
+			{
+				at : Str,
+				root_id : Str,
+				kind : U8,
+				relative : Str,
+				cache_override : Bool,
+				cache_tag : U8,
+				cache_max_age_seconds : U32,
+			},
+		),
+		file_max_concurrent : U16,
+		file_chunk_bytes : U32,
 	}
 
 	ShutdownReasonFromHost : {
@@ -64,17 +96,37 @@ InternalServer :: [].{
 
 	to_host_outcome : Server.Outcome -> OutcomeToHost
 	to_host_outcome = |outcome| {
-		{ response, stop, exit_code } = Server.Outcome.to_host(outcome)
-		response_to_host(response, stop, exit_code)
+		raw = Server.Outcome.to_host(outcome)
+		response_to_host(raw)
 	}
 
-	response_to_host : Response.Response, Bool, I64 -> OutcomeToHost
-	response_to_host = |response, stop, exit_code| {
-		status: Response.status(response),
-		headers: Response.headers(response).map(to_host_header),
-		body: Response.body(response),
-		stop,
-		exit_code,
+	response_to_host : {
+		kind : U8,
+		response : Response.Response,
+		stop : Bool,
+		exit_code : I64,
+		file_root_id : Str,
+		file_relative : Str,
+		file_disposition : U8,
+		file_download_name : Str,
+		file_cache_override : Bool,
+		file_cache_tag : U8,
+		file_cache_max_age_seconds : U32,
+	} -> OutcomeToHost
+	response_to_host = |raw| {
+		status: Response.status(raw.response),
+		headers: Response.headers(raw.response).map(to_host_header),
+		body: Response.body(raw.response),
+		stop: raw.stop,
+		exit_code: raw.exit_code,
+		kind: raw.kind,
+		file_root_id: raw.file_root_id,
+		file_relative: raw.file_relative,
+		file_disposition: raw.file_disposition,
+		file_download_name: raw.file_download_name,
+		file_cache_override: raw.file_cache_override,
+		file_cache_tag: raw.file_cache_tag,
+		file_cache_max_age_seconds: raw.file_cache_max_age_seconds,
 	}
 
 	to_host_config : Server.Config -> ConfigToHost

--- a/platform/Server.roc
+++ b/platform/Server.roc
@@ -1,4 +1,5 @@
 import Host
+import Path
 import http.Header
 import http.Method
 import http.Response
@@ -57,6 +58,251 @@ Server :: [].{
 	default_max_queued_handlers : U16
 	default_max_queued_handlers = 64
 
+	## Default maximum number of host-managed file responses that may be active
+	## concurrently. File transfers do not consume Roc handler capacity.
+	default_max_file_transfers : U16
+	default_max_file_transfers = 32
+
+	## Default chunk size used while streaming files: 64 KiB. A transfer owns
+	## at most one queued chunk and one active read buffer, so memory use does
+	## not scale with file size.
+	default_file_chunk_bytes : U32
+	default_file_chunk_bytes = 64 * 1024
+
+	## Host-managed file responses use one cross-platform contract. Roots and
+	## routes are validated and activated as one immutable configuration before
+	## the listener is bound. Paths are root-relative regular files; dotfiles,
+	## dot components, symlinks/reparse points, directories, NULs, drive/UNC
+	## paths, backslashes, and encoded separators are denied without revealing
+	## filesystem layout. There is no directory listing, index lookup, or SPA
+	## fallback.
+	##
+	## Public routes own their exact path or prefix for all methods: GET and HEAD
+	## use the native file engine, while other methods return 405 and never fall
+	## through to Roc. Query strings do not participate in route matching.
+	##
+	## Responses include a deterministic extension-based Content-Type (or
+	## application/octet-stream), Content-Length, Last-Modified when available,
+	## a weak ETag, Accept-Ranges, Content-Disposition, and the selected cache
+	## policy. Preconditions are evaluated before ranges. One byte range,
+	## including suffix and open-ended forms, is supported; malformed and
+	## multi-range requests are safely ignored, and valid unsatisfiable ranges
+	## return 416.
+
+	## A small, typed cache policy for host-managed file responses.
+	CachePolicy := [NoStore, Revalidate, PrivateFor(U32), PublicFor(U32)].{
+
+		## Platform ABI conversion hook; not an application API.
+		to_host : CachePolicy -> { tag : U8, max_age_seconds : U32 }
+		to_host = |policy|
+			match policy {
+				NoStore => { tag: 0, max_age_seconds: 0 }
+				Revalidate => { tag: 1, max_age_seconds: 0 }
+				PrivateFor(seconds) => { tag: 2, max_age_seconds: seconds }
+				PublicFor(seconds) => { tag: 3, max_age_seconds: seconds }
+			}
+	}
+
+	## Do not allow caches to store the response.
+	no_store : CachePolicy
+	no_store = NoStore
+
+	## Allow storage but require revalidation before reuse. This is the
+	## conservative default for declared roots.
+	revalidate : CachePolicy
+	revalidate = Revalidate
+
+	## Permit private caches to reuse a response for the given number of seconds.
+	private_for : U32 -> CachePolicy
+	private_for = |seconds| PrivateFor(seconds)
+
+	## Permit shared and private caches to reuse a response for the given number
+	## of seconds.
+	public_for : U32 -> CachePolicy
+	public_for = |seconds| PublicFor(seconds)
+
+	## An immutable descriptor for one startup-declared filesystem root. Its
+	## identifier is the only value sent in a response plan; the host rejects
+	## plans whose identifier was not activated by the returned Config.
+	FileRoot := [
+		FileRoot({ id : Str, path : Path.Path, cache : CachePolicy }),
+	].{
+
+		## Platform ABI conversion hook; not an application API.
+		to_host : FileRoot -> {
+			id : Str,
+			path_tag : U8,
+			path_utf8 : Str,
+			path_unix_bytes : List(U8),
+			path_windows_u16s : List(U16),
+			cache_tag : U8,
+			cache_max_age_seconds : U32,
+		}
+		to_host = |FileRoot(root)| {
+			(path_tag, path_utf8, path_unix_bytes, path_windows_u16s) = 
+				match Path.to_raw(root.path) {
+					Utf8(str) => (0, str, [], [])
+					UnixBytes(bytes) => (1, "", bytes, [])
+					WindowsU16s(u16s) => (2, "", [], u16s)
+				}
+			cache = CachePolicy.to_host(root.cache)
+			{
+				id: root.id,
+				path_tag,
+				path_utf8,
+				path_unix_bytes,
+				path_windows_u16s,
+				cache_tag: cache.tag,
+				cache_max_age_seconds: cache.max_age_seconds,
+			}
+		}
+	}
+
+	## Declare a root with the conservative revalidation cache policy. Root
+	## identifiers contain 1-64 ASCII letters, digits, '-' or '_'; the complete
+	## configuration is validated before listening.
+	file_root : { id : Str, path : Path.Path } -> FileRoot
+	file_root = |{ id, path }| FileRoot({ id, path, cache: Revalidate })
+
+	## Declare a root with an explicit cache policy.
+	file_root_with_cache : { id : Str, path : Path.Path, cache : CachePolicy } -> FileRoot
+	file_root_with_cache = |root| FileRoot(root)
+
+	## A validated relative child path used by exact routes and authorized file
+	## plans. The host repeats this validation at the ABI boundary.
+	RelativeFile := [RelativeFile(Str)].{
+
+		## Platform ABI conversion hook; not an application API.
+		to_host : RelativeFile -> Str
+		to_host = |RelativeFile(relative)| relative
+	}
+
+	## Construct a safe relative child path of at most 4 KiB. Empty components,
+	## dot components, dotfiles, separators other than '/', NULs, and Windows
+	## drive syntax are rejected so the value has one cross-platform meaning.
+	relative_file : Str -> Try(RelativeFile, [InvalidRelativeFile])
+	relative_file = |relative| {
+		relative_bytes = Str.to_utf8(relative)
+		segments = Str.split_on(relative, "/")
+		valid = 
+			Bool.not(relative.is_empty())
+				and relative_bytes.len() <= 4 * 1024
+					and segments.all(
+						|segment| {
+							bytes = Str.to_utf8(segment)
+							Bool.not(bytes.is_empty())
+								and segment != "."
+									and segment != ".."
+										and match bytes {
+											[46, ..] => Bool.False
+											_ => bytes.all(|byte| byte != 0 and byte != 58 and byte != 92)
+										}
+						},
+					)
+		if valid {
+			Ok(RelativeFile(relative))
+		} else {
+			Err(InvalidRelativeFile)
+		}
+	}
+
+	## Override a root's cache policy for one native route or response plan, or
+	## inherit the root policy.
+	CacheChoice := [Inherit, Override(CachePolicy)].{
+
+		## Platform ABI conversion hook; not an application API.
+		to_host : CacheChoice -> { override : Bool, tag : U8, max_age_seconds : U32 }
+		to_host = |choice|
+			match choice {
+				Inherit => { override: Bool.False, tag: 0, max_age_seconds: 0 }
+				Override(policy) => {
+					raw = CachePolicy.to_host(policy)
+					{ override: Bool.True, tag: raw.tag, max_age_seconds: raw.max_age_seconds }
+				}
+			}
+	}
+
+	## Inherit the cache policy declared by a file root.
+	inherit_cache : CacheChoice
+	inherit_cache = Inherit
+
+	## Override a root cache policy for one route or response plan.
+	override_cache : CachePolicy -> CacheChoice
+	override_cache = |policy| Override(policy)
+
+	## One startup-declared host-native file route. Static mounts own an exact
+	## prefix on segment boundaries. Static files own one exact URI path.
+	NativeRoute := [
+		NativeRoute(
+			{
+				at : Str,
+				files : FileRoot,
+				kind : U8,
+				relative : Str,
+				cache : CacheChoice,
+			},
+		),
+	].{
+
+		## Platform ABI conversion hook; not an application API.
+		to_host : NativeRoute -> {
+			at : Str,
+			root_id : Str,
+			kind : U8,
+			relative : Str,
+			cache_override : Bool,
+			cache_tag : U8,
+			cache_max_age_seconds : U32,
+		}
+		to_host = |NativeRoute(route)| {
+			FileRoot(root) = route.files
+			cache = CacheChoice.to_host(route.cache)
+			{
+				at: route.at,
+				root_id: root.id,
+				kind: route.kind,
+				relative: route.relative,
+				cache_override: cache.override,
+				cache_tag: cache.tag,
+				cache_max_age_seconds: cache.max_age_seconds,
+			}
+		}
+	}
+
+	## Declare a public static mount that inherits its root cache policy. Route
+	## paths are ASCII absolute URI paths of at most 4 KiB and are validated at
+	## startup.
+	static_mount : { at : Str, files : FileRoot } -> NativeRoute
+	static_mount = |{ at, files }|
+		NativeRoute({ at, files, kind: 0, relative: "", cache: Inherit })
+
+	## Declare a public static mount with an explicit cache policy.
+	static_mount_with_cache : { at : Str, files : FileRoot, cache : CachePolicy } -> NativeRoute
+	static_mount_with_cache = |{ at, files, cache }|
+		NativeRoute({ at, files, kind: 0, relative: "", cache: Override(cache) })
+
+	## Declare one exact public file route that inherits its root cache policy.
+	static_file : { at : Str, files : FileRoot, relative : RelativeFile } -> NativeRoute
+	static_file = |{ at, files, relative }|
+		NativeRoute({
+			at,
+			files,
+			kind: 1,
+			relative: RelativeFile.to_host(relative),
+			cache: Inherit,
+		})
+
+	## Declare one exact public file route with an explicit cache policy.
+	static_file_with_cache : { at : Str, files : FileRoot, relative : RelativeFile, cache : CachePolicy } -> NativeRoute
+	static_file_with_cache = |{ at, files, relative, cache }|
+		NativeRoute({
+			at,
+			files,
+			kind: 1,
+			relative: RelativeFile.to_host(relative),
+			cache: Override(cache),
+		})
+
 	## Opaque runtime configuration returned from the application's `init!`
 	## function. Use the builders below so future server settings can be added
 	## without invalidating application record construction.
@@ -87,6 +333,12 @@ Server :: [].{
 					drain_timeout_ms : U64,
 					hook_timeout_ms : U64,
 				},
+				file_roots : List(FileRoot),
+				native_routes : List(NativeRoute),
+				file_transfers : {
+					max_concurrent : U16,
+					chunk_bytes : U32,
+				},
 			},
 		),
 	].{
@@ -105,6 +357,30 @@ Server :: [].{
 			max_connections : U32,
 			max_handlers : U16,
 			max_queued_handlers : U16,
+			file_roots : List(
+				{
+					id : Str,
+					path_tag : U8,
+					path_utf8 : Str,
+					path_unix_bytes : List(U8),
+					path_windows_u16s : List(U16),
+					cache_tag : U8,
+					cache_max_age_seconds : U32,
+				},
+			),
+			native_routes : List(
+				{
+					at : Str,
+					root_id : Str,
+					kind : U8,
+					relative : Str,
+					cache_override : Bool,
+					cache_tag : U8,
+					cache_max_age_seconds : U32,
+				},
+			),
+			file_max_concurrent : U16,
+			file_chunk_bytes : U32,
 		}
 		to_host = |Config(config)| {
 			host: config.listen.host,
@@ -117,6 +393,10 @@ Server :: [].{
 			max_connections: config.limits.max_connections,
 			max_handlers: config.limits.max_handlers,
 			max_queued_handlers: config.limits.max_queued_handlers,
+			file_roots: config.file_roots.map(FileRoot.to_host),
+			native_routes: config.native_routes.map(NativeRoute.to_host),
+			file_max_concurrent: config.file_transfers.max_concurrent,
+			file_chunk_bytes: config.file_transfers.chunk_bytes,
 		}
 	}
 
@@ -142,6 +422,12 @@ Server :: [].{
 			drain_timeout_ms: 30_000,
 			hook_timeout_ms: 10_000,
 		},
+		file_roots: [],
+		native_routes: [],
+		file_transfers: {
+			max_concurrent: default_max_file_transfers,
+			chunk_bytes: default_file_chunk_bytes,
+		},
 	})
 
 	## Set the listener host and port. The default is loopback-only on port 8000.
@@ -165,6 +451,20 @@ Server :: [].{
 	## Set the request-drain deadline and final shutdown-hook deadline.
 	with_graceful_shutdown : Config, { drain_timeout_ms : U64, hook_timeout_ms : U64 } -> Config
 	with_graceful_shutdown = |Config(config), graceful_shutdown| Config({ ..config, graceful_shutdown })
+
+	## Replace the complete set of startup-declared file roots.
+	with_file_roots : Config, List(FileRoot) -> Config
+	with_file_roots = |Config(config), file_roots| Config({ ..config, file_roots })
+
+	## Replace the immutable host-native route table.
+	with_native_routes : Config, List(NativeRoute) -> Config
+	with_native_routes = |Config(config), native_routes| Config({ ..config, native_routes })
+
+	## Set the active-transfer bound and streaming chunk size for host-managed
+	## file responses. Saturation returns 503 without queueing. Each transfer
+	## owns at most one queued chunk and one active read buffer.
+	with_file_transfer_limits : Config, { max_concurrent : U16, chunk_bytes : U32 } -> Config
+	with_file_transfer_limits = |Config(config), file_transfers| Config({ ..config, file_transfers })
 
 	## A request-scoped inbound body. The host expires this capability when the
 	## request handler returns, and permits only one active reader at a time.
@@ -273,21 +573,113 @@ Server :: [].{
 	## graceful shutdown; the first shutdown cause wins.
 	Outcome := [
 		Respond(Response.Response),
+		ServeFile(
+			{
+				files : FileRoot,
+				relative : RelativeFile,
+				disposition : [Inline, Attachment(Str)],
+				cache : CacheChoice,
+			},
+		),
 		StopAfter({ response : Response.Response, exit_code : I64 }),
 	].{
 
 		## Platform ABI conversion hook; not an application API.
-		to_host : Outcome -> { response : Response.Response, stop : Bool, exit_code : I64 }
+		to_host : Outcome -> {
+			kind : U8,
+			response : Response.Response,
+			stop : Bool,
+			exit_code : I64,
+			file_root_id : Str,
+			file_relative : Str,
+			file_disposition : U8,
+			file_download_name : Str,
+			file_cache_override : Bool,
+			file_cache_tag : U8,
+			file_cache_max_age_seconds : U32,
+		}
 		to_host = |outcome|
 			match outcome {
-				Respond(response) => { response, stop: Bool.False, exit_code: 0 }
-				StopAfter({ response, exit_code }) => { response, stop: Bool.True, exit_code }
+				Respond(response) => {
+					kind: 0,
+					response,
+					stop: Bool.False,
+					exit_code: 0,
+					file_root_id: "",
+					file_relative: "",
+					file_disposition: 0,
+					file_download_name: "",
+					file_cache_override: Bool.False,
+					file_cache_tag: 0,
+					file_cache_max_age_seconds: 0,
+				}
+				ServeFile({ files, relative, disposition, cache }) => {
+					FileRoot(root) = files
+					raw_cache = CacheChoice.to_host(cache)
+					(disposition_tag, download_name) = 
+						match disposition {
+							Inline => (0, "")
+							Attachment(name) => (1, name)
+						}
+					{
+						kind: 1,
+						response: Response.from_status(500),
+						stop: Bool.False,
+						exit_code: 0,
+						file_root_id: root.id,
+						file_relative: RelativeFile.to_host(relative),
+						file_disposition: disposition_tag,
+						file_download_name: download_name,
+						file_cache_override: raw_cache.override,
+						file_cache_tag: raw_cache.tag,
+						file_cache_max_age_seconds: raw_cache.max_age_seconds,
+					}
+				}
+				StopAfter({ response, exit_code }) => {
+					kind: 0,
+					response,
+					stop: Bool.True,
+					exit_code,
+					file_root_id: "",
+					file_relative: "",
+					file_disposition: 0,
+					file_download_name: "",
+					file_cache_override: Bool.False,
+					file_cache_tag: 0,
+					file_cache_max_age_seconds: 0,
+				}
 			}
 	}
 
 	## Return a response and keep serving requests.
 	respond : Response.Response -> Outcome
 	respond = |response| Respond(response)
+
+	## Ask the host to stream one authorized file inline, inheriting the root's
+	## cache policy. The plan can only name a startup-declared root and a
+	## validated relative child path.
+	file_response : { files : FileRoot, relative : RelativeFile } -> Outcome
+	file_response = |{ files, relative }|
+		ServeFile({ files, relative, disposition: Inline, cache: Inherit })
+
+	## Ask the host to stream one authorized file with explicit
+	## disposition/cache options.
+	file_response_with : {
+		files : FileRoot,
+		relative : RelativeFile,
+		disposition : [Inline, Attachment(Str)],
+		cache : CacheChoice,
+	} -> Outcome
+	file_response_with = |plan| ServeFile(plan)
+
+	## Render a host-managed file inline.
+	inline : [Inline, Attachment(Str)]
+	inline = Inline
+
+	## Render a host-managed file as an attachment. The host safely encodes the
+	## supplied filename and prevents response-header injection.
+	attachment : Str -> [Inline, Attachment(Str)]
+	attachment = |name| Attachment(name)
 
 	## Return a final response, then begin graceful shutdown with exit code 0.
 	stop_after : Response.Response -> Outcome

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -172,6 +172,14 @@ internal_server_error = {
 	body: Str.to_utf8("Internal Server Error"),
 	stop: False,
 	exit_code: 0,
+	kind: 0,
+	file_root_id: "",
+	file_relative: "",
+	file_disposition: 0,
+	file_download_name: "",
+	file_cache_override: False,
+	file_cache_tag: 0,
+	file_cache_max_age_seconds: 0,
 }
 
 shutdown_for_host! : InternalServer.ShutdownReasonFromHost, Box(Context) => Try({}, I64)

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -60,6 +60,7 @@ HTTP2_FLAG_END_STREAM = 0x1
 HTTP2_FLAG_ACK = 0x1
 HTTP2_FLAG_END_HEADERS = 0x4
 HTTP2_MAX_TEST_BODY_BYTES = 1024 * 1024
+MAX_GENERATED_FIXTURE_BYTES = 64 * 1024 * 1024
 
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="backslashreplace")
@@ -209,14 +210,34 @@ def validate_case(app_path: str, case: object, names: set[str]) -> None:
     ):
         fail(f"{owner}: env must be an object of strings")
     fixtures = case.get("fixtures", [])
-    if not isinstance(fixtures, list) or not all(
-        isinstance(item, dict)
-        and set(item) == {"source", "dest"}
-        and isinstance(item["source"], str)
-        and isinstance(item["dest"], str)
-        for item in fixtures
-    ):
-        fail(f"{owner}: fixtures must contain source/dest string objects")
+    if not isinstance(fixtures, list):
+        fail(f"{owner}: fixtures must be an array")
+    for fixture in fixtures:
+        if not isinstance(fixture, dict) or not isinstance(fixture.get("dest"), str):
+            fail(f"{owner}: every fixture needs a string dest")
+        keys = set(fixture)
+        allowed_metadata = {"dest", "mtime_unix"}
+        content_keys = keys - allowed_metadata
+        valid_content = (
+            content_keys == {"source"} and isinstance(fixture["source"], str)
+        ) or (
+            content_keys == {"text"} and isinstance(fixture["text"], str)
+        ) or (
+            content_keys == {"hex"} and isinstance(fixture["hex"], str)
+        ) or (
+            content_keys == {"repeat", "size_bytes"}
+            and isinstance(fixture["repeat"], str)
+            and bool(fixture["repeat"])
+            and isinstance(fixture["size_bytes"], int)
+            and 0 <= fixture["size_bytes"] <= MAX_GENERATED_FIXTURE_BYTES
+        )
+        if not valid_content:
+            fail(
+                f"{owner}: fixture content must be source, text, hex, "
+                "or repeat with size_bytes up to 64 MiB"
+            )
+        if "mtime_unix" in fixture and not isinstance(fixture["mtime_unix"], int):
+            fail(f"{owner}: fixture mtime_unix must be an integer")
     http2_requests = case.get("http2_requests", [])
     if not isinstance(http2_requests, list):
         fail(f"{owner}: http2_requests must be an array")
@@ -564,10 +585,28 @@ def install_fixtures(case: dict[str, object], source: Path, temp: Path) -> None:
     assert isinstance(fixtures, list)
     for fixture in fixtures:
         assert isinstance(fixture, dict)
-        src = Path(expanded(str(fixture["source"]), source, temp))
         dest = Path(expanded(str(fixture["dest"]), source, temp))
         dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(src, dest)
+        if "source" in fixture:
+            src = Path(expanded(str(fixture["source"]), source, temp))
+            shutil.copy2(src, dest)
+        elif "text" in fixture:
+            dest.write_text(str(fixture["text"]), encoding="utf-8", newline="")
+        elif "hex" in fixture:
+            dest.write_bytes(bytes.fromhex(str(fixture["hex"])))
+        else:
+            pattern = str(fixture["repeat"]).encode()
+            size = int(fixture["size_bytes"])
+            with dest.open("wb") as output:
+                block = (pattern * (65536 // len(pattern) + 1))[:65536]
+                remaining = size
+                while remaining:
+                    chunk = block[:remaining]
+                    output.write(chunk)
+                    remaining -= len(chunk)
+        if "mtime_unix" in fixture:
+            timestamp = int(fixture["mtime_unix"])
+            os.utime(dest, (timestamp, timestamp))
 
 
 def assertion_text(
@@ -1133,6 +1172,13 @@ def run_http_exchange(port: int, request: dict[str, object], owner: str) -> None
         expected = str(request["expect_body"]).encode()
         if response_body != expected:
             fail(f"{owner}: response body expected {expected!r}, got {response_body!r}")
+    if "expect_body_bytes" in request:
+        expected_length = int(request["expect_body_bytes"])
+        if len(response_body) != expected_length:
+            fail(
+                f"{owner}: response body expected {expected_length} bytes, "
+                f"got {len(response_body)}"
+            )
     body_text = response_body.decode("utf-8", errors="replace")
     assertion_text(owner, "response body", body_text, request, "body_")
 

--- a/scripts/test_harness_test.py
+++ b/scripts/test_harness_test.py
@@ -177,6 +177,36 @@ class SpecValidationTests(unittest.TestCase):
                 test.portable_file_bytes(database), b"first\r\nsecond\r"
             )
 
+    def test_generated_fixtures_are_bounded_and_reproducible(self) -> None:
+        case = {
+            "fixtures": [
+                {
+                    "dest": "{temp}/text.txt",
+                    "text": "hello",
+                    "mtime_unix": 1_700_000_000,
+                },
+                {"dest": "{temp}/bytes.bin", "hex": "00ff10"},
+                {
+                    "dest": "{temp}/large.bin",
+                    "repeat": "abc",
+                    "size_bytes": 65_539,
+                },
+            ]
+        }
+        with tempfile.TemporaryDirectory() as raw_directory:
+            temp = Path(raw_directory)
+            test.install_fixtures(case, test.ROOT, temp)
+
+            self.assertEqual((temp / "text.txt").read_text(), "hello")
+            self.assertEqual(
+                int((temp / "text.txt").stat().st_mtime), 1_700_000_000
+            )
+            self.assertEqual((temp / "bytes.bin").read_bytes(), b"\x00\xff\x10")
+            large = (temp / "large.bin").read_bytes()
+            self.assertEqual(len(large), 65_539)
+            self.assertEqual(large[:9], b"abcabcabc")
+            self.assertEqual(large[-4:], b"aabc")
+
     def test_artifact_manifest_round_trip(self) -> None:
         defaults, apps = test.load_spec()
         with tempfile.TemporaryDirectory() as raw_directory:

--- a/scripts/test_spec.json
+++ b/scripts/test_spec.json
@@ -622,6 +622,378 @@
       ]
     },
     {
+      "path": "examples/static-files.roc",
+      "mode": "server",
+      "cases": [
+        {
+          "name": "public-routes-bypass-roc",
+          "cwd": "temp",
+          "fixtures": [
+            {
+              "dest": "{temp}/assets/hello.txt",
+              "text": "hello asset",
+              "mtime_unix": 1700000000
+            },
+            {
+              "dest": "{temp}/assets/favicon.ico",
+              "hex": "000102",
+              "mtime_unix": 1700000000
+            },
+            {
+              "dest": "{temp}/assets/large.bin",
+              "repeat": "z",
+              "size_bytes": 8388609,
+              "mtime_unix": 1700000000
+            },
+            {
+              "dest": "{temp}/downloads/placeholder.txt",
+              "text": "unused"
+            }
+          ],
+          "requests": [
+            {
+              "target": "/assets/hello.txt?v=1",
+              "expect_body": "hello asset",
+              "response_headers": {
+                "Accept-Ranges": "bytes",
+                "Cache-Control": "public, max-age=3600",
+                "Content-Disposition": "inline",
+                "Content-Length": "11",
+                "Content-Type": "text/plain; charset=utf-8",
+                "Last-Modified": "Tue, 14 Nov 2023 22:13:20 GMT"
+              }
+            },
+            {
+              "method": "HEAD",
+              "target": "/assets/hello.txt",
+              "expect_body": "",
+              "response_headers": {
+                "Content-Length": "11"
+              }
+            },
+            {
+              "target": "/favicon.ico",
+              "expect_body_hex": "000102",
+              "response_headers": {
+                "Content-Type": "image/x-icon"
+              }
+            },
+            {
+              "target": "/assets/large.bin",
+              "expect_body_bytes": 8388609,
+              "response_headers": {
+                "Content-Length": "8388609"
+              }
+            }
+          ],
+          "stdout_regex": [
+            "\\AListening on <http://[^\\n]+>\\n\\Z"
+          ]
+        },
+        {
+          "name": "authorized-file-policy",
+          "cwd": "temp",
+          "fixtures": [
+            {
+              "dest": "{temp}/downloads/reports/annual report.txt",
+              "text": "authorized report",
+              "mtime_unix": 1700000000
+            },
+            {
+              "dest": "{temp}/assets/placeholder.txt",
+              "text": "unused"
+            }
+          ],
+          "requests": [
+            {
+              "target": "/download?token=secret",
+              "expect_body": "authorized report",
+              "response_headers": {
+                "Cache-Control": "no-store",
+                "Content-Disposition": "attachment; filename=\"annual report.txt\"; filename*=UTF-8''annual%20report.txt",
+                "Content-Length": "17",
+                "Content-Type": "text/plain; charset=utf-8"
+              }
+            },
+            {
+              "target": "/download",
+              "status": 403,
+              "expect_body": "Download denied"
+            }
+          ],
+          "stdout_contains": [
+            "Roc handled /download?token=secret",
+            "Roc handled /download"
+          ]
+        },
+        {
+          "name": "owned-route-security-and-methods",
+          "cwd": "temp",
+          "fixtures": [
+            {
+              "dest": "{temp}/assets/hello.txt",
+              "text": "hello asset"
+            },
+            {
+              "dest": "{temp}/assets/.hidden",
+              "text": "hidden"
+            },
+            {
+              "dest": "{temp}/assets/subdir/inside.txt",
+              "text": "inside"
+            },
+            {
+              "dest": "{temp}/downloads/placeholder.txt",
+              "text": "unused"
+            }
+          ],
+          "requests": [
+            {
+              "target": "/assets/missing.txt",
+              "status": 404,
+              "expect_body": ""
+            },
+            {
+              "target": "/assets",
+              "status": 404,
+              "expect_body": ""
+            },
+            {
+              "target": "/assets/subdir",
+              "status": 404,
+              "expect_body": ""
+            },
+            {
+              "target": "/assets/.hidden",
+              "status": 404,
+              "expect_body": ""
+            },
+            {
+              "target": "/assets/%2e%2e/hello.txt",
+              "status": 404,
+              "expect_body": ""
+            },
+            {
+              "target": "/assets/subdir%2Finside.txt",
+              "status": 404,
+              "expect_body": ""
+            },
+            {
+              "target": "/assets/subdir%5Cinside.txt",
+              "status": 404,
+              "expect_body": ""
+            },
+            {
+              "target": "/assets/C:%5Csecret.txt",
+              "status": 404,
+              "expect_body": ""
+            },
+            {
+              "target": "/assets/%FF",
+              "status": 404,
+              "expect_body": ""
+            },
+            {
+              "method": "POST",
+              "target": "/assets/hello.txt",
+              "status": 405,
+              "expect_body": "Method Not Allowed",
+              "response_headers": {
+                "Allow": "GET, HEAD"
+              }
+            },
+            {
+              "target": "/assets2/hello.txt",
+              "status": 404,
+              "expect_body": "Roc fallback"
+            }
+          ],
+          "stdout_contains": [
+            "Roc handled /assets2/hello.txt"
+          ]
+        },
+        {
+          "name": "conditional-and-range-semantics",
+          "cwd": "temp",
+          "fixtures": [
+            {
+              "dest": "{temp}/assets/hello.txt",
+              "text": "hello asset",
+              "mtime_unix": 1700000000
+            },
+            {
+              "dest": "{temp}/assets/empty.bin",
+              "hex": "",
+              "mtime_unix": 1700000000
+            },
+            {
+              "dest": "{temp}/assets/data.unknown",
+              "hex": "00ff",
+              "mtime_unix": 1700000000
+            },
+            {
+              "dest": "{temp}/downloads/placeholder.txt",
+              "text": "unused"
+            }
+          ],
+          "requests": [
+            {
+              "target": "/assets/hello.txt",
+              "headers": {
+                "If-None-Match": "*"
+              },
+              "status": 304,
+              "expect_body": ""
+            },
+            {
+              "target": "/assets/hello.txt",
+              "headers": {
+                "If-Match": "\"bogus\""
+              },
+              "status": 412,
+              "expect_body": ""
+            },
+            {
+              "target": "/assets/hello.txt",
+              "headers": {
+                "If-Unmodified-Since": "Wed, 01 Jan 2020 00:00:00 GMT"
+              },
+              "status": 412,
+              "expect_body": ""
+            },
+            {
+              "target": "/assets/hello.txt",
+              "headers": {
+                "If-Modified-Since": "Wed, 01 Jan 2025 00:00:00 GMT"
+              },
+              "status": 304,
+              "expect_body": ""
+            },
+            {
+              "target": "/assets/hello.txt",
+              "headers": {
+                "If-None-Match": "\"bogus\"",
+                "If-Modified-Since": "Wed, 01 Jan 2025 00:00:00 GMT"
+              },
+              "expect_body": "hello asset"
+            },
+            {
+              "target": "/assets/hello.txt",
+              "headers": {
+                "Range": "bytes=0-4"
+              },
+              "status": 206,
+              "expect_body": "hello",
+              "response_headers": {
+                "Content-Length": "5",
+                "Content-Range": "bytes 0-4/11"
+              }
+            },
+            {
+              "method": "HEAD",
+              "target": "/assets/hello.txt",
+              "headers": {
+                "Range": "bytes=-5"
+              },
+              "status": 206,
+              "expect_body": "",
+              "response_headers": {
+                "Content-Length": "5",
+                "Content-Range": "bytes 6-10/11"
+              }
+            },
+            {
+              "target": "/assets/hello.txt",
+              "headers": {
+                "Range": "bytes=6-"
+              },
+              "status": 206,
+              "expect_body": "asset"
+            },
+            {
+              "target": "/assets/hello.txt",
+              "headers": {
+                "Range": "bytes=99-"
+              },
+              "status": 416,
+              "expect_body": "",
+              "response_headers": {
+                "Content-Range": "bytes */11"
+              }
+            },
+            {
+              "target": "/assets/hello.txt",
+              "headers": {
+                "Range": "bytes=0-1,4-5"
+              },
+              "expect_body": "hello asset"
+            },
+            {
+              "target": "/assets/hello.txt",
+              "headers": {
+                "Range": "bytes=0-4",
+                "If-Range": "Wed, 01 Jan 2025 00:00:00 GMT"
+              },
+              "status": 206,
+              "expect_body": "hello"
+            },
+            {
+              "target": "/assets/hello.txt",
+              "headers": {
+                "Range": "bytes=0-4",
+                "If-Range": "W/\"bogus\""
+              },
+              "expect_body": "hello asset"
+            },
+            {
+              "target": "/assets/empty.bin",
+              "expect_body": "",
+              "response_headers": {
+                "Content-Length": "0"
+              }
+            },
+            {
+              "target": "/assets/data.unknown",
+              "expect_body_hex": "00ff",
+              "response_headers": {
+                "Content-Type": "application/octet-stream"
+              }
+            }
+          ],
+          "stdout_regex": [
+            "\\AListening on <http://[^\\n]+>\\n\\Z"
+          ]
+        },
+        {
+          "name": "http2-native-files",
+          "cwd": "temp",
+          "fixtures": [
+            {
+              "dest": "{temp}/assets/one.txt",
+              "text": "one"
+            },
+            {
+              "dest": "{temp}/downloads/placeholder.txt",
+              "text": "unused"
+            }
+          ],
+          "http2_requests": [
+            {
+              "name": "one",
+              "target": "/assets/one.txt",
+              "expect_body": "one"
+            }
+          ],
+          "http2_completion_order": [
+            "one"
+          ],
+          "stdout_regex": [
+            "\\AListening on <http://[^\\n]+>\\n\\Z"
+          ]
+        }
+      ]
+    },
+    {
       "path": "examples/tcp.roc",
       "mode": "server",
       "cases": [

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -120,6 +120,8 @@ pub(crate) type HostIOErrPayloadType = IOErrPayload;
 pub(crate) type HostIOErrTagType = IOErrTag;
 
 pub(crate) type ServerConfig = InitForHostOkConfig;
+pub(crate) type ServerFileRoot = InitForHostOkConfigFileRoots;
+pub(crate) type ServerNativeRoute = InitForHostOkConfigNativeRoutes;
 pub(crate) type ServerRequest = RespondForHostArg0;
 pub(crate) type ServerResponse = RespondForHost;
 pub(crate) type ServerHeader = RespondForHostArg0Headers;

--- a/src/file_server.rs
+++ b/src/file_server.rs
@@ -1,0 +1,1446 @@
+//! Immutable native file routes and host-owned, bounded file responses.
+
+use crate::shutdown::ActiveRequest;
+use bytes::Bytes;
+use cap_primitives::fs::{open, open_ambient_dir, open_dir_nofollow, FollowSymlinks, OpenOptions};
+use http_body_util::{combinators::UnsyncBoxBody, BodyExt, Empty, Full};
+use hyper::body::{Body, Frame, SizeHint};
+use hyper::header::{
+    ACCEPT_RANGES, ALLOW, CACHE_CONTROL, CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_RANGE,
+    CONTENT_TYPE, ETAG, IF_MATCH, IF_MODIFIED_SINCE, IF_NONE_MATCH, IF_RANGE, IF_UNMODIFIED_SINCE,
+    LAST_MODIFIED, RANGE,
+};
+use hyper::{HeaderMap, Method, StatusCode};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::File;
+use std::io::{self, Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
+
+pub(crate) type ServerBody = UnsyncBoxBody<Bytes, io::Error>;
+pub(crate) type ServerResponse = hyper::Response<ServerBody>;
+
+const MAX_FILE_ROOTS: usize = 64;
+const MAX_NATIVE_ROUTES: usize = 128;
+const MAX_ROUTE_PATH_BYTES: usize = 4 * 1024;
+const MAX_RELATIVE_PATH_BYTES: usize = 4 * 1024;
+const MAX_DOWNLOAD_NAME_CHARS: usize = 150;
+
+pub(crate) fn full_body(bytes: Bytes) -> ServerBody {
+    Full::new(bytes)
+        .map_err(|never| match never {})
+        .boxed_unsync()
+}
+
+pub(crate) fn empty_body() -> ServerBody {
+    Empty::<Bytes>::new()
+        .map_err(|never| match never {})
+        .boxed_unsync()
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CachePolicy {
+    NoStore,
+    Revalidate,
+    PrivateFor(u32),
+    PublicFor(u32),
+}
+
+impl CachePolicy {
+    pub(crate) fn from_abi(tag: u8, max_age_seconds: u32) -> Result<Self, String> {
+        match tag {
+            0 if max_age_seconds == 0 => Ok(Self::NoStore),
+            1 if max_age_seconds == 0 => Ok(Self::Revalidate),
+            2 => Ok(Self::PrivateFor(max_age_seconds)),
+            3 => Ok(Self::PublicFor(max_age_seconds)),
+            _ => Err("invalid file cache policy".to_owned()),
+        }
+    }
+
+    fn header_value(self) -> String {
+        match self {
+            Self::NoStore => "no-store".to_owned(),
+            Self::Revalidate => "no-cache".to_owned(),
+            Self::PrivateFor(seconds) => format!("private, max-age={seconds}"),
+            Self::PublicFor(seconds) => format!("public, max-age={seconds}"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct FileRootSpec {
+    pub(crate) id: String,
+    pub(crate) path: PathBuf,
+    pub(crate) cache: CachePolicy,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum NativeRouteKind {
+    Prefix,
+    Exact,
+}
+
+#[derive(Debug)]
+pub(crate) struct NativeRouteSpec {
+    pub(crate) at: String,
+    pub(crate) root_id: String,
+    pub(crate) kind: NativeRouteKind,
+    pub(crate) relative: String,
+    pub(crate) cache: Option<CachePolicy>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum Disposition {
+    Inline,
+    Attachment(String),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct FilePlan {
+    root_id: String,
+    relative: String,
+    encoded_uri_path: bool,
+    disposition: Disposition,
+    cache: Option<CachePolicy>,
+}
+
+impl FilePlan {
+    pub(crate) fn authorized(
+        root_id: String,
+        relative: String,
+        disposition: Disposition,
+        cache: Option<CachePolicy>,
+    ) -> Self {
+        Self {
+            root_id,
+            relative,
+            encoded_uri_path: false,
+            disposition,
+            cache,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FileRoot {
+    handle: File,
+    cache: CachePolicy,
+}
+
+#[derive(Clone, Debug)]
+struct NativeRoute {
+    at: String,
+    root_id: String,
+    kind: NativeRouteKind,
+    relative: String,
+    cache: Option<CachePolicy>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct FileService {
+    roots: Arc<BTreeMap<String, Arc<FileRoot>>>,
+    exact_routes: Arc<BTreeMap<String, NativeRoute>>,
+    prefix_routes: Arc<Vec<NativeRoute>>,
+    transfers: Arc<Semaphore>,
+    chunk_bytes: usize,
+    diagnostics: Arc<TransferDiagnostics>,
+}
+
+impl FileService {
+    pub(crate) fn activate(
+        root_specs: Vec<FileRootSpec>,
+        route_specs: Vec<NativeRouteSpec>,
+        max_concurrent: usize,
+        chunk_bytes: usize,
+    ) -> Result<Self, String> {
+        if root_specs.len() > MAX_FILE_ROOTS {
+            return Err(format!(
+                "at most {MAX_FILE_ROOTS} file roots may be declared"
+            ));
+        }
+        if route_specs.len() > MAX_NATIVE_ROUTES {
+            return Err(format!(
+                "at most {MAX_NATIVE_ROUTES} native routes may be declared"
+            ));
+        }
+        if max_concurrent == 0 {
+            return Err("maximum concurrent file transfers must be non-zero".to_owned());
+        }
+        if chunk_bytes == 0 {
+            return Err("file transfer chunk size must be non-zero".to_owned());
+        }
+
+        let mut roots = BTreeMap::new();
+        for spec in root_specs {
+            validate_root_id(&spec.id)?;
+            if roots.contains_key(&spec.id) {
+                return Err(format!("duplicate file root identifier {:?}", spec.id));
+            }
+            let handle = open_ambient_dir(&spec.path, cap_primitives::ambient_authority())
+                .map_err(|error| {
+                    format!(
+                        "file root {:?} is missing, inaccessible, or not a directory: {error}",
+                        spec.id
+                    )
+                })?;
+            let metadata = handle
+                .metadata()
+                .map_err(|error| format!("failed to inspect file root {:?}: {error}", spec.id))?;
+            if !metadata.is_dir() {
+                return Err(format!("file root {:?} is not a directory", spec.id));
+            }
+            roots.insert(
+                spec.id,
+                Arc::new(FileRoot {
+                    handle,
+                    cache: spec.cache,
+                }),
+            );
+        }
+
+        let mut exact_routes = BTreeMap::new();
+        let mut prefix_routes = Vec::new();
+        let mut prefix_paths = BTreeSet::new();
+        for spec in route_specs {
+            validate_route_path(&spec.at)?;
+            if !roots.contains_key(&spec.root_id) {
+                return Err(format!(
+                    "native route {:?} references undeclared file root {:?}",
+                    spec.at, spec.root_id
+                ));
+            }
+            if spec.kind == NativeRouteKind::Exact {
+                validate_relative_path(&spec.relative)?;
+            } else if !spec.relative.is_empty() {
+                return Err(format!(
+                    "static mount {:?} supplied an unexpected relative file",
+                    spec.at
+                ));
+            }
+            let route = NativeRoute {
+                at: spec.at.clone(),
+                root_id: spec.root_id,
+                kind: spec.kind,
+                relative: spec.relative,
+                cache: spec.cache,
+            };
+            match spec.kind {
+                NativeRouteKind::Exact => {
+                    if exact_routes.insert(spec.at.clone(), route).is_some() {
+                        return Err(format!("duplicate exact native route {:?}", spec.at));
+                    }
+                }
+                NativeRouteKind::Prefix => {
+                    if !prefix_paths.insert(spec.at.clone()) {
+                        return Err(format!("duplicate native route prefix {:?}", spec.at));
+                    }
+                    prefix_routes.push(route);
+                }
+            }
+        }
+        prefix_routes.sort_by(|left, right| {
+            right
+                .at
+                .len()
+                .cmp(&left.at.len())
+                .then_with(|| left.at.cmp(&right.at))
+        });
+
+        Ok(Self {
+            roots: Arc::new(roots),
+            exact_routes: Arc::new(exact_routes),
+            prefix_routes: Arc::new(prefix_routes),
+            transfers: Arc::new(Semaphore::new(max_concurrent)),
+            chunk_bytes,
+            diagnostics: Arc::new(TransferDiagnostics::default()),
+        })
+    }
+
+    pub(crate) fn route(&self, uri_path: &str) -> Option<FilePlan> {
+        if let Some(route) = self.exact_routes.get(uri_path) {
+            return Some(route.plan(route.relative.clone(), false));
+        }
+        for route in self.prefix_routes.iter() {
+            let relative = if route.at == "/" {
+                match uri_path.strip_prefix('/') {
+                    Some(relative) => relative,
+                    None => continue,
+                }
+            } else if uri_path == route.at {
+                ""
+            } else {
+                match uri_path
+                    .strip_prefix(&route.at)
+                    .and_then(|suffix| suffix.strip_prefix('/'))
+                {
+                    Some(relative) => relative,
+                    None => continue,
+                }
+            };
+            return Some(route.plan(relative.to_owned(), true));
+        }
+        None
+    }
+
+    pub(crate) async fn serve(
+        &self,
+        plan: FilePlan,
+        method: Method,
+        headers: HeaderMap,
+        active_request: Arc<ActiveRequest>,
+    ) -> ServerResponse {
+        if method != Method::GET && method != Method::HEAD {
+            return simple_response(
+                StatusCode::METHOD_NOT_ALLOWED,
+                &[(ALLOW, "GET, HEAD")],
+                Bytes::from_static(b"Method Not Allowed"),
+            );
+        }
+        let root = match self.roots.get(&plan.root_id) {
+            Some(root) => Arc::clone(root),
+            None => {
+                eprintln!(
+                    "Roc returned a file response for undeclared root {:?}",
+                    plan.root_id
+                );
+                return simple_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &[],
+                    Bytes::from_static(b"Internal Server Error"),
+                );
+            }
+        };
+        let permit = match Arc::clone(&self.transfers).try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                return simple_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    &[],
+                    Bytes::from_static(b"Native file transfer capacity is exhausted"),
+                );
+            }
+        };
+        let lease = TransferLease::new(permit, active_request, Arc::clone(&self.diagnostics));
+        let chunk_bytes = self.chunk_bytes;
+        let (prepared_sender, prepared_receiver) = oneshot::channel();
+        let spawn_result = std::thread::Builder::new()
+            .name("basic-webserver-file".to_owned())
+            .spawn(move || {
+                prepare_and_stream(
+                    root,
+                    plan,
+                    method,
+                    headers,
+                    chunk_bytes,
+                    lease,
+                    prepared_sender,
+                );
+            });
+        if let Err(error) = spawn_result {
+            return simple_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &[],
+                Bytes::from(format!("Failed to start file transfer: {error}")),
+            );
+        }
+
+        match prepared_receiver.await {
+            Ok(prepared) => prepared.into_response(),
+            Err(_) => simple_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &[],
+                Bytes::from_static(b"File transfer failed before producing a response"),
+            ),
+        }
+    }
+
+    pub(crate) fn active_transfers(&self) -> usize {
+        self.diagnostics.active.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn high_water_transfers(&self) -> usize {
+        self.diagnostics.high_water.load(Ordering::Acquire)
+    }
+}
+
+impl NativeRoute {
+    fn plan(&self, relative: String, encoded_uri_path: bool) -> FilePlan {
+        debug_assert!(
+            self.kind == NativeRouteKind::Prefix || !encoded_uri_path,
+            "only prefix routes derive paths from request URIs"
+        );
+        FilePlan {
+            root_id: self.root_id.clone(),
+            relative,
+            encoded_uri_path,
+            disposition: Disposition::Inline,
+            cache: self.cache,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct TransferDiagnostics {
+    active: AtomicUsize,
+    high_water: AtomicUsize,
+}
+
+struct TransferLease {
+    _permit: OwnedSemaphorePermit,
+    _active_request: Arc<ActiveRequest>,
+    diagnostics: Arc<TransferDiagnostics>,
+}
+
+impl TransferLease {
+    fn new(
+        permit: OwnedSemaphorePermit,
+        active_request: Arc<ActiveRequest>,
+        diagnostics: Arc<TransferDiagnostics>,
+    ) -> Arc<Self> {
+        let active = diagnostics.active.fetch_add(1, Ordering::AcqRel) + 1;
+        diagnostics.high_water.fetch_max(active, Ordering::AcqRel);
+        Arc::new(Self {
+            _permit: permit,
+            _active_request: active_request,
+            diagnostics,
+        })
+    }
+}
+
+impl Drop for TransferLease {
+    fn drop(&mut self) {
+        let previous = self.diagnostics.active.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "file transfer accounting underflow");
+    }
+}
+
+struct FileBody {
+    receiver: mpsc::Receiver<io::Result<Bytes>>,
+    lease: Option<Arc<TransferLease>>,
+    remaining: u64,
+}
+
+impl Body for FileBody {
+    type Data = Bytes;
+    type Error = io::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        match self.receiver.poll_recv(context) {
+            Poll::Ready(Some(Ok(bytes))) => {
+                self.remaining = self.remaining.saturating_sub(bytes.len() as u64);
+                Poll::Ready(Some(Ok(Frame::data(bytes))))
+            }
+            Poll::Ready(Some(Err(error))) => {
+                self.lease.take();
+                Poll::Ready(Some(Err(error)))
+            }
+            Poll::Ready(None) => {
+                self.lease.take();
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.remaining == 0
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::with_exact(self.remaining)
+    }
+}
+
+struct Prepared {
+    status: StatusCode,
+    headers: HeaderMap,
+    body: Option<FileBody>,
+}
+
+impl Prepared {
+    fn into_response(self) -> ServerResponse {
+        let body = self
+            .body
+            .map_or_else(empty_body, |body| body.boxed_unsync());
+        let mut response = hyper::Response::new(body);
+        *response.status_mut() = self.status;
+        *response.headers_mut() = self.headers;
+        response
+    }
+
+    fn without_body(status: StatusCode, headers: HeaderMap) -> Self {
+        Self {
+            status,
+            headers,
+            body: None,
+        }
+    }
+}
+
+fn prepare_and_stream(
+    root: Arc<FileRoot>,
+    plan: FilePlan,
+    method: Method,
+    request_headers: HeaderMap,
+    chunk_bytes: usize,
+    lease: Arc<TransferLease>,
+    prepared_sender: oneshot::Sender<Prepared>,
+) {
+    let segments = if plan.encoded_uri_path {
+        decode_uri_relative_path(&plan.relative)
+    } else {
+        validate_relative_path(&plan.relative)
+    };
+    let segments = match segments {
+        Ok(segments) => segments,
+        Err(_) => {
+            let _ = prepared_sender.send(not_found());
+            return;
+        }
+    };
+    let mut file = match open_relative_file(&root.handle, &segments) {
+        Ok(file) => file,
+        Err(_) => {
+            let _ = prepared_sender.send(not_found());
+            return;
+        }
+    };
+    let metadata = match file.metadata() {
+        Ok(metadata) if metadata.is_file() => metadata,
+        _ => {
+            let _ = prepared_sender.send(not_found());
+            return;
+        }
+    };
+    let length = metadata.len();
+    let modified = metadata.modified().ok();
+    let etag = weak_etag(length, modified);
+    let cache = plan.cache.unwrap_or(root.cache);
+    let mut response_headers = representation_headers(
+        segments
+            .last()
+            .expect("validated relative paths contain a final component"),
+        length,
+        modified,
+        &etag,
+        cache,
+        &plan.disposition,
+    );
+
+    if let Some(status) = precondition_status(&request_headers, &etag, modified, &method) {
+        if status == StatusCode::NOT_MODIFIED {
+            response_headers.remove(CONTENT_LENGTH);
+            response_headers.remove(CONTENT_TYPE);
+            response_headers.remove(CONTENT_DISPOSITION);
+        } else {
+            response_headers.insert(CONTENT_LENGTH, hyper::header::HeaderValue::from_static("0"));
+        }
+        let _ = prepared_sender.send(Prepared::without_body(status, response_headers));
+        return;
+    }
+
+    let selected_range = if if_range_allows(&request_headers, &etag, modified) {
+        parse_range(&request_headers, length)
+    } else {
+        RangeSelection::Ignore
+    };
+    let (status, start, response_length) = match selected_range {
+        RangeSelection::Ignore => (StatusCode::OK, 0, length),
+        RangeSelection::Unsatisfiable => {
+            response_headers.insert(
+                CONTENT_RANGE,
+                format!("bytes */{length}")
+                    .parse()
+                    .expect("content range generated by host is valid"),
+            );
+            response_headers.insert(CONTENT_LENGTH, hyper::header::HeaderValue::from_static("0"));
+            let _ = prepared_sender.send(Prepared::without_body(
+                StatusCode::RANGE_NOT_SATISFIABLE,
+                response_headers,
+            ));
+            return;
+        }
+        RangeSelection::Range { start, end } => {
+            let response_length = end - start + 1;
+            response_headers.insert(
+                CONTENT_RANGE,
+                format!("bytes {start}-{end}/{length}")
+                    .parse()
+                    .expect("content range generated by host is valid"),
+            );
+            (StatusCode::PARTIAL_CONTENT, start, response_length)
+        }
+    };
+    response_headers.insert(
+        CONTENT_LENGTH,
+        response_length
+            .to_string()
+            .parse()
+            .expect("content length generated by host is valid"),
+    );
+
+    if method == Method::HEAD || response_length == 0 {
+        let _ = prepared_sender.send(Prepared::without_body(status, response_headers));
+        return;
+    }
+    if file.seek(SeekFrom::Start(start)).is_err() {
+        let _ = prepared_sender.send(not_found());
+        return;
+    }
+
+    let (body_sender, body_receiver) = mpsc::channel(1);
+    let body = FileBody {
+        receiver: body_receiver,
+        lease: Some(Arc::clone(&lease)),
+        remaining: response_length,
+    };
+    if prepared_sender
+        .send(Prepared {
+            status,
+            headers: response_headers,
+            body: Some(body),
+        })
+        .is_err()
+    {
+        return;
+    }
+
+    let mut remaining = response_length;
+    while remaining > 0 {
+        let next = usize::try_from(remaining.min(chunk_bytes as u64))
+            .expect("bounded file chunk fits usize");
+        let mut buffer = vec![0; next];
+        if let Err(error) = file.read_exact(&mut buffer) {
+            let _ = body_sender.blocking_send(Err(error));
+            return;
+        }
+        remaining -= next as u64;
+        if body_sender.blocking_send(Ok(Bytes::from(buffer))).is_err() {
+            return;
+        }
+    }
+}
+
+fn simple_response(
+    status: StatusCode,
+    headers: &[(hyper::header::HeaderName, &'static str)],
+    body: Bytes,
+) -> ServerResponse {
+    let mut response = hyper::Response::new(full_body(body));
+    *response.status_mut() = status;
+    for (name, value) in headers {
+        response
+            .headers_mut()
+            .insert(name, hyper::header::HeaderValue::from_static(value));
+    }
+    response
+}
+
+fn not_found() -> Prepared {
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_LENGTH, hyper::header::HeaderValue::from_static("0"));
+    Prepared::without_body(StatusCode::NOT_FOUND, headers)
+}
+
+fn validate_root_id(id: &str) -> Result<(), String> {
+    if id.is_empty()
+        || id.len() > 64
+        || !id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(format!(
+            "file root identifier {id:?} must contain 1-64 ASCII letters, digits, '-' or '_'"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_route_path(path: &str) -> Result<(), String> {
+    if !path.starts_with('/')
+        || path.len() > MAX_ROUTE_PATH_BYTES
+        || (path.len() > 1 && path.ends_with('/'))
+        || path.contains("//")
+        || !path.is_ascii()
+        || path
+            .bytes()
+            .any(|byte| byte == b'%' || byte == b'\\' || byte == 0 || byte == b'?')
+    {
+        return Err(format!("invalid native route path {path:?}"));
+    }
+    for segment in path.split('/').skip(1) {
+        if segment == "." || segment == ".." || segment.starts_with('.') {
+            return Err(format!("invalid native route path {path:?}"));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_relative_path(relative: &str) -> Result<Vec<String>, String> {
+    if relative.is_empty() || relative.len() > MAX_RELATIVE_PATH_BYTES {
+        return Err("relative file path is empty or too long".to_owned());
+    }
+    relative.split('/').map(validate_decoded_segment).collect()
+}
+
+fn decode_uri_relative_path(relative: &str) -> Result<Vec<String>, String> {
+    if relative.is_empty() || relative.len() > MAX_RELATIVE_PATH_BYTES {
+        return Err("relative file path is empty or too long".to_owned());
+    }
+    relative
+        .split('/')
+        .map(|segment| {
+            if segment.is_empty() || segment.as_bytes().contains(&b'\\') {
+                return Err("invalid URI path component".to_owned());
+            }
+            let bytes = percent_decode(segment.as_bytes())?;
+            let decoded =
+                String::from_utf8(bytes).map_err(|_| "URI path is not valid UTF-8".to_owned())?;
+            validate_decoded_segment(&decoded)
+        })
+        .collect()
+}
+
+fn percent_decode(input: &[u8]) -> Result<Vec<u8>, String> {
+    let mut output = Vec::with_capacity(input.len());
+    let mut index = 0;
+    while index < input.len() {
+        if input[index] != b'%' {
+            output.push(input[index]);
+            index += 1;
+            continue;
+        }
+        if index + 2 >= input.len() {
+            return Err("truncated percent escape".to_owned());
+        }
+        let high =
+            hex_value(input[index + 1]).ok_or_else(|| "invalid percent escape".to_owned())?;
+        let low = hex_value(input[index + 2]).ok_or_else(|| "invalid percent escape".to_owned())?;
+        let byte = high * 16 + low;
+        if byte == b'/' || byte == b'\\' {
+            return Err("encoded path separator".to_owned());
+        }
+        output.push(byte);
+        index += 3;
+    }
+    Ok(output)
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn validate_decoded_segment(segment: &str) -> Result<String, String> {
+    if segment.is_empty()
+        || segment == "."
+        || segment == ".."
+        || segment.starts_with('.')
+        || segment
+            .bytes()
+            .any(|byte| byte == 0 || byte == b'\\' || byte == b':' || byte == b'/')
+    {
+        return Err("unsafe relative file component".to_owned());
+    }
+    Ok(segment.to_owned())
+}
+
+fn open_relative_file(root: &File, segments: &[String]) -> io::Result<File> {
+    let (last, parents) = segments
+        .split_last()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "empty relative path"))?;
+    let mut current = root.try_clone()?;
+    for parent in parents {
+        current = open_dir_nofollow(&current, Path::new(parent))?;
+    }
+    let mut options = OpenOptions::new();
+    options.read(true)._cap_fs_ext_follow(FollowSymlinks::No);
+    open(&current, Path::new(last), &options)
+}
+
+fn representation_headers(
+    relative: &str,
+    length: u64,
+    modified: Option<SystemTime>,
+    etag: &str,
+    cache: CachePolicy,
+    disposition: &Disposition,
+) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        ACCEPT_RANGES,
+        hyper::header::HeaderValue::from_static("bytes"),
+    );
+    headers.insert(
+        CACHE_CONTROL,
+        cache
+            .header_value()
+            .parse()
+            .expect("typed cache policy generates a valid header"),
+    );
+    headers.insert(
+        CONTENT_LENGTH,
+        length
+            .to_string()
+            .parse()
+            .expect("file length generates a valid header"),
+    );
+    headers.insert(
+        CONTENT_TYPE,
+        content_type(relative)
+            .parse()
+            .expect("static content type is a valid header"),
+    );
+    headers.insert(
+        ETAG,
+        etag.parse()
+            .expect("host-generated ETag is a valid header value"),
+    );
+    if let Some(modified) = modified {
+        headers.insert(
+            LAST_MODIFIED,
+            httpdate::fmt_http_date(modified)
+                .parse()
+                .expect("HTTP date is a valid header"),
+        );
+    }
+    let disposition = match disposition {
+        Disposition::Inline => "inline".to_owned(),
+        Disposition::Attachment(name) => attachment_header(name),
+    };
+    headers.insert(
+        CONTENT_DISPOSITION,
+        disposition
+            .parse()
+            .expect("encoded content disposition is a valid header"),
+    );
+    headers
+}
+
+fn content_type(relative: &str) -> &'static str {
+    let extension = relative
+        .rsplit('/')
+        .next()
+        .and_then(|name| name.rsplit_once('.').map(|(_, extension)| extension))
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match extension.as_str() {
+        "css" => "text/css; charset=utf-8",
+        "csv" => "text/csv; charset=utf-8",
+        "gif" => "image/gif",
+        "htm" | "html" => "text/html; charset=utf-8",
+        "ico" => "image/x-icon",
+        "jpeg" | "jpg" => "image/jpeg",
+        "js" | "mjs" => "text/javascript; charset=utf-8",
+        "json" => "application/json",
+        "pdf" => "application/pdf",
+        "png" => "image/png",
+        "svg" => "image/svg+xml",
+        "txt" => "text/plain; charset=utf-8",
+        "wasm" => "application/wasm",
+        "webp" => "image/webp",
+        "xml" => "application/xml",
+        _ => "application/octet-stream",
+    }
+}
+
+fn attachment_header(name: &str) -> String {
+    let bounded: String = name.chars().take(MAX_DOWNLOAD_NAME_CHARS).collect();
+    let fallback: String = bounded
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, ' ' | '-' | '_' | '.') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let fallback = if fallback.is_empty() {
+        "download"
+    } else {
+        fallback.as_str()
+    };
+    let encoded = bounded
+        .as_bytes()
+        .iter()
+        .map(|byte| {
+            if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_') {
+                (*byte as char).to_string()
+            } else {
+                format!("%{byte:02X}")
+            }
+        })
+        .collect::<String>();
+    format!("attachment; filename=\"{fallback}\"; filename*=UTF-8''{encoded}")
+}
+
+fn weak_etag(length: u64, modified: Option<SystemTime>) -> String {
+    let nanos = modified
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map_or(0, |duration| duration.as_nanos());
+    format!("W/\"{length:x}-{nanos:x}\"")
+}
+
+fn precondition_status(
+    headers: &HeaderMap,
+    etag: &str,
+    modified: Option<SystemTime>,
+    method: &Method,
+) -> Option<StatusCode> {
+    if headers.contains_key(IF_MATCH) {
+        if !etag_condition_matches(headers, IF_MATCH, etag, false) {
+            return Some(StatusCode::PRECONDITION_FAILED);
+        }
+    } else if let (Some(value), Some(modified)) = (headers.get(IF_UNMODIFIED_SINCE), modified) {
+        if parse_http_date(value).is_some_and(|date| is_later(modified, date)) {
+            return Some(StatusCode::PRECONDITION_FAILED);
+        }
+    }
+
+    if headers.contains_key(IF_NONE_MATCH) {
+        if etag_condition_matches(headers, IF_NONE_MATCH, etag, true) {
+            return Some(if method == Method::GET || method == Method::HEAD {
+                StatusCode::NOT_MODIFIED
+            } else {
+                StatusCode::PRECONDITION_FAILED
+            });
+        }
+    } else if method == Method::GET || method == Method::HEAD {
+        if let (Some(value), Some(modified)) = (headers.get(IF_MODIFIED_SINCE), modified) {
+            if parse_http_date(value).is_some_and(|date| !is_later(modified, date)) {
+                return Some(StatusCode::NOT_MODIFIED);
+            }
+        }
+    }
+    None
+}
+
+fn etag_condition_matches(
+    headers: &HeaderMap,
+    name: hyper::header::HeaderName,
+    current: &str,
+    weak: bool,
+) -> bool {
+    headers.get_all(name).iter().any(|value| {
+        value.to_str().ok().is_some_and(|raw| {
+            raw.split(',').any(|candidate| {
+                let candidate = candidate.trim();
+                candidate == "*"
+                    || if weak {
+                        strip_weak(candidate) == strip_weak(current)
+                            && candidate.ends_with('"')
+                            && candidate.contains('"')
+                    } else {
+                        !candidate.starts_with("W/") && candidate == current
+                    }
+            })
+        })
+    })
+}
+
+fn strip_weak(value: &str) -> &str {
+    value.strip_prefix("W/").unwrap_or(value)
+}
+
+fn parse_http_date(value: &hyper::header::HeaderValue) -> Option<SystemTime> {
+    value
+        .to_str()
+        .ok()
+        .and_then(|raw| httpdate::parse_http_date(raw).ok())
+}
+
+fn unix_seconds(time: SystemTime) -> u64 {
+    time.duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_secs())
+}
+
+fn is_later(left: SystemTime, right: SystemTime) -> bool {
+    unix_seconds(left) > unix_seconds(right)
+}
+
+fn if_range_allows(headers: &HeaderMap, etag: &str, modified: Option<SystemTime>) -> bool {
+    let Some(value) = headers.get(IF_RANGE) else {
+        return true;
+    };
+    let Ok(raw) = value.to_str() else {
+        return false;
+    };
+    if raw.starts_with('"') || raw.starts_with("W/") {
+        return !raw.starts_with("W/") && !etag.starts_with("W/") && raw == etag;
+    }
+    match (httpdate::parse_http_date(raw).ok(), modified) {
+        (Some(date), Some(modified)) => !is_later(modified, date),
+        _ => false,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RangeSelection {
+    Ignore,
+    Unsatisfiable,
+    Range { start: u64, end: u64 },
+}
+
+fn parse_range(headers: &HeaderMap, length: u64) -> RangeSelection {
+    let mut values = headers.get_all(RANGE).iter();
+    let Some(value) = values.next() else {
+        return RangeSelection::Ignore;
+    };
+    if values.next().is_some() {
+        return RangeSelection::Ignore;
+    }
+    let Some(raw) = value.to_str().ok() else {
+        return RangeSelection::Ignore;
+    };
+    let Some(spec) = raw.strip_prefix("bytes=") else {
+        return RangeSelection::Ignore;
+    };
+    if spec.contains(',') {
+        return RangeSelection::Ignore;
+    }
+    let Some((first, last)) = spec.split_once('-') else {
+        return RangeSelection::Ignore;
+    };
+    if first.is_empty() {
+        let Ok(suffix) = last.parse::<u64>() else {
+            return RangeSelection::Ignore;
+        };
+        if suffix == 0 || length == 0 {
+            return RangeSelection::Unsatisfiable;
+        }
+        let start = length.saturating_sub(suffix);
+        return RangeSelection::Range {
+            start,
+            end: length - 1,
+        };
+    }
+    let Ok(start) = first.parse::<u64>() else {
+        return RangeSelection::Ignore;
+    };
+    if start >= length {
+        return RangeSelection::Unsatisfiable;
+    }
+    if last.is_empty() {
+        return RangeSelection::Range {
+            start,
+            end: length - 1,
+        };
+    }
+    let Ok(end) = last.parse::<u64>() else {
+        return RangeSelection::Ignore;
+    };
+    if start > end {
+        return RangeSelection::Ignore;
+    }
+    RangeSelection::Range {
+        start,
+        end: end.min(length - 1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn route_matching_has_segment_boundaries_and_precedence() {
+        let temp = tempfile_dir();
+        let service = FileService::activate(
+            vec![FileRootSpec {
+                id: "root".to_owned(),
+                path: temp.clone(),
+                cache: CachePolicy::Revalidate,
+            }],
+            vec![
+                NativeRouteSpec {
+                    at: "/assets".to_owned(),
+                    root_id: "root".to_owned(),
+                    kind: NativeRouteKind::Prefix,
+                    relative: String::new(),
+                    cache: None,
+                },
+                NativeRouteSpec {
+                    at: "/assets/special".to_owned(),
+                    root_id: "root".to_owned(),
+                    kind: NativeRouteKind::Exact,
+                    relative: "special.txt".to_owned(),
+                    cache: None,
+                },
+                NativeRouteSpec {
+                    at: "/assets/deep".to_owned(),
+                    root_id: "root".to_owned(),
+                    kind: NativeRouteKind::Prefix,
+                    relative: String::new(),
+                    cache: None,
+                },
+            ],
+            2,
+            1024,
+        )
+        .unwrap();
+
+        assert_eq!(
+            service.route("/assets/special").unwrap().relative,
+            "special.txt"
+        );
+        assert_eq!(
+            service.route("/assets/deep/file.txt").unwrap().relative,
+            "file.txt"
+        );
+        assert_eq!(
+            service.route("/assets/file.txt").unwrap().relative,
+            "file.txt"
+        );
+        assert!(service.route("/assets2/file.txt").is_none());
+        fs::remove_dir(temp).unwrap();
+    }
+
+    #[test]
+    fn route_activation_rejects_duplicates_and_missing_roots() {
+        let temp = tempfile_dir();
+        let duplicate_root = FileService::activate(
+            vec![
+                FileRootSpec {
+                    id: "root".to_owned(),
+                    path: temp.clone(),
+                    cache: CachePolicy::Revalidate,
+                },
+                FileRootSpec {
+                    id: "root".to_owned(),
+                    path: temp.clone(),
+                    cache: CachePolicy::NoStore,
+                },
+            ],
+            Vec::new(),
+            1,
+            1,
+        );
+        assert!(duplicate_root
+            .unwrap_err()
+            .contains("duplicate file root identifier"));
+
+        let absent = FileService::activate(
+            vec![FileRootSpec {
+                id: "absent".to_owned(),
+                path: temp.join("does-not-exist"),
+                cache: CachePolicy::Revalidate,
+            }],
+            Vec::new(),
+            1,
+            1,
+        );
+        assert!(absent.unwrap_err().contains("missing, inaccessible"));
+
+        let duplicate = FileService::activate(
+            vec![FileRootSpec {
+                id: "root".to_owned(),
+                path: temp.clone(),
+                cache: CachePolicy::Revalidate,
+            }],
+            vec![
+                NativeRouteSpec {
+                    at: "/assets".to_owned(),
+                    root_id: "root".to_owned(),
+                    kind: NativeRouteKind::Prefix,
+                    relative: String::new(),
+                    cache: None,
+                },
+                NativeRouteSpec {
+                    at: "/assets".to_owned(),
+                    root_id: "root".to_owned(),
+                    kind: NativeRouteKind::Prefix,
+                    relative: String::new(),
+                    cache: None,
+                },
+            ],
+            1,
+            1,
+        );
+        assert!(duplicate
+            .unwrap_err()
+            .contains("duplicate native route prefix"));
+
+        let missing = FileService::activate(
+            Vec::new(),
+            vec![NativeRouteSpec {
+                at: "/assets".to_owned(),
+                root_id: "missing".to_owned(),
+                kind: NativeRouteKind::Prefix,
+                relative: String::new(),
+                cache: None,
+            }],
+            1,
+            1,
+        );
+        assert!(missing.unwrap_err().contains("undeclared file root"));
+        fs::remove_dir(temp).unwrap();
+    }
+
+    #[test]
+    fn uri_path_validation_rejects_traversal_and_encoded_separators() {
+        for invalid in [
+            "",
+            ".",
+            "..",
+            "%2e%2e",
+            ".hidden",
+            "dir/.hidden",
+            "dir//file",
+            "dir/%2Ffile",
+            "dir/%5cfile",
+            "C:%5csecret",
+            "dir/%00file",
+            "dir/%ff",
+            "dir/%",
+        ] {
+            assert!(
+                decode_uri_relative_path(invalid).is_err(),
+                "{invalid:?} should be rejected"
+            );
+        }
+        assert_eq!(
+            decode_uri_relative_path("dir/a%20file.txt").unwrap(),
+            ["dir", "a file.txt"]
+        );
+        assert!(decode_uri_relative_path(&"x".repeat(MAX_RELATIVE_PATH_BYTES + 1)).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rooted_open_rejects_symlinks_in_every_component() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile_dir();
+        let outside = tempfile_dir();
+        fs::write(outside.join("secret.txt"), b"secret").unwrap();
+        fs::create_dir(root.join("inside")).unwrap();
+        fs::write(root.join("inside/file.txt"), b"ok").unwrap();
+        symlink(&outside, root.join("linked-dir")).unwrap();
+        symlink(
+            outside.join("secret.txt"),
+            root.join("inside/linked-file.txt"),
+        )
+        .unwrap();
+        let root_handle = open_ambient_dir(&root, cap_primitives::ambient_authority()).unwrap();
+
+        assert!(
+            open_relative_file(&root_handle, &["inside".to_owned(), "file.txt".to_owned()]).is_ok()
+        );
+        assert!(open_relative_file(
+            &root_handle,
+            &["linked-dir".to_owned(), "secret.txt".to_owned()]
+        )
+        .is_err());
+        assert!(open_relative_file(
+            &root_handle,
+            &["inside".to_owned(), "linked-file.txt".to_owned()]
+        )
+        .is_err());
+
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(outside).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn component_swap_race_never_opens_an_outside_file() {
+        use std::os::unix::fs::symlink;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let root = tempfile_dir();
+        let outside = tempfile_dir();
+        fs::create_dir(root.join("slot")).unwrap();
+        fs::write(root.join("slot/file.txt"), b"public").unwrap();
+        fs::write(outside.join("file.txt"), b"secret").unwrap();
+        let root_handle = open_ambient_dir(&root, cap_primitives::ambient_authority()).unwrap();
+        let stop = Arc::new(AtomicBool::new(false));
+        let attacker_stop = Arc::clone(&stop);
+        let attacker_root = root.clone();
+        let attacker_outside = outside.clone();
+        let attacker = std::thread::spawn(move || {
+            while !attacker_stop.load(Ordering::Acquire) {
+                if fs::rename(attacker_root.join("slot"), attacker_root.join("slot-real")).is_ok() {
+                    let _ = symlink(&attacker_outside, attacker_root.join("slot"));
+                    let _ = fs::remove_file(attacker_root.join("slot"));
+                    let _ = fs::rename(attacker_root.join("slot-real"), attacker_root.join("slot"));
+                }
+            }
+        });
+
+        for _ in 0..2_000 {
+            if let Ok(mut file) =
+                open_relative_file(&root_handle, &["slot".to_owned(), "file.txt".to_owned()])
+            {
+                let mut bytes = Vec::new();
+                file.read_to_end(&mut bytes).unwrap();
+                assert_eq!(bytes, b"public");
+            }
+        }
+        stop.store(true, Ordering::Release);
+        attacker.join().unwrap();
+        if root.join("slot-real").exists() {
+            let _ = fs::remove_file(root.join("slot"));
+            fs::rename(root.join("slot-real"), root.join("slot")).unwrap();
+        }
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(outside).unwrap();
+    }
+
+    #[tokio::test]
+    async fn dropped_body_releases_transfer_capacity_and_request_accounting() {
+        use crate::shutdown::RequestTracker;
+
+        let root = tempfile_dir();
+        fs::write(root.join("large.bin"), vec![b'x'; 64 * 1024]).unwrap();
+        let service = FileService::activate(
+            vec![FileRootSpec {
+                id: "root".to_owned(),
+                path: root.clone(),
+                cache: CachePolicy::Revalidate,
+            }],
+            Vec::new(),
+            1,
+            1024,
+        )
+        .unwrap();
+        let tracker = RequestTracker::new();
+        let plan = || {
+            FilePlan::authorized(
+                "root".to_owned(),
+                "large.bin".to_owned(),
+                Disposition::Inline,
+                None,
+            )
+        };
+
+        let first = service
+            .serve(
+                plan(),
+                Method::GET,
+                HeaderMap::new(),
+                Arc::new(tracker.begin().unwrap()),
+            )
+            .await;
+        assert_eq!(first.status(), StatusCode::OK);
+        assert_eq!(service.active_transfers(), 1);
+
+        let saturated = service
+            .serve(
+                plan(),
+                Method::GET,
+                HeaderMap::new(),
+                Arc::new(tracker.begin().unwrap()),
+            )
+            .await;
+        assert_eq!(saturated.status(), StatusCode::SERVICE_UNAVAILABLE);
+        drop(saturated);
+        drop(first);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while service.active_transfers() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropped response did not cancel its file worker");
+        assert_eq!(tracker.active(), 0);
+        assert_eq!(service.high_water_transfers(), 1);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn single_range_parser_is_bounded_and_deterministic() {
+        fn headers(value: &'static str) -> HeaderMap {
+            let mut headers = HeaderMap::new();
+            headers.insert(RANGE, hyper::header::HeaderValue::from_static(value));
+            headers
+        }
+
+        assert_eq!(
+            parse_range(&headers("bytes=2-4"), 10),
+            RangeSelection::Range { start: 2, end: 4 }
+        );
+        assert_eq!(
+            parse_range(&headers("bytes=7-"), 10),
+            RangeSelection::Range { start: 7, end: 9 }
+        );
+        assert_eq!(
+            parse_range(&headers("bytes=-3"), 10),
+            RangeSelection::Range { start: 7, end: 9 }
+        );
+        assert_eq!(
+            parse_range(&headers("bytes=99-"), 10),
+            RangeSelection::Unsatisfiable
+        );
+        assert_eq!(
+            parse_range(&headers("bytes=0-1,4-5"), 10),
+            RangeSelection::Ignore
+        );
+        assert_eq!(
+            parse_range(&headers("items=0-1"), 10),
+            RangeSelection::Ignore
+        );
+
+        let mut repeated = headers("bytes=0-1");
+        repeated.append(RANGE, hyper::header::HeaderValue::from_static("bytes=4-5"));
+        assert_eq!(parse_range(&repeated, 10), RangeSelection::Ignore);
+    }
+
+    #[test]
+    fn attachment_filenames_cannot_inject_headers() {
+        let header = attachment_header("report\"\r\nX-Evil: yes.pdf");
+        assert!(!header.contains('\r'));
+        assert!(!header.contains('\n'));
+        assert!(hyper::header::HeaderValue::from_str(&header).is_ok());
+        assert!(header.starts_with("attachment;"));
+    }
+
+    #[test]
+    fn preconditions_follow_if_match_and_if_none_match_precedence() {
+        let modified = UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+        let etag = weak_etag(10, Some(modified));
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            IF_MATCH,
+            hyper::header::HeaderValue::from_static("\"strong\""),
+        );
+        headers.insert(IF_NONE_MATCH, etag.parse().unwrap());
+        assert_eq!(
+            precondition_status(&headers, &etag, Some(modified), &Method::GET),
+            Some(StatusCode::PRECONDITION_FAILED)
+        );
+
+        headers.remove(IF_MATCH);
+        assert_eq!(
+            precondition_status(&headers, &etag, Some(modified), &Method::GET),
+            Some(StatusCode::NOT_MODIFIED)
+        );
+    }
+
+    fn tempfile_dir() -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "basic-webserver-file-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir(&path).unwrap();
+        path
+    }
+}

--- a/src/host_resource.rs
+++ b/src/host_resource.rs
@@ -7,6 +7,7 @@ use std::sync::Mutex;
 const TOKEN_INDEX_BITS: u32 = 16;
 const TOKEN_INDEX_MASK: u64 = (1_u64 << TOKEN_INDEX_BITS) - 1;
 const MAX_GENERATION: u64 = u64::MAX >> TOKEN_INDEX_BITS;
+const DEBUG_FREED_REFCOUNT: isize = 0xDEADBEEFDEADBEEFu64 as isize;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ReserveError {
@@ -161,7 +162,17 @@ impl<T> HostResourceHeap<T> {
         };
         let slot = &self.slots[index];
         let mut state = self.lock_state();
-        if state.slots[index] != SlotState::Live || slot.refcount.load(Ordering::Acquire) != 0 {
+        let refcount = slot.refcount.load(Ordering::Acquire);
+        // Roc's debug runtime poisons the final refcount immediately before it
+        // invokes the host deallocator. Optimized runtimes leave it at zero.
+        // Slot state still makes a second deallocation unambiguously corrupt.
+        if state.slots[index] != SlotState::Live
+            || (refcount != 0 && refcount != DEBUG_FREED_REFCOUNT)
+        {
+            eprintln!(
+                "host resource deallocation invariant failed: index={index}, state={:?}, refcount={}",
+                state.slots[index], refcount
+            );
             return DeallocRoute::Corrupt;
         }
         let token = unsafe { *slot.token.get() };
@@ -413,6 +424,23 @@ mod tests {
         let handle = heap.reserve().unwrap().insert(42);
         assert_eq!(unsafe { *heap.get(handle).unwrap() }, 42);
         assert_eq!(final_dealloc(&heap, handle), DeallocRoute::Deallocated);
+    }
+
+    #[test]
+    fn debug_runtime_refcount_poison_is_a_valid_final_deallocation() {
+        let heap = HostResourceHeap::<usize>::new(1);
+        let handle = heap.reserve().unwrap().insert(42);
+        let base = unsafe { handle.cast::<u8>().sub(core::mem::size_of::<isize>()) };
+        unsafe {
+            (*(base.cast::<AtomicIsize>())).store(DEBUG_FREED_REFCOUNT, Ordering::Release);
+        }
+
+        assert_eq!(heap.route_dealloc(base.cast()), DeallocRoute::Deallocated);
+        assert_eq!(
+            heap.route_dealloc(base.cast()),
+            DeallocRoute::Corrupt,
+            "slot state must still reject a duplicate debug deallocation"
+        );
     }
 
     #[test]

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -1,7 +1,12 @@
 //! Tokio/Hyper server lifecycle and the provided Roc application entrypoints.
 
 use crate::abi::{
-    roc_host, ServerConfig, ServerHeader, ServerRequest, ServerResponse, ServerShutdownReason,
+    roc_host, ServerConfig, ServerFileRoot, ServerHeader, ServerNativeRoute, ServerRequest,
+    ServerResponse as RocServerResponse, ServerShutdownReason,
+};
+use crate::file_server::{
+    full_body, CachePolicy, Disposition, FilePlan, FileRootSpec, FileService, NativeRouteKind,
+    NativeRouteSpec, ServerResponse,
 };
 use crate::request_body::{clear_registry, install_registry, BodyRegistry, PumpError};
 use crate::request_parts::{request_target, RequestPartsBacking};
@@ -9,19 +14,22 @@ use crate::roc_platform_abi::*;
 use crate::shutdown::{RequestTracker, ShutdownController, ShutdownReason};
 use bytes::Bytes;
 use futures::{Future, FutureExt, StreamExt};
-use http_body_util::{BodyExt, Full};
+use http_body_util::BodyExt;
+#[cfg(test)]
+use http_body_util::Full;
 use hyper::header::CONTENT_LENGTH;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::panic::AssertUnwindSafe;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::{spawn_blocking, JoinSet};
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 struct RuntimeConfig {
     host: String,
     port: u16,
@@ -33,33 +41,60 @@ struct RuntimeConfig {
     body_buffered_chunks: usize,
     drain_timeout: Duration,
     hook_timeout: Duration,
+    files: FileService,
 }
 
 impl RuntimeConfig {
     fn from_roc(config: ServerConfig) -> Result<Self, String> {
-        let host = config.host.as_str().to_owned();
-        unsafe { config.host.decref(roc_host()) };
-
-        if config.body_chunk_bytes == 0 {
-            return Err("request body chunk size must be non-zero".to_owned());
-        }
-        if config.body_buffered_chunks == 0 {
-            return Err("request body buffered chunk count must be non-zero".to_owned());
-        }
-        let (max_connections, max_handlers) =
-            validate_concurrency_limits(config.max_connections, config.max_handlers)?;
-        Ok(Self {
-            host,
-            port: config.port,
-            max_connections,
-            max_handlers,
-            max_queued_handlers: config.max_queued_handlers as usize,
-            body_max_bytes: config.body_max_bytes,
-            body_chunk_bytes: config.body_chunk_bytes as usize,
-            body_buffered_chunks: config.body_buffered_chunks as usize,
-            drain_timeout: Duration::from_millis(config.drain_timeout_ms),
-            hook_timeout: Duration::from_millis(config.hook_timeout_ms),
-        })
+        let result = (|| {
+            if config.body_chunk_bytes == 0 {
+                return Err("request body chunk size must be non-zero".to_owned());
+            }
+            if config.body_buffered_chunks == 0 {
+                return Err("request body buffered chunk count must be non-zero".to_owned());
+            }
+            if config.file_chunk_bytes > 1024 * 1024 {
+                return Err("file transfer chunk size cannot exceed 1 MiB".to_owned());
+            }
+            let (max_connections, max_handlers) =
+                validate_concurrency_limits(config.max_connections, config.max_handlers)?;
+            let roots = config
+                .file_roots
+                .as_slice()
+                .iter()
+                .map(file_root_from_roc)
+                .collect::<Result<Vec<_>, _>>()?;
+            let routes = config
+                .native_routes
+                .as_slice()
+                .iter()
+                .map(native_route_from_roc)
+                .collect::<Result<Vec<_>, _>>()?;
+            let files = FileService::activate(
+                roots,
+                routes,
+                config.file_max_concurrent as usize,
+                config.file_chunk_bytes as usize,
+            )?;
+            Ok(Self {
+                host: config.host.as_str().to_owned(),
+                port: config.port,
+                max_connections,
+                max_handlers,
+                max_queued_handlers: config.max_queued_handlers as usize,
+                body_max_bytes: config.body_max_bytes,
+                body_chunk_bytes: config.body_chunk_bytes as usize,
+                body_buffered_chunks: config.body_buffered_chunks as usize,
+                drain_timeout: Duration::from_millis(config.drain_timeout_ms),
+                hook_timeout: Duration::from_millis(config.hook_timeout_ms),
+                files,
+            })
+        })();
+        // SAFETY: every Roc-owned field in the ABI config is borrowed only
+        // inside the closure above and this consumes the one reference returned
+        // by `init!` on both success and failure.
+        unsafe { config.decref(roc_host()) };
+        result
     }
 
     fn max_http2_streams_per_connection(&self) -> u32 {
@@ -72,6 +107,75 @@ impl RuntimeConfig {
             .try_into()
             .expect("validated handler capacity fits in u32")
     }
+}
+
+fn file_root_from_roc(root: &ServerFileRoot) -> Result<FileRootSpec, String> {
+    let path = path_buf_from_file_root(root)?;
+    Ok(FileRootSpec {
+        id: root.id.as_str().to_owned(),
+        path,
+        cache: CachePolicy::from_abi(root.cache_tag, root.cache_max_age_seconds)?,
+    })
+}
+
+fn path_buf_from_file_root(root: &ServerFileRoot) -> Result<PathBuf, String> {
+    match root.path_tag {
+        0 if root.path_unix_bytes.is_empty() && root.path_windows_u16s.is_empty() => {
+            Ok(PathBuf::from(root.path_utf8.as_str()))
+        }
+        1 if root.path_utf8.is_empty() && root.path_windows_u16s.is_empty() => {
+            #[cfg(unix)]
+            {
+                use std::os::unix::ffi::OsStringExt;
+                Ok(PathBuf::from(std::ffi::OsString::from_vec(
+                    root.path_unix_bytes.as_slice().to_vec(),
+                )))
+            }
+            #[cfg(not(unix))]
+            {
+                Err("a Unix file-root path was supplied on a non-Unix target".to_owned())
+            }
+        }
+        2 if root.path_utf8.is_empty() && root.path_unix_bytes.is_empty() => {
+            #[cfg(windows)]
+            {
+                use std::os::windows::ffi::OsStringExt;
+                Ok(PathBuf::from(std::ffi::OsString::from_wide(
+                    root.path_windows_u16s.as_slice(),
+                )))
+            }
+            #[cfg(not(windows))]
+            {
+                Err("a Windows file-root path was supplied on a non-Windows target".to_owned())
+            }
+        }
+        _ => Err("malformed native file-root path".to_owned()),
+    }
+}
+
+fn native_route_from_roc(route: &ServerNativeRoute) -> Result<NativeRouteSpec, String> {
+    let kind = match route.kind {
+        0 => NativeRouteKind::Prefix,
+        1 => NativeRouteKind::Exact,
+        _ => return Err("invalid native route kind".to_owned()),
+    };
+    let cache = if route.cache_override {
+        Some(CachePolicy::from_abi(
+            route.cache_tag,
+            route.cache_max_age_seconds,
+        )?)
+    } else if route.cache_tag == 0 && route.cache_max_age_seconds == 0 {
+        None
+    } else {
+        return Err("malformed native route cache override".to_owned());
+    };
+    Ok(NativeRouteSpec {
+        at: route.at.as_str().to_owned(),
+        root_id: route.root_id.as_str().to_owned(),
+        kind,
+        relative: route.relative.as_str().to_owned(),
+        cache,
+    })
 }
 
 fn validate_concurrency_limits(
@@ -407,25 +511,83 @@ fn request_to_roc_copied(
     }
 }
 
-fn call_roc(
-    request: ServerRequest,
-    context: RocBox,
-) -> (hyper::Response<Full<Bytes>>, Option<i64>) {
+fn call_roc(request: ServerRequest, context: RocBox) -> RocOutcome {
     let response = unsafe { roc_respond_for_host(request, context) };
-    response_to_hyper(response)
+    outcome_from_roc(response)
 }
 
-fn response_to_hyper(response: ServerResponse) -> (hyper::Response<Full<Bytes>>, Option<i64>) {
-    let stop_code = response.stop.then_some(response.exit_code);
+enum RocOutcome {
+    Ordinary(ServerResponse, Option<i64>),
+    File(FilePlan),
+    Invalid(String),
+}
+
+fn outcome_from_roc(response: RocServerResponse) -> RocOutcome {
+    match response.kind {
+        0 => {
+            let stop_code = response.stop.then_some(response.exit_code);
+            RocOutcome::Ordinary(response_to_hyper(response), stop_code)
+        }
+        1 => {
+            let root_id = response.file_root_id.as_str().to_owned();
+            let relative = response.file_relative.as_str().to_owned();
+            let disposition = match response.file_disposition {
+                0 if response.file_download_name.is_empty() => Disposition::Inline,
+                1 => Disposition::Attachment(response.file_download_name.as_str().to_owned()),
+                _ => {
+                    unsafe { response.decref(roc_host()) };
+                    return RocOutcome::Invalid(
+                        "Roc returned a malformed file disposition".to_owned(),
+                    );
+                }
+            };
+            let cache = if response.file_cache_override {
+                match CachePolicy::from_abi(
+                    response.file_cache_tag,
+                    response.file_cache_max_age_seconds,
+                ) {
+                    Ok(cache) => Some(cache),
+                    Err(detail) => {
+                        unsafe { response.decref(roc_host()) };
+                        return RocOutcome::Invalid(detail);
+                    }
+                }
+            } else if response.file_cache_tag == 0 && response.file_cache_max_age_seconds == 0 {
+                None
+            } else {
+                unsafe { response.decref(roc_host()) };
+                return RocOutcome::Invalid(
+                    "Roc returned a malformed file cache override".to_owned(),
+                );
+            };
+            let valid = !response.stop
+                && response.status == 500
+                && response.body.is_empty()
+                && response.headers.is_empty();
+            unsafe { response.decref(roc_host()) };
+            if !valid {
+                return RocOutcome::Invalid(
+                    "Roc returned a malformed file response plan".to_owned(),
+                );
+            }
+            RocOutcome::File(FilePlan::authorized(root_id, relative, disposition, cache))
+        }
+        _ => {
+            unsafe { response.decref(roc_host()) };
+            RocOutcome::Invalid("Roc returned an unknown response-plan kind".to_owned())
+        }
+    }
+}
+
+fn response_to_hyper(response: RocServerResponse) -> ServerResponse {
     let mut builder = hyper::Response::builder().status(response.status);
     for header in response.headers.as_slice() {
         builder = builder.header(header.name.as_str(), header.value.as_str());
     }
     let body = Bytes::from_owner(RocResponseOwner { response });
-    let hyper_response = builder
-        .body(Full::new(body))
-        .unwrap_or_else(|_| internal_server_error("Failed to build response"));
-    (hyper_response, stop_code)
+    builder
+        .body(full_body(body))
+        .unwrap_or_else(|_| internal_server_error("Failed to build response"))
 }
 
 /// Owns every Roc reference in a response while Hyper may still transmit the
@@ -433,7 +595,7 @@ fn response_to_hyper(response: ServerResponse) -> (hyper::Response<Full<Bytes>>,
 /// generated recursive decref remains the single source of truth, and keeping
 /// the small header descriptors alive until body completion is bounded.
 struct RocResponseOwner {
-    response: ServerResponse,
+    response: RocServerResponse,
 }
 
 impl AsRef<[u8]> for RocResponseOwner {
@@ -455,40 +617,40 @@ impl Drop for RocResponseOwner {
     }
 }
 
-fn internal_server_error(message: &str) -> hyper::Response<Full<Bytes>> {
+fn internal_server_error(message: &str) -> ServerResponse {
     hyper::Response::builder()
         .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
-        .body(Full::new(Bytes::copy_from_slice(message.as_bytes())))
+        .body(full_body(Bytes::copy_from_slice(message.as_bytes())))
         .expect("static 500 response is valid")
 }
 
-fn service_unavailable() -> hyper::Response<Full<Bytes>> {
+fn service_unavailable() -> ServerResponse {
     hyper::Response::builder()
         .status(hyper::StatusCode::SERVICE_UNAVAILABLE)
-        .body(Full::new(Bytes::from_static(b"Server is shutting down")))
+        .body(full_body(Bytes::from_static(b"Server is shutting down")))
         .expect("static 503 response is valid")
 }
 
-fn overloaded() -> hyper::Response<Full<Bytes>> {
+fn overloaded() -> ServerResponse {
     hyper::Response::builder()
         .status(hyper::StatusCode::SERVICE_UNAVAILABLE)
-        .body(Full::new(Bytes::from_static(b"Server is overloaded")))
+        .body(full_body(Bytes::from_static(b"Server is overloaded")))
         .expect("static 503 response is valid")
 }
 
-fn invalid_request_headers() -> hyper::Response<Full<Bytes>> {
+fn invalid_request_headers() -> ServerResponse {
     hyper::Response::builder()
         .status(hyper::StatusCode::BAD_REQUEST)
-        .body(Full::new(Bytes::from_static(
+        .body(full_body(Bytes::from_static(
             b"Request header values must be valid UTF-8",
         )))
         .expect("static 400 response is valid")
 }
 
-fn payload_too_large(limit: u64) -> hyper::Response<Full<Bytes>> {
+fn payload_too_large(limit: u64) -> ServerResponse {
     hyper::Response::builder()
         .status(hyper::StatusCode::PAYLOAD_TOO_LARGE)
-        .body(Full::new(Bytes::from(format!(
+        .body(full_body(Bytes::from(format!(
             "Request body exceeds the {limit}-byte limit"
         ))))
         .expect("static 413 response is valid")
@@ -497,11 +659,21 @@ fn payload_too_large(limit: u64) -> hyper::Response<Full<Bytes>> {
 async fn handle_req(
     request: hyper::Request<hyper::body::Incoming>,
     context: ServerContext,
-) -> hyper::Response<Full<Bytes>> {
+) -> ServerResponse {
     let active_request = match context.requests.begin() {
-        Some(active) => active,
+        Some(active) => Arc::new(active),
         None => return service_unavailable(),
     };
+
+    if let Some(plan) = context.config.files.route(request.uri().path()) {
+        let (parts, body) = request.into_parts();
+        drop(body);
+        return context
+            .config
+            .files
+            .serve(plan, parts.method, parts.headers, active_request)
+            .await;
+    }
 
     if !request_headers_are_utf8(request.headers()) {
         return invalid_request_headers();
@@ -518,6 +690,8 @@ async fn handle_req(
     };
 
     let (parts, body) = request.into_parts();
+    let file_method = parts.method.clone();
+    let file_headers = parts.headers.clone();
     let registration = context.bodies.register(context.config.body_max_bytes);
     let body_id = registration.id;
     let stream = body
@@ -529,12 +703,13 @@ async fn handle_req(
     let body_limit = context.config.body_max_bytes;
     let bodies = Arc::clone(&context.bodies);
     let roc_context = Arc::clone(&context.roc_context);
+    let handler_request = Arc::clone(&active_request);
     let handled = spawn_blocking(move || {
         // These guards intentionally live in the non-cancellable blocking task.
         // Aborting its Tokio JoinHandle must not make shutdown believe Roc has
         // stopped using its handler slot, body, or immutable application
         // context.
-        let _active_request = active_request;
+        let _active_request = handler_request;
         let _active_handler = active_handler;
         let roc_request = request_to_roc(parts, body_id, body_limit, declared_length);
         let request_context = roc_context.retain_for_request();
@@ -545,13 +720,24 @@ async fn handle_req(
     .await;
 
     match handled {
-        Ok((response, Some(exit_code))) => {
+        Ok(RocOutcome::Ordinary(response, Some(exit_code))) => {
             context
                 .shutdown
                 .request(ShutdownReason::ApplicationRequested { exit_code });
             response
         }
-        Ok((response, None)) => response,
+        Ok(RocOutcome::Ordinary(response, None)) => response,
+        Ok(RocOutcome::File(plan)) => {
+            context
+                .config
+                .files
+                .serve(plan, file_method, file_headers, active_request)
+                .await
+        }
+        Ok(RocOutcome::Invalid(detail)) => {
+            eprintln!("Invalid Roc response plan: {detail}");
+            internal_server_error("500 Internal Server Error")
+        }
         Err(error) => {
             context.bodies.expire(body_id);
             eprintln!("Recovered from calling Roc: {error:?}");
@@ -561,8 +747,8 @@ async fn handle_req(
 }
 
 async fn handle_panics(
-    future: impl Future<Output = hyper::Response<Full<Bytes>>>,
-) -> Result<hyper::Response<Full<Bytes>>, Infallible> {
+    future: impl Future<Output = ServerResponse>,
+) -> Result<ServerResponse, Infallible> {
     match AssertUnwindSafe(future).catch_unwind().await {
         Ok(response) => Ok(response),
         Err(_) => Ok(internal_server_error("Panic detected")),
@@ -684,6 +870,17 @@ async fn run_server(context: ServerContext) -> ShutdownReason {
         std::process::exit(1);
     }
 
+    debug_assert_eq!(
+        context.config.files.active_transfers(),
+        0,
+        "all native file transfers must drain before shutdown"
+    );
+    if context.config.files.high_water_transfers() > 0 {
+        eprintln!(
+            "Native file transfer high-water mark: {}",
+            context.config.files.high_water_transfers()
+        );
+    }
     signal_task.abort();
     reason
 }
@@ -868,15 +1065,22 @@ mod tests {
             "the escaped response slice must keep request metadata alive"
         );
 
-        let roc_response = ServerResponse {
+        let roc_response = RocServerResponse {
             exit_code: 0,
             body: escaped_body,
+            file_download_name: RocStr::empty(),
+            file_relative: RocStr::empty(),
+            file_root_id: RocStr::empty(),
             headers: RocList::empty(),
+            file_cache_max_age_seconds: 0,
             status: 200,
+            file_cache_override: false,
+            file_cache_tag: 0,
+            file_disposition: 0,
+            kind: 0,
             stop: false,
         };
-        let (response, stop_code) = response_to_hyper(roc_response);
-        assert_eq!(stop_code, None);
+        let response = response_to_hyper(roc_response);
         assert_eq!(crate::request_parts::active_backings(), 1);
 
         let body = response.into_body().collect().await.unwrap().to_bytes();
@@ -1008,6 +1212,7 @@ mod tests {
             body_buffered_chunks: 1,
             drain_timeout: Duration::from_secs(30),
             hook_timeout: Duration::from_secs(10),
+            files: FileService::activate(Vec::new(), Vec::new(), 1, 1024).unwrap(),
         };
         assert_eq!(config.max_http2_streams_per_connection(), 96);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod cmd;
 mod dir;
 mod env;
 mod file;
+mod file_server;
 mod host_resource;
 mod http;
 mod http_error;

--- a/src/roc_platform_abi.rs
+++ b/src/roc_platform_abi.rs
@@ -1320,75 +1320,157 @@ const _: () = assert!(core::mem::size_of::<AnonStruct1f12a65955b54fe1>() == 12, 
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(core::mem::align_of::<AnonStruct1f12a65955b54fe1>() == 4, "AnonStruct1f12a65955b54fe1 alignment mismatch");
 
-/// Element type for __AnonStruct_e340dbd21a9f8d48
+/// Element type for __AnonStruct_9d4feaaa75529fdc
 #[cfg(target_pointer_width = "32")]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStructE340dbd21a9f8d48 {
-    pub config: AnonStructF0688567cca5fbf7,
+pub struct AnonStruct9d4feaaa75529fdc {
+    pub config: AnonStructAeeb7f2cfe80f10,
     pub context: RocBox,
 }
 
-/// Element type for __AnonStruct_e340dbd21a9f8d48
+/// Element type for __AnonStruct_9d4feaaa75529fdc
 #[cfg(not(target_pointer_width = "32"))]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStructE340dbd21a9f8d48 {
-    pub config: AnonStructF0688567cca5fbf7,
+pub struct AnonStruct9d4feaaa75529fdc {
+    pub config: AnonStructAeeb7f2cfe80f10,
     pub context: RocBox,
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<AnonStructE340dbd21a9f8d48>() == 72, "AnonStructE340dbd21a9f8d48 size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStruct9d4feaaa75529fdc>() == 128, "AnonStruct9d4feaaa75529fdc size mismatch");
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::align_of::<AnonStructE340dbd21a9f8d48>() == 8, "AnonStructE340dbd21a9f8d48 alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStruct9d4feaaa75529fdc>() == 8, "AnonStruct9d4feaaa75529fdc alignment mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::size_of::<AnonStructE340dbd21a9f8d48>() == 64, "AnonStructE340dbd21a9f8d48 size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStruct9d4feaaa75529fdc>() == 96, "AnonStruct9d4feaaa75529fdc size mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::align_of::<AnonStructE340dbd21a9f8d48>() == 8, "AnonStructE340dbd21a9f8d48 alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStruct9d4feaaa75529fdc>() == 8, "AnonStruct9d4feaaa75529fdc alignment mismatch");
 
-/// Element type for __AnonStruct_f0688567cca5fbf7
+/// Element type for __AnonStruct_aeeb7f2cfe80f10
 #[cfg(target_pointer_width = "32")]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStructF0688567cca5fbf7 {
+pub struct AnonStructAeeb7f2cfe80f10 {
     pub body_max_bytes: u64,
     pub drain_timeout_ms: u64,
     pub hook_timeout_ms: u64,
+    pub file_roots: RocList<AnonStruct3b01e35488cb00dc>,
     pub host: RocStr,
+    pub native_routes: RocList<AnonStructFf6f93028827ced0>,
     pub body_chunk_bytes: u32,
+    pub file_chunk_bytes: u32,
     pub max_connections: u32,
     pub body_buffered_chunks: u16,
+    pub file_max_concurrent: u16,
     pub max_handlers: u16,
     pub max_queued_handlers: u16,
     pub port: u16,
 }
 
-/// Element type for __AnonStruct_f0688567cca5fbf7
+/// Element type for __AnonStruct_aeeb7f2cfe80f10
 #[cfg(not(target_pointer_width = "32"))]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStructF0688567cca5fbf7 {
+pub struct AnonStructAeeb7f2cfe80f10 {
     pub body_max_bytes: u64,
     pub drain_timeout_ms: u64,
     pub hook_timeout_ms: u64,
+    pub file_roots: RocList<AnonStruct3b01e35488cb00dc>,
     pub host: RocStr,
+    pub native_routes: RocList<AnonStructFf6f93028827ced0>,
     pub body_chunk_bytes: u32,
+    pub file_chunk_bytes: u32,
     pub max_connections: u32,
     pub body_buffered_chunks: u16,
+    pub file_max_concurrent: u16,
     pub max_handlers: u16,
     pub max_queued_handlers: u16,
     pub port: u16,
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<AnonStructF0688567cca5fbf7>() == 64, "AnonStructF0688567cca5fbf7 size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStructAeeb7f2cfe80f10>() == 120, "AnonStructAeeb7f2cfe80f10 size mismatch");
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::align_of::<AnonStructF0688567cca5fbf7>() == 8, "AnonStructF0688567cca5fbf7 alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStructAeeb7f2cfe80f10>() == 8, "AnonStructAeeb7f2cfe80f10 alignment mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::size_of::<AnonStructF0688567cca5fbf7>() == 56, "AnonStructF0688567cca5fbf7 size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStructAeeb7f2cfe80f10>() == 88, "AnonStructAeeb7f2cfe80f10 size mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::align_of::<AnonStructF0688567cca5fbf7>() == 8, "AnonStructF0688567cca5fbf7 alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStructAeeb7f2cfe80f10>() == 8, "AnonStructAeeb7f2cfe80f10 alignment mismatch");
+
+/// Element type for __AnonStruct_3b01e35488cb00dc
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AnonStruct3b01e35488cb00dc {
+    pub id: RocStr,
+    pub path_unix_bytes: RocListWith<u8, false>,
+    pub path_utf8: RocStr,
+    pub path_windows_u16s: RocListWith<u16, false>,
+    pub cache_max_age_seconds: u32,
+    pub cache_tag: u8,
+    pub path_tag: u8,
+}
+
+/// Element type for __AnonStruct_3b01e35488cb00dc
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AnonStruct3b01e35488cb00dc {
+    pub id: RocStr,
+    pub path_unix_bytes: RocListWith<u8, false>,
+    pub path_utf8: RocStr,
+    pub path_windows_u16s: RocListWith<u16, false>,
+    pub cache_max_age_seconds: u32,
+    pub cache_tag: u8,
+    pub path_tag: u8,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<AnonStruct3b01e35488cb00dc>() == 104, "AnonStruct3b01e35488cb00dc size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<AnonStruct3b01e35488cb00dc>() == 8, "AnonStruct3b01e35488cb00dc alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<AnonStruct3b01e35488cb00dc>() == 56, "AnonStruct3b01e35488cb00dc size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<AnonStruct3b01e35488cb00dc>() == 4, "AnonStruct3b01e35488cb00dc alignment mismatch");
+
+/// Element type for __AnonStruct_ff6f93028827ced0
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AnonStructFf6f93028827ced0 {
+    pub at: RocStr,
+    pub relative: RocStr,
+    pub root_id: RocStr,
+    pub cache_max_age_seconds: u32,
+    pub cache_override: bool,
+    pub cache_tag: u8,
+    pub kind: u8,
+}
+
+/// Element type for __AnonStruct_ff6f93028827ced0
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AnonStructFf6f93028827ced0 {
+    pub at: RocStr,
+    pub relative: RocStr,
+    pub root_id: RocStr,
+    pub cache_max_age_seconds: u32,
+    pub cache_override: bool,
+    pub cache_tag: u8,
+    pub kind: u8,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<AnonStructFf6f93028827ced0>() == 80, "AnonStructFf6f93028827ced0 size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<AnonStructFf6f93028827ced0>() == 8, "AnonStructFf6f93028827ced0 alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<AnonStructFf6f93028827ced0>() == 44, "AnonStructFf6f93028827ced0 size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<AnonStructFf6f93028827ced0>() == 4, "AnonStructFf6f93028827ced0 alignment mismatch");
 
 /// Element type for __AnonStruct_9618161a745c1367
 #[cfg(target_pointer_width = "32")]
@@ -1429,38 +1511,54 @@ const _: () = assert!(core::mem::size_of::<AnonStruct9618161a745c1367>() == 64, 
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(core::mem::align_of::<AnonStruct9618161a745c1367>() == 8, "AnonStruct9618161a745c1367 alignment mismatch");
 
-/// Element type for __AnonStruct_6f3dea2f169284fc
+/// Element type for __AnonStruct_aeceb9ea017a78f4
 #[cfg(target_pointer_width = "32")]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStruct6f3dea2f169284fc {
+pub struct AnonStructAeceb9ea017a78f4 {
     pub exit_code: i64,
     pub body: RocListWith<u8, false>,
+    pub file_download_name: RocStr,
+    pub file_relative: RocStr,
+    pub file_root_id: RocStr,
     pub headers: RocList<AnonStruct82a96c5d55d63488>,
+    pub file_cache_max_age_seconds: u32,
     pub status: u16,
+    pub file_cache_override: bool,
+    pub file_cache_tag: u8,
+    pub file_disposition: u8,
+    pub kind: u8,
     pub stop: bool,
 }
 
-/// Element type for __AnonStruct_6f3dea2f169284fc
+/// Element type for __AnonStruct_aeceb9ea017a78f4
 #[cfg(not(target_pointer_width = "32"))]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStruct6f3dea2f169284fc {
+pub struct AnonStructAeceb9ea017a78f4 {
     pub exit_code: i64,
     pub body: RocListWith<u8, false>,
+    pub file_download_name: RocStr,
+    pub file_relative: RocStr,
+    pub file_root_id: RocStr,
     pub headers: RocList<AnonStruct82a96c5d55d63488>,
+    pub file_cache_max_age_seconds: u32,
     pub status: u16,
+    pub file_cache_override: bool,
+    pub file_cache_tag: u8,
+    pub file_disposition: u8,
+    pub kind: u8,
     pub stop: bool,
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<AnonStruct6f3dea2f169284fc>() == 64, "AnonStruct6f3dea2f169284fc size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStructAeceb9ea017a78f4>() == 144, "AnonStructAeceb9ea017a78f4 size mismatch");
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::align_of::<AnonStruct6f3dea2f169284fc>() == 8, "AnonStruct6f3dea2f169284fc alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStructAeceb9ea017a78f4>() == 8, "AnonStructAeceb9ea017a78f4 alignment mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::size_of::<AnonStruct6f3dea2f169284fc>() == 40, "AnonStruct6f3dea2f169284fc size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStructAeceb9ea017a78f4>() == 80, "AnonStructAeceb9ea017a78f4 size mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::align_of::<AnonStruct6f3dea2f169284fc>() == 8, "AnonStruct6f3dea2f169284fc alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStructAeceb9ea017a78f4>() == 8, "AnonStructAeceb9ea017a78f4 alignment mismatch");
 
 /// Element type for __AnonStruct_628b43fd33b27733
 #[cfg(target_pointer_width = "32")]
@@ -4814,7 +4912,7 @@ pub enum InitForHostResultTag {
 #[derive(Clone, Copy)]
 pub union InitForHostResultPayload {
     pub err: core::mem::ManuallyDrop<i64>,
-    pub ok: core::mem::ManuallyDrop<AnonStructE340dbd21a9f8d48>,
+    pub ok: core::mem::ManuallyDrop<AnonStruct9d4feaaa75529fdc>,
 }
 
 #[cfg(target_pointer_width = "32")]
@@ -4828,7 +4926,7 @@ pub struct InitForHostResultPayloadAlignment;
 #[derive(Clone, Copy)]
 pub struct InitForHostResult {
     pub _payload_alignment: [InitForHostResultPayloadAlignment; 0],
-    pub payload: [u8; 64],
+    pub payload: [u8; 96],
     pub tag: InitForHostResultTag,
 }
 
@@ -4853,29 +4951,29 @@ impl InitForHostResult {
     }
 
     #[cfg(target_pointer_width = "32")]
-    pub fn payload_ok(&self) -> AnonStructE340dbd21a9f8d48 {
-        unsafe { core::ptr::read(self.payload.as_ptr() as *const AnonStructE340dbd21a9f8d48) }
+    pub fn payload_ok(&self) -> AnonStruct9d4feaaa75529fdc {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const AnonStruct9d4feaaa75529fdc) }
     }
 
     #[cfg(not(target_pointer_width = "32"))]
-    pub fn payload_ok(&self) -> AnonStructE340dbd21a9f8d48 {
+    pub fn payload_ok(&self) -> AnonStruct9d4feaaa75529fdc {
         unsafe { core::mem::ManuallyDrop::into_inner(self.payload.ok) }
     }
 
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<InitForHostResult>() == 80, "InitForHostResult size mismatch");
+const _: () = assert!(core::mem::size_of::<InitForHostResult>() == 136, "InitForHostResult size mismatch");
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(core::mem::align_of::<InitForHostResult>() == 8, "InitForHostResult alignment mismatch");
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::offset_of!(InitForHostResult, tag) == 72, "InitForHostResult tag offset mismatch");
+const _: () = assert!(core::mem::offset_of!(InitForHostResult, tag) == 128, "InitForHostResult tag offset mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::size_of::<InitForHostResult>() == 72, "InitForHostResult size mismatch");
+const _: () = assert!(core::mem::size_of::<InitForHostResult>() == 104, "InitForHostResult size mismatch");
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(core::mem::align_of::<InitForHostResult>() == 8, "InitForHostResult alignment mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::offset_of!(InitForHostResult, tag) == 64, "InitForHostResult tag offset mismatch");
+const _: () = assert!(core::mem::offset_of!(InitForHostResult, tag) == 96, "InitForHostResult tag offset mismatch");
 
 /// Tag discriminant for Try.
 #[repr(u8)]
@@ -6220,11 +6318,13 @@ pub type HostTcpReadUntilResultTag = HostTcpReadExactlyResultTag;
 pub type HostTcpReadUpToResult = HostTcpReadExactlyResult;
 pub type HostTcpReadUpToResultPayload = HostTcpReadExactlyResultPayload;
 pub type HostTcpReadUpToResultTag = HostTcpReadExactlyResultTag;
-pub type InitForHostOk = AnonStructE340dbd21a9f8d48;
-pub type InitForHostOkConfig = AnonStructF0688567cca5fbf7;
+pub type InitForHostOk = AnonStruct9d4feaaa75529fdc;
+pub type InitForHostOkConfig = AnonStructAeeb7f2cfe80f10;
+pub type InitForHostOkConfigFileRoots = AnonStruct3b01e35488cb00dc;
+pub type InitForHostOkConfigNativeRoutes = AnonStructFf6f93028827ced0;
 pub type RespondForHostArg0 = AnonStruct9618161a745c1367;
 pub type RespondForHostArg0Headers = AnonStruct82a96c5d55d63488;
-pub type RespondForHost = AnonStruct6f3dea2f169284fc;
+pub type RespondForHost = AnonStructAeceb9ea017a78f4;
 pub type RespondForHostHeaders = AnonStruct82a96c5d55d63488;
 pub type ShutdownForHostArg0 = AnonStruct628b43fd33b27733;
 
@@ -8539,7 +8639,7 @@ impl InitForHostResult {
     }
 }
 
-impl AnonStructE340dbd21a9f8d48 {
+impl AnonStruct9d4feaaa75529fdc {
     /// Recursively decrement Roc-owned fields.
     ///
     /// # Safety
@@ -8562,14 +8662,34 @@ impl AnonStructE340dbd21a9f8d48 {
     }
 }
 
-impl AnonStructF0688567cca5fbf7 {
+impl AnonStructAeeb7f2cfe80f10 {
     /// Recursively decrement Roc-owned fields.
     ///
     /// # Safety
     /// `self` must own one live Roc reference for each refcounted field.
     pub unsafe fn decref(self, roc_host: &RocHost) {
         let value = self;
+        {
+            let list = value.file_roots;
+            if list.has_one_ref() {
+                for item_ref in list.allocation_items() {
+                    let item = *item_ref;
+                        unsafe { item.decref(roc_host); }
+                }
+            }
+            unsafe { list.decref(roc_host); }
+        }
         unsafe { value.host.decref(roc_host); }
+        {
+            let list = value.native_routes;
+            if list.has_one_ref() {
+                for item_ref in list.allocation_items() {
+                    let item = *item_ref;
+                        unsafe { item.decref(roc_host); }
+                }
+            }
+            unsafe { list.decref(roc_host); }
+        }
     }
 
     /// Increment Roc-owned fields.
@@ -8579,7 +8699,61 @@ impl AnonStructF0688567cca5fbf7 {
     /// be balanced by later decrefs.
     pub unsafe fn incref(self, amount: isize) {
         let value = self;
+        unsafe { value.file_roots.incref(amount); }
         unsafe { value.host.incref(amount); }
+        unsafe { value.native_routes.incref(amount); }
+    }
+}
+
+impl AnonStruct3b01e35488cb00dc {
+    /// Recursively decrement Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted field.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let value = self;
+        unsafe { value.id.decref(roc_host); }
+        unsafe { value.path_unix_bytes.decref(roc_host); }
+        unsafe { value.path_utf8.decref(roc_host); }
+        unsafe { value.path_windows_u16s.decref(roc_host); }
+    }
+
+    /// Increment Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        unsafe { value.id.incref(amount); }
+        unsafe { value.path_unix_bytes.incref(amount); }
+        unsafe { value.path_utf8.incref(amount); }
+        unsafe { value.path_windows_u16s.incref(amount); }
+    }
+}
+
+impl AnonStructFf6f93028827ced0 {
+    /// Recursively decrement Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted field.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let value = self;
+        unsafe { value.at.decref(roc_host); }
+        unsafe { value.relative.decref(roc_host); }
+        unsafe { value.root_id.decref(roc_host); }
+    }
+
+    /// Increment Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        unsafe { value.at.incref(amount); }
+        unsafe { value.relative.incref(amount); }
+        unsafe { value.root_id.incref(amount); }
     }
 }
 
@@ -8617,7 +8791,7 @@ impl AnonStruct9618161a745c1367 {
     }
 }
 
-impl AnonStruct6f3dea2f169284fc {
+impl AnonStructAeceb9ea017a78f4 {
     /// Recursively decrement Roc-owned fields.
     ///
     /// # Safety
@@ -8625,6 +8799,9 @@ impl AnonStruct6f3dea2f169284fc {
     pub unsafe fn decref(self, roc_host: &RocHost) {
         let value = self;
         unsafe { value.body.decref(roc_host); }
+        unsafe { value.file_download_name.decref(roc_host); }
+        unsafe { value.file_relative.decref(roc_host); }
+        unsafe { value.file_root_id.decref(roc_host); }
         {
             let list = value.headers;
             if list.has_one_ref() {
@@ -8645,6 +8822,9 @@ impl AnonStruct6f3dea2f169284fc {
     pub unsafe fn incref(self, amount: isize) {
         let value = self;
         unsafe { value.body.incref(amount); }
+        unsafe { value.file_download_name.incref(amount); }
+        unsafe { value.file_relative.incref(amount); }
+        unsafe { value.file_root_id.incref(amount); }
         unsafe { value.headers.incref(amount); }
     }
 }
@@ -9091,7 +9271,7 @@ unsafe extern "C" {
     pub fn roc_init_for_host() -> InitForHostResult;
 
     /// Entrypoint: respond_for_host!
-    pub fn roc_respond_for_host(arg0: AnonStruct9618161a745c1367, arg1: RocBox) -> AnonStruct6f3dea2f169284fc;
+    pub fn roc_respond_for_host(arg0: AnonStruct9618161a745c1367, arg1: RocBox) -> AnonStructAeceb9ea017a78f4;
 
     /// Entrypoint: shutdown_for_host!
     pub fn roc_shutdown_for_host(arg0: AnonStruct628b43fd33b27733, arg1: RocBox) -> ShutdownForHostResult;


### PR DESCRIPTION
## Summary

- add immutable startup-declared file roots, exact routes, prefix mounts, typed cache policy, and authorized file response plans to the Roc API and generated ABI
- activate the complete native file configuration before binding, then serve public routes without Roc handler admission and authorized downloads after Roc policy
- add a shared host-owned streaming engine with race-free capability-relative opens, deny-by-default traversal/symlink/dotfile behavior, bounded transfer workers and buffers, cancellation/drain accounting, and HTTP conditional/range semantics
- add a realistic static-files example plus cross-platform specification coverage for public and authorized files, security cases, metadata, large files, HTTP/1.1, and HTTP/2

## Design notes

The implementation follows design.md ownership boundaries: Roc owns routing and authorization policy, while the host owns filesystem handles, streaming, transport backpressure, and operational limits. Native route topology is finite and immutable. File plans can reference only a startup-activated root identifier and a validated relative child path.

File resolution uses capability-relative component opens with no-follow semantics and retains the opened file handle as the response identity. Transfers run in a dedicated, semaphore-bounded blocking domain and use a single-slot channel, limiting each active transfer to one queued chunk plus one active read buffer.

## Verification

- python3 scripts/test.py: 213 platform tests, 22 application builds, and all 29 real-listener runtime cases passed
- cargo test --lib: 104 tests passed
- cargo clippy --all-targets -- -D warnings
- python3 scripts/build.py --all: x64musl and arm64musl hosts built successfully
- pinned scripts/regenerate_glue.py --check: committed ABI glue is current

Closes #169