### PR TITLE
Document safe SQLite parameter handling

### DIFF
--- a/platform/Sqlite.roc
+++ b/platform/Sqlite.roc
@@ -11,6 +11,13 @@ import Path
 ## results are selected by the expected Roc type. Structural records derive
 ## their parser automatically when their fields use supported SQLite types.
 ##
+## Treat `query` as trusted, application-owned SQL. Never interpolate request
+## data or other untrusted values into it. Pass data values through `params`,
+## which uses SQLite parameter binding rather than manual escaping. Parameters
+## cannot represent identifiers or SQL syntax; choose dynamic identifiers and
+## clauses from an application-controlled allowlist before constructing a
+## query.
+##
 ## ```roc
 ## Todo : { id : I64, task : Str }
 ##

--- a/scripts/test_spec.json
+++ b/scripts/test_spec.json
@@ -611,6 +611,20 @@
               "headers": {
                 "Content-Type": "application/json"
               },
+              "body": "{\"task\":\"'); DROP TABLE todos;--\",\"status\":\"completed\"}",
+              "body_contains": ["'); DROP TABLE todos;--", "completed"]
+            },
+            {
+              "method": "GET",
+              "target": "/todos",
+              "body_contains": ["Prepare for AoC", "Spec task", "'); DROP TABLE todos;--"]
+            },
+            {
+              "method": "POST",
+              "target": "/todos",
+              "headers": {
+                "Content-Type": "application/json"
+              },
               "body": "{}",
               "status": 400,
               "expect_body": "Expected JSON with string fields \"task\" and \"status\"."


### PR DESCRIPTION
## Summary

- document that SQLite query text must be trusted application-owned SQL
- direct untrusted values through bound `params` and dynamic SQL structure through application allowlists
- exercise an injection-shaped todo through the real HTTP listener and verify the database remains queryable

## Validation

- `python3 scripts/test.py --operation validate --roc <pinned nightly 306abd6>`
- focused `examples/todos.roc [routes-and-database]` runtime case
- `ROC_DOCS_URL_ROOT=/basic-webserver/main roc docs --output=... platform/main.roc`
- reviewed the generated `Sqlite` page; pinned and current compiler output was byte-identical

Closes #119