### PR TITLE
Restore derived Path and OsStr codecs

### DIFF
--- a/platform/OsStr.roc
+++ b/platform/OsStr.roc
@@ -59,9 +59,11 @@ OsStr := [
 	from_interpolation = |first, rest|
 		Utf8(rest.fold(first, |acc, (interpolated, segment)| acc.concat(interpolated).concat(segment)))
 
-	## TODO: Restore generic parser_for and encoder_for helpers when the compiler
-	## no longer treats auto-derived `_` declarations in platforms as hosted:
-	## https://github.com/roc-lang/roc/issues/10162
+	## Decode an OS string through a generic encoding.
+	parser_for : _
+
+	## Encode an OS string through a generic encoding.
+	encoder_for : _
 
 	## Convert an OS string to a string if its raw representation is valid text.
 	to_str_try : OsStr -> Try(Str, [InvalidStr(U64)])
@@ -244,8 +246,26 @@ is_low_surrogate = |unit| unit >= 0xDC00 and unit <= 0xDFFF
 is_surrogate : U16 -> Bool
 is_surrogate = |unit| unit >= 0xD800 and unit <= 0xDFFF
 
+os_str_json_round_trips : OsStr -> Bool
+os_str_json_round_trips = |os_str| {
+	decoded : Try(OsStr, [InvalidJson(Str)])
+	decoded = Json.parse(Json.to_str(os_str))
+
+	match decoded {
+		Ok(value) => value == os_str
+		Err(_) => False
+	}
+}
+
 ## Inspection identifies the representation and preserves invalid raw units.
 expect Str.inspect(OsStr.utf8("a\nb")) == "OsStr.utf8(\"a\\nb\")"
+
+## Derived generic codecs roundtrip every OS string representation.
+expect [
+	OsStr.utf8("config.toml"),
+	OsStr.unix_bytes([97, 255, 98]),
+	OsStr.windows_u16s([0xD800, 97]),
+].all(os_str_json_round_trips)
 
 ## Unix text inspection uses the canonical UTF-8 representation.
 expect Str.inspect(OsStr.unix("abc")) == "OsStr.utf8(\"abc\")"

--- a/platform/Path.roc
+++ b/platform/Path.roc
@@ -192,9 +192,11 @@ Path := [
 	from_interpolation = |first, rest|
 		Utf8(rest.fold(first, |acc, (interpolated, segment)| acc.concat(interpolated).concat(segment)))
 
-	## TODO: Restore generic parser_for and encoder_for helpers when the compiler
-	## no longer treats auto-derived `_` declarations in platforms as hosted:
-	## https://github.com/roc-lang/roc/issues/10162
+	## Decode a path through a generic encoding.
+	parser_for : _
+
+	## Encode a path through a generic encoding.
+	encoder_for : _
 
 	## Create a Unix path from a Roc string by storing its UTF-8 bytes.
 	unix : Str -> Path
@@ -597,8 +599,26 @@ quoted_literal_path = "config.txt"
 path_identity : Path -> Path
 path_identity = |path| path
 
+path_json_round_trips : Path -> Bool
+path_json_round_trips = |path| {
+	decoded : Try(Path, [InvalidJson(Str)])
+	decoded = Json.parse(Json.to_str(path))
+
+	match decoded {
+		Ok(value) => value == path
+		Err(_) => False
+	}
+}
+
 ## Constructors preserve Unix, Windows, and UTF-8 path representations.
 expect Path.unix("abc") == Unix([97, 98, 99])
+
+## Derived generic codecs roundtrip every path representation.
+expect [
+	Path.utf8("config.toml"),
+	Path.unix_bytes([97, 255, 98]),
+	Path.windows_u16s([0xD800, 97]),
+].all(path_json_round_trips)
 
 ## Unix byte construction preserves every byte.
 expect Path.unix_bytes([97, 98, 99]) == Unix([97, 98, 99])


### PR DESCRIPTION
## Summary

- restore compiler-derived `parser_for` and `encoder_for` methods on `Path` and `OsStr` now that [roc-lang/roc#10162](https://github.com/roc-lang/roc/issues/10162) is fixed
- cover JSON round trips for UTF-8 values, invalid Unix bytes, and invalid Windows UTF-16 units

## Testing

- `roc fmt --check platform/Path.roc platform/OsStr.roc`
- `roc test platform/main.roc --no-cache` (215 tests passed)
- `python3 -m unittest scripts.test_harness_test` (22 tests passed)
- `python3 scripts/test.py` currently stops during the check stage on the SQLite examples because the current compiler cannot find implicitly derived record parser methods; this also reproduces against the unchanged released platform and is consistent with the open derivation failure in [roc-lang/roc#10418](https://github.com/roc-lang/roc/issues/10418)