### PR TITLE
Make response framing a tested host guarantee

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ The listener accepts HTTP/1.1 and cleartext prior-knowledge HTTP/2. It does not
 terminate TLS or perform public protocol negotiation; production deployments
 normally put a reverse proxy or load balancer in front. Ordinary responses are
 complete in-memory values, while request bodies can be consumed as bounded
-streams.
+streams. The host validates response fields and owns framing for both protocol
+versions; see the [response design](design.md#response-validation-and-framing).
 
 Eligible responses of at least 1 KiB are compressed automatically when the
 client accepts Zstandard, Brotli, or gzip. The host negotiates quality weights,

--- a/design.md
+++ b/design.md
@@ -687,6 +687,43 @@ Large or transport-oriented responses are represented by a closed set of typed
 native response plans, such as serving a file. The host streams those responses
 without moving their contents through Roc.
 
+### Response validation and framing
+
+The application response contract is independent of the HTTP wire version.
+Ordinary responses contain one status, a complete ordered header list, and a
+complete bounded representation body. The host validates the whole response
+before transmission and owns HTTP/1.1 and HTTP/2 message framing.
+
+Applications may select representation metadata, but they do not control
+connection state or transfer framing. Header names and values must use valid
+HTTP field syntax. `Connection`, `HTTP2-Settings`, `Keep-Alive`,
+`Proxy-Connection`, `TE`, `Transfer-Encoding`, `Upgrade`, `Trailer`, and fields
+nominated by `Connection` are rejected. `Content-Length` is host-owned: an
+application may omit it or assert the complete returned representation length,
+but repeated values must agree and the host emits one canonical length for the
+bytes it will transmit after content coding. Repeated non-framing fields retain
+their order; the platform does not impose application security-header policy
+or maintain a registry of repeatable extension fields.
+
+Method and status semantics are part of the common contract:
+
+- a `HEAD` handler returns the representation it would return for `GET`; the
+  host derives its metadata and transmits no content;
+- `204` and `304` require an empty body and no application-supplied
+  `Content-Length`;
+- `205` requires an empty body and is transmitted with a zero length;
+- standalone informational responses are invalid because the ordinary
+  one-response API cannot provide the final response that must follow them;
+- a successful ordinary `CONNECT` response is invalid because the platform
+  does not expose a tunnel outcome.
+
+An invalid application response is never partially transmitted. The host logs
+a diagnostic and substitutes a fixed, bounded `500 Internal Server Error`.
+`StopAfter` uses the same validation while preserving its graceful-shutdown
+intent. Native and host-generated responses pass through the same final
+invariants, while native streams with an unknown length leave the protocol
+framing choice to the host.
+
 ### Response content coding
 
 The host negotiates response compression from `Accept-Encoding` by default.

--- a/platform/Server.roc
+++ b/platform/Server.roc
@@ -586,8 +586,21 @@ Server :: [].{
 			}
 	}
 
-	## A successful request outcome. StopAfter sends its response while beginning
-	## graceful shutdown; the first shutdown cause wins.
+	## A successful request outcome. Ordinary responses have one host-owned
+	## framing contract across HTTP/1.1 and HTTP/2. Header names and values must
+	## be valid; connection-specific fields and transfer coding are rejected.
+	## Content-Length is optional, but when present every value must agree with
+	## the complete returned body before host content coding. The host emits one
+	## canonical length for the bytes it will transmit.
+	##
+	## HEAD transmits no body but reports the returned representation's length.
+	## 204 and 304 require an empty body and no Content-Length; 205 also requires
+	## an empty body. Informational responses and successful CONNECT responses
+	## are unsupported. An invalid response is logged and replaced with a bounded
+	## 500 before any part of it is transmitted.
+	##
+	## StopAfter applies the same validation, sends the resulting response while
+	## beginning graceful shutdown, and preserves the first shutdown cause.
 	Outcome := [
 		Respond(Response.Response),
 		ServeFile(

--- a/src/file_server.rs
+++ b/src/file_server.rs
@@ -4,10 +4,11 @@ use crate::compression::{
     apply_content_coding, encoded_etag, response_is_compressible, vary_on_accept_encoding,
     AcceptedEncodings, ContentCoding, ContentEncoder,
 };
+use crate::response::{empty_body, full_body, ServerResponse};
 use crate::shutdown::ActiveRequest;
 use bytes::Bytes;
 use cap_primitives::fs::{open, open_ambient_dir, open_dir_nofollow, FollowSymlinks, OpenOptions};
-use http_body_util::{combinators::UnsyncBoxBody, BodyExt, Empty, Full};
+use http_body_util::BodyExt;
 use hyper::body::{Body, Frame, SizeHint};
 use hyper::header::{
     ACCEPT_RANGES, ALLOW, CACHE_CONTROL, CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_LENGTH,
@@ -26,26 +27,11 @@ use std::task::{Context, Poll};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
 
-pub(crate) type ServerBody = UnsyncBoxBody<Bytes, io::Error>;
-pub(crate) type ServerResponse = hyper::Response<ServerBody>;
-
 const MAX_FILE_ROOTS: usize = 64;
 const MAX_NATIVE_ROUTES: usize = 128;
 const MAX_ROUTE_PATH_BYTES: usize = 4 * 1024;
 const MAX_RELATIVE_PATH_BYTES: usize = 4 * 1024;
 const MAX_DOWNLOAD_NAME_CHARS: usize = 150;
-
-pub(crate) fn full_body(bytes: Bytes) -> ServerBody {
-    Full::new(bytes)
-        .map_err(|never| match never {})
-        .boxed_unsync()
-}
-
-pub(crate) fn empty_body() -> ServerBody {
-    Empty::<Bytes>::new()
-        .map_err(|never| match never {})
-        .boxed_unsync()
-}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum CachePolicy {

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -9,11 +9,14 @@ use crate::compression::{
     AcceptedEncodings, MAX_BUFFERED_COMPRESSION_BYTES,
 };
 use crate::file_server::{
-    full_body, CachePolicy, Disposition, FilePlan, FileRootSpec, FileService, NativeRouteKind,
-    NativeRouteSpec, ServerResponse,
+    CachePolicy, Disposition, FilePlan, FileRootSpec, FileService, NativeRouteKind, NativeRouteSpec,
 };
 use crate::request_body::{register as register_body, PumpError};
 use crate::request_parts::{request_target, RequestPartsBacking};
+use crate::response::{
+    application_parts, finalize_response, full_body, safe_internal_server_error, RequestSemantics,
+    ServerResponse,
+};
 use crate::roc_platform_abi::*;
 use crate::shutdown::{RequestTracker, ShutdownController, ShutdownReason};
 use bytes::Bytes;
@@ -522,13 +525,17 @@ fn call_roc(
     request: ServerRequest,
     context: RocBox,
     accepted_encodings: AcceptedEncodings,
+    response_semantics: &RequestSemantics,
 ) -> RocOutcome {
     let response = unsafe { roc_respond_for_host(request, context) };
-    outcome_from_roc(response, accepted_encodings)
+    outcome_from_roc(response, accepted_encodings, response_semantics)
 }
 
 enum RocOutcome {
-    Ordinary(ServerResponse, Option<i64>),
+    Ordinary(
+        Result<ServerResponse, crate::response::ResponseError>,
+        Option<i64>,
+    ),
     File(FilePlan),
     Invalid(String),
 }
@@ -536,11 +543,19 @@ enum RocOutcome {
 fn outcome_from_roc(
     response: RocServerResponse,
     accepted_encodings: AcceptedEncodings,
+    response_semantics: &RequestSemantics,
 ) -> RocOutcome {
     match response.kind {
         0 => {
             let stop_code = response.stop.then_some(response.exit_code);
-            RocOutcome::Ordinary(response_to_hyper(response, accepted_encodings), stop_code)
+            RocOutcome::Ordinary(
+                response_to_hyper(
+                    RocResponseOwner { response },
+                    accepted_encodings,
+                    response_semantics,
+                ),
+                stop_code,
+            )
         }
         1 => {
             let root_id = response.file_root_id.as_str().to_owned();
@@ -594,39 +609,45 @@ fn outcome_from_roc(
 }
 
 fn response_to_hyper(
-    response: RocServerResponse,
+    owner: RocResponseOwner,
     accepted_encodings: AcceptedEncodings,
-) -> ServerResponse {
-    crate::request_body::validate_response_body(&response.body);
-    let mut builder = hyper::Response::builder().status(response.status);
-    for header in response.headers.as_slice() {
-        builder = builder.header(header.name.as_str(), header.value.as_str());
-    }
-    let head = match builder.body(()) {
-        Ok(head) => head,
-        Err(_) => {
-            unsafe { response.decref(roc_host()) };
-            return internal_server_error("Failed to build response");
-        }
-    };
+    request: &RequestSemantics,
+) -> Result<ServerResponse, crate::response::ResponseError> {
+    crate::request_body::validate_response_body(&owner.response.body);
+    let body_length = owner.response.body.len();
+    let (status, headers) = application_parts(
+        owner.response.status,
+        owner
+            .response
+            .headers
+            .as_slice()
+            .iter()
+            .map(|header| (header.name.as_str(), header.value.as_str())),
+        body_length as u64,
+        request,
+    )?;
+    let mut head = hyper::Response::new(());
+    *head.status_mut() = status;
+    *head.headers_mut() = headers;
     let (mut parts, ()) = head.into_parts();
-    let body_length = response.body.len();
     if body_length <= MAX_BUFFERED_COMPRESSION_BYTES
         && response_is_compressible(parts.status, &parts.headers, body_length as u64)
     {
         vary_on_accept_encoding(&mut parts.headers);
         if let Some(coding) = accepted_encodings.preferred() {
-            if let Ok(encoded) = encode_bytes(coding, response.body.as_slice()) {
+            if let Ok(encoded) = encode_bytes(coding, owner.response.body.as_slice()) {
                 if encoded.len() < body_length {
                     apply_content_coding(&mut parts.headers, coding, Some(encoded.len()));
-                    unsafe { response.decref(roc_host()) };
-                    return hyper::Response::from_parts(parts, full_body(Bytes::from(encoded)));
+                    return Ok(hyper::Response::from_parts(
+                        parts,
+                        full_body(Bytes::from(encoded)),
+                    ));
                 }
             }
         }
     }
-    let body = Bytes::from_owner(RocResponseOwner { response });
-    hyper::Response::from_parts(parts, full_body(body))
+    let body = Bytes::from_owner(owner);
+    Ok(hyper::Response::from_parts(parts, full_body(body)))
 }
 
 /// Owns every Roc reference in a response while Hyper may still transmit the
@@ -654,13 +675,6 @@ impl Drop for RocResponseOwner {
         // and Bytes drops its owner exactly once after its last clone.
         unsafe { self.response.decref(roc_host()) };
     }
-}
-
-fn internal_server_error(message: &str) -> ServerResponse {
-    hyper::Response::builder()
-        .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
-        .body(full_body(Bytes::copy_from_slice(message.as_bytes())))
-        .expect("static 500 response is valid")
 }
 
 fn service_unavailable() -> ServerResponse {
@@ -695,9 +709,10 @@ fn payload_too_large(limit: u64) -> ServerResponse {
         .expect("static 413 response is valid")
 }
 
-async fn handle_req(
+async fn handle_req_unframed(
     request: hyper::Request<hyper::body::Incoming>,
     context: ServerContext,
+    response_semantics: &RequestSemantics,
 ) -> ServerResponse {
     let active_request = match context.requests.begin() {
         Some(active) => Arc::new(active),
@@ -748,6 +763,7 @@ async fn handle_req(
     let body_handle = registration.handle;
     let roc_context = Arc::clone(&context.roc_context);
     let handler_request = Arc::clone(&active_request);
+    let handler_response_semantics = response_semantics.clone();
     let handled = spawn_blocking(move || {
         // These guards intentionally live in the non-cancellable blocking task.
         // Aborting its Tokio JoinHandle must not make shutdown believe Roc has
@@ -762,20 +778,32 @@ async fn handle_req(
             declared_length,
         );
         let request_context = roc_context.retain_for_request();
-        let result = call_roc(roc_request, request_context, accepted_encodings);
+        let result = call_roc(
+            roc_request,
+            request_context,
+            accepted_encodings,
+            &handler_response_semantics,
+        );
         body_handle.expire();
         result
     })
     .await;
 
     match handled {
-        Ok(RocOutcome::Ordinary(response, Some(exit_code))) => {
-            context
-                .shutdown
-                .request(ShutdownReason::ApplicationRequested { exit_code });
-            response
+        Ok(RocOutcome::Ordinary(response, stop_code)) => {
+            if let Some(exit_code) = stop_code {
+                context
+                    .shutdown
+                    .request(ShutdownReason::ApplicationRequested { exit_code });
+            }
+            match response {
+                Ok(response) => response,
+                Err(error) => {
+                    eprintln!("Invalid Roc response: {error}");
+                    safe_internal_server_error(response_semantics)
+                }
+            }
         }
-        Ok(RocOutcome::Ordinary(response, None)) => response,
         Ok(RocOutcome::File(plan)) => {
             context
                 .config
@@ -785,21 +813,37 @@ async fn handle_req(
         }
         Ok(RocOutcome::Invalid(detail)) => {
             eprintln!("Invalid Roc response plan: {detail}");
-            internal_server_error("500 Internal Server Error")
+            safe_internal_server_error(response_semantics)
         }
         Err(error) => {
             eprintln!("Recovered from calling Roc: {error:?}");
-            internal_server_error("500 Internal Server Error")
+            safe_internal_server_error(response_semantics)
+        }
+    }
+}
+
+async fn handle_req(
+    request: hyper::Request<hyper::body::Incoming>,
+    context: ServerContext,
+    response_semantics: RequestSemantics,
+) -> ServerResponse {
+    let response = handle_req_unframed(request, context, &response_semantics).await;
+    match finalize_response(response, &response_semantics) {
+        Ok(response) => response,
+        Err(error) => {
+            eprintln!("Invalid host response: {error}");
+            safe_internal_server_error(&response_semantics)
         }
     }
 }
 
 async fn handle_panics(
     future: impl Future<Output = ServerResponse>,
+    response_semantics: RequestSemantics,
 ) -> Result<ServerResponse, Infallible> {
     match AssertUnwindSafe(future).catch_unwind().await {
         Ok(response) => Ok(response),
-        Err(_) => Ok(internal_server_error("Panic detected")),
+        Err(_) => Ok(safe_internal_server_error(&response_semantics)),
     }
 }
 
@@ -816,7 +860,11 @@ async fn serve_connection(stream: tokio::net::TcpStream, context: ServerContext)
     let connection = builder.serve_connection(
         io,
         hyper::service::service_fn(move |request| {
-            handle_panics(handle_req(request, service_context.clone()))
+            let response_semantics = RequestSemantics::from_request(&request);
+            handle_panics(
+                handle_req(request, service_context.clone(), response_semantics.clone()),
+                response_semantics,
+            )
         }),
     );
     tokio::pin!(connection);
@@ -997,6 +1045,13 @@ mod tests {
         AcceptedEncodings::from_headers(&hyper::HeaderMap::new())
     }
 
+    fn get_http1_semantics() -> RequestSemantics {
+        RequestSemantics {
+            method: hyper::Method::GET,
+            version: hyper::Version::HTTP_11,
+        }
+    }
+
     #[test]
     fn method_tags_match_internal_server_contract() {
         assert_eq!(method_to_tag(&hyper::Method::CONNECT), 0);
@@ -1137,7 +1192,14 @@ mod tests {
             kind: 0,
             stop: false,
         };
-        let response = response_to_hyper(roc_response, no_compression());
+        let response = response_to_hyper(
+            RocResponseOwner {
+                response: roc_response,
+            },
+            no_compression(),
+            &get_http1_semantics(),
+        )
+        .unwrap();
         assert_eq!(crate::request_parts::active_backings(), 1);
 
         let body = response.into_body().collect().await.unwrap().to_bytes();
@@ -1194,7 +1256,12 @@ mod tests {
             stop: false,
         };
 
-        let response = response_to_hyper(response, no_compression());
+        let response = response_to_hyper(
+            RocResponseOwner { response },
+            no_compression(),
+            &get_http1_semantics(),
+        )
+        .unwrap();
         assert_eq!(drops.load(Ordering::Acquire), 0);
         let transmitted = response.into_body().collect().await.unwrap().to_bytes();
         assert_eq!(transmitted.as_ptr(), original_ptr);
@@ -1229,17 +1296,59 @@ mod tests {
             "gzip, br, zstd".parse().unwrap(),
         );
 
-        let response =
-            response_to_hyper(response, AcceptedEncodings::from_headers(&request_headers));
+        let response = response_to_hyper(
+            RocResponseOwner { response },
+            AcceptedEncodings::from_headers(&request_headers),
+            &get_http1_semantics(),
+        )
+        .unwrap();
+        let response = finalize_response(response, &get_http1_semantics()).unwrap();
         assert_eq!(response.headers()[hyper::header::CONTENT_ENCODING], "zstd");
         assert_eq!(response.headers()[hyper::header::VARY], "Accept-Encoding");
+        let transmitted_length = response.headers()[CONTENT_LENGTH]
+            .to_str()
+            .unwrap()
+            .parse::<usize>()
+            .unwrap();
         let encoded = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(encoded.len(), transmitted_length);
         let mut decoded = Vec::new();
         zstd::stream::read::Decoder::new(encoded.as_ref())
             .unwrap()
             .read_to_end(&mut decoded)
             .unwrap();
         assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn invalid_stop_after_keeps_its_shutdown_intent_and_uses_normal_validation() {
+        initialize_test_host();
+        let response = RocServerResponse {
+            exit_code: 17,
+            body: unsafe { RocListWith::<u8, false>::from_slice(b"not allowed", roc_host()) },
+            file_download_name: RocStr::empty(),
+            file_relative: RocStr::empty(),
+            file_root_id: RocStr::empty(),
+            headers: RocList::empty(),
+            file_cache_max_age_seconds: 0,
+            status: 204,
+            file_cache_override: false,
+            file_cache_tag: 0,
+            file_disposition: 0,
+            kind: 0,
+            stop: true,
+        };
+
+        let RocOutcome::Ordinary(response, stop_code) =
+            outcome_from_roc(response, no_compression(), &get_http1_semantics())
+        else {
+            panic!("StopAfter must remain an ordinary response");
+        };
+        assert_eq!(stop_code, Some(17));
+        assert_eq!(
+            response.unwrap_err().to_string(),
+            "status 204 No Content forbids response content"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod os_str;
 mod path;
 mod request_body;
 mod request_parts;
+mod response;
 mod roc_alloc;
 mod roc_platform_abi;
 mod shutdown;

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,0 +1,756 @@
+//! Protocol-independent response validation and framing.
+//!
+//! Roc supplies response semantics; the host owns message framing. Every
+//! response passes through this module before Hyper sees it, including native
+//! file responses and host-generated errors. Keeping the rules here makes the
+//! HTTP/1.1 and HTTP/2 contracts independent of encoder-specific cleanup.
+
+use bytes::Bytes;
+use http_body_util::{combinators::UnsyncBoxBody, BodyExt, Empty, Full};
+use hyper::body::Body;
+use hyper::header::{HeaderName, HeaderValue, CONTENT_LENGTH};
+use hyper::{HeaderMap, Method, StatusCode, Version};
+use std::fmt;
+use std::io;
+
+pub(crate) type ServerBody = UnsyncBoxBody<Bytes, io::Error>;
+pub(crate) type ServerResponse = hyper::Response<ServerBody>;
+
+const CONNECTION_SPECIFIC_FIELDS: &[&str] = &[
+    "connection",
+    "http2-settings",
+    "keep-alive",
+    "proxy-connection",
+    "te",
+    "transfer-encoding",
+    "upgrade",
+];
+const UNSUPPORTED_TRAILER_FIELD: &str = "trailer";
+
+#[derive(Clone, Debug)]
+pub(crate) struct RequestSemantics {
+    pub(crate) method: Method,
+    pub(crate) version: Version,
+}
+
+impl RequestSemantics {
+    pub(crate) fn from_request<B>(request: &hyper::Request<B>) -> Self {
+        Self {
+            method: request.method().clone(),
+            version: request.version(),
+        }
+    }
+
+    fn protocol_name(&self) -> &'static str {
+        match self.version {
+            Version::HTTP_2 => "HTTP/2",
+            Version::HTTP_10 | Version::HTTP_11 => "HTTP/1",
+            _ => "HTTP",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ResponseError(String);
+
+impl ResponseError {
+    fn new(detail: impl Into<String>) -> Self {
+        Self(detail.into())
+    }
+}
+
+impl fmt::Display for ResponseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+pub(crate) fn full_body(bytes: Bytes) -> ServerBody {
+    Full::new(bytes)
+        .map_err(|never| match never {})
+        .boxed_unsync()
+}
+
+pub(crate) fn empty_body() -> ServerBody {
+    Empty::<Bytes>::new()
+        .map_err(|never| match never {})
+        .boxed_unsync()
+}
+
+/// Validate application-supplied status and headers, and replace any accepted
+/// Content-Length fields with one canonical host-owned value.
+pub(crate) fn application_parts<'a>(
+    raw_status: u16,
+    raw_headers: impl IntoIterator<Item = (&'a str, &'a str)>,
+    representation_length: u64,
+    request: &RequestSemantics,
+) -> Result<(StatusCode, HeaderMap), ResponseError> {
+    let status = StatusCode::from_u16(raw_status)
+        .map_err(|_| ResponseError::new(format!("invalid response status {raw_status}")))?;
+    let length_rule = length_rule(status, request)?;
+    if (matches!(length_rule, LengthRule::Forbidden) || status == StatusCode::RESET_CONTENT)
+        && representation_length != 0
+    {
+        return Err(ResponseError::new(format!(
+            "status {status} forbids response content"
+        )));
+    }
+
+    let mut headers = HeaderMap::new();
+    let mut supplied_lengths = Vec::new();
+    for (raw_name, raw_value) in raw_headers {
+        let name = HeaderName::from_bytes(raw_name.as_bytes()).map_err(|_| {
+            ResponseError::new(format!("invalid response header name {raw_name:?}"))
+        })?;
+        let value = HeaderValue::from_str(raw_value).map_err(|_| {
+            ResponseError::new(format!("invalid value for response header {raw_name:?}"))
+        })?;
+        if is_connection_specific(&name) || name.as_str() == UNSUPPORTED_TRAILER_FIELD {
+            return Err(ResponseError::new(format!(
+                "{} response field {name:?} controls unsupported connection framing or trailers",
+                request.protocol_name()
+            )));
+        }
+        if name == CONTENT_LENGTH {
+            supplied_lengths.extend(parse_content_length_value(value.as_bytes())?);
+        } else {
+            headers.append(name, value);
+        }
+    }
+
+    let supplied_length = one_content_length(&supplied_lengths)?;
+    match length_rule {
+        LengthRule::Forbidden => {
+            if supplied_length.is_some() {
+                return Err(ResponseError::new(format!(
+                    "status {status} forbids Content-Length"
+                )));
+            }
+        }
+        LengthRule::Representation => {
+            if let Some(supplied) = supplied_length {
+                if supplied != representation_length {
+                    return Err(ResponseError::new(format!(
+                        "Content-Length {supplied} does not match the {representation_length}-byte response representation"
+                    )));
+                }
+            }
+            set_content_length(&mut headers, representation_length);
+        }
+    }
+    Ok((status, headers))
+}
+
+/// Apply the same framing invariants to application, native, and host-generated
+/// responses immediately before protocol transmission.
+pub(crate) fn finalize_response(
+    mut response: ServerResponse,
+    request: &RequestSemantics,
+) -> Result<ServerResponse, ResponseError> {
+    let status = response.status();
+    let length_rule = length_rule(status, request)?;
+    for name in response.headers().keys() {
+        if is_connection_specific(name) || name.as_str() == UNSUPPORTED_TRAILER_FIELD {
+            return Err(ResponseError::new(format!(
+                "host response contained unsupported connection framing or trailer field {name:?}"
+            )));
+        }
+    }
+    let supplied_lengths = response
+        .headers()
+        .get_all(CONTENT_LENGTH)
+        .iter()
+        .map(|value| parse_content_length_value(value.as_bytes()))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    let supplied_length = one_content_length(&supplied_lengths)?;
+    let body_length = response.body().size_hint().exact();
+    if status == StatusCode::RESET_CONTENT && body_length != Some(0) {
+        return Err(ResponseError::new(
+            "status 205 Reset Content forbids response content",
+        ));
+    }
+
+    match length_rule {
+        LengthRule::Forbidden => {
+            if supplied_length.is_some() {
+                return Err(ResponseError::new(format!(
+                    "status {status} forbids Content-Length"
+                )));
+            }
+            if body_length != Some(0) {
+                return Err(ResponseError::new(format!(
+                    "status {status} forbids response content"
+                )));
+            }
+            response.headers_mut().remove(CONTENT_LENGTH);
+        }
+        LengthRule::Representation if request.method == Method::HEAD => {
+            // Native responses can arrive with the body already suppressed and
+            // a representation length in the header. Complete ordinary and
+            // host error responses still carry their representation here.
+            let representation_length = match (supplied_length, body_length) {
+                (Some(length), Some(0)) => Some(length),
+                (Some(length), Some(body_length)) if length == body_length => Some(length),
+                (Some(length), Some(body_length)) => {
+                    return Err(ResponseError::new(format!(
+                        "Content-Length {length} does not match the {body_length}-byte response representation"
+                    )));
+                }
+                (Some(_), None) => {
+                    return Err(ResponseError::new(
+                        "Content-Length cannot frame a response body with an unknown encoded length",
+                    ));
+                }
+                (None, Some(0)) | (None, None) => None,
+                (None, Some(body_length)) => Some(body_length),
+            };
+            if let Some(representation_length) = representation_length {
+                set_content_length(response.headers_mut(), representation_length);
+            } else {
+                response.headers_mut().remove(CONTENT_LENGTH);
+            }
+            *response.body_mut() = empty_body();
+        }
+        LengthRule::Representation => match (supplied_length, body_length) {
+            (Some(length), Some(body_length)) if length != body_length => {
+                return Err(ResponseError::new(format!(
+                    "Content-Length {length} does not match the {body_length}-byte response body"
+                )));
+            }
+            (Some(_), None) => {
+                return Err(ResponseError::new(
+                    "Content-Length cannot frame a response body with an unknown encoded length",
+                ));
+            }
+            (_, Some(body_length)) => {
+                set_content_length(response.headers_mut(), body_length);
+            }
+            (None, None) => {
+                response.headers_mut().remove(CONTENT_LENGTH);
+            }
+        },
+    }
+    Ok(response)
+}
+
+pub(crate) fn safe_internal_server_error(request: &RequestSemantics) -> ServerResponse {
+    let mut response =
+        hyper::Response::new(full_body(Bytes::from_static(b"500 Internal Server Error")));
+    *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+    response.headers_mut().insert(
+        hyper::header::CONTENT_TYPE,
+        HeaderValue::from_static("text/plain; charset=utf-8"),
+    );
+    finalize_response(response, request).expect("the static safe 500 response must be valid")
+}
+
+fn length_rule(
+    status: StatusCode,
+    request: &RequestSemantics,
+) -> Result<LengthRule, ResponseError> {
+    if status.is_informational() {
+        return Err(ResponseError::new(
+            "ordinary responses cannot be informational because no final response would follow",
+        ));
+    }
+    if request.method == Method::CONNECT && status.is_success() {
+        return Err(ResponseError::new(
+            "a successful CONNECT requires an unsupported tunnel outcome",
+        ));
+    }
+    if status == StatusCode::NO_CONTENT || status == StatusCode::NOT_MODIFIED {
+        Ok(LengthRule::Forbidden)
+    } else {
+        Ok(LengthRule::Representation)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum LengthRule {
+    Forbidden,
+    Representation,
+}
+
+fn is_connection_specific(name: &HeaderName) -> bool {
+    CONNECTION_SPECIFIC_FIELDS
+        .iter()
+        .any(|forbidden| name.as_str() == *forbidden)
+}
+
+fn parse_content_length_value(value: &[u8]) -> Result<Vec<u64>, ResponseError> {
+    let text = std::str::from_utf8(value)
+        .map_err(|_| ResponseError::new("Content-Length is not valid ASCII"))?;
+    text.split(',')
+        .map(|part| {
+            let digits = part.trim_matches([' ', '\t']);
+            if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+                return Err(ResponseError::new(format!(
+                    "invalid Content-Length value {text:?}"
+                )));
+            }
+            digits
+                .parse::<u64>()
+                .map_err(|_| ResponseError::new(format!("invalid Content-Length value {text:?}")))
+        })
+        .collect()
+}
+
+fn one_content_length(lengths: &[u64]) -> Result<Option<u64>, ResponseError> {
+    let Some((&first, rest)) = lengths.split_first() else {
+        return Ok(None);
+    };
+    if rest.iter().any(|length| *length != first) {
+        return Err(ResponseError::new(
+            "conflicting Content-Length field values",
+        ));
+    }
+    Ok(Some(first))
+}
+
+fn set_content_length(headers: &mut HeaderMap, length: u64) {
+    headers.remove(CONTENT_LENGTH);
+    headers.insert(
+        CONTENT_LENGTH,
+        HeaderValue::from_str(&length.to_string())
+            .expect("a decimal u64 is a valid Content-Length"),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_body_util::{BodyExt, Full};
+    use hyper::service::service_fn;
+    use hyper_util::rt::{TokioExecutor, TokioIo};
+    use std::convert::Infallible;
+
+    #[derive(Clone)]
+    struct ApplicationCase {
+        name: &'static str,
+        method: Method,
+        status: u16,
+        headers: Vec<(&'static str, &'static str)>,
+        body: &'static [u8],
+        expected_status: StatusCode,
+        expected_body: &'static [u8],
+        expected_content_length: Option<u64>,
+    }
+
+    impl ApplicationCase {
+        fn valid(
+            name: &'static str,
+            method: Method,
+            status: u16,
+            headers: Vec<(&'static str, &'static str)>,
+            body: &'static [u8],
+            expected_body: &'static [u8],
+            expected_content_length: Option<u64>,
+        ) -> Self {
+            Self {
+                name,
+                method,
+                status,
+                headers,
+                body,
+                expected_status: StatusCode::from_u16(status).unwrap(),
+                expected_body,
+                expected_content_length,
+            }
+        }
+
+        fn invalid(
+            name: &'static str,
+            method: Method,
+            status: u16,
+            headers: Vec<(&'static str, &'static str)>,
+            body: &'static [u8],
+        ) -> Self {
+            Self {
+                name,
+                method,
+                status,
+                headers,
+                body,
+                expected_status: StatusCode::INTERNAL_SERVER_ERROR,
+                expected_body: b"500 Internal Server Error",
+                expected_content_length: Some(25),
+            }
+        }
+    }
+
+    fn application_response_for_wire(
+        case: &ApplicationCase,
+        semantics: &RequestSemantics,
+    ) -> ServerResponse {
+        let unframed = match application_parts(
+            case.status,
+            case.headers.iter().copied(),
+            case.body.len() as u64,
+            semantics,
+        ) {
+            Ok((status, headers)) => {
+                let mut response = hyper::Response::new(full_body(Bytes::from_static(case.body)));
+                *response.status_mut() = status;
+                *response.headers_mut() = headers;
+                response
+            }
+            Err(_) => return safe_internal_server_error(semantics),
+        };
+        finalize_response(unframed, semantics)
+            .unwrap_or_else(|_| safe_internal_server_error(semantics))
+    }
+
+    async fn wire_exchange(
+        version: Version,
+        case: ApplicationCase,
+    ) -> (StatusCode, HeaderMap, Bytes) {
+        let semantics = RequestSemantics {
+            method: case.method.clone(),
+            version,
+        };
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let server_semantics = semantics.clone();
+        let server_case = case.clone();
+        let server = tokio::spawn(async move {
+            let service = service_fn(move |_request| {
+                let response = application_response_for_wire(&server_case, &server_semantics);
+                async move { Ok::<_, Infallible>(response) }
+            });
+            match version {
+                Version::HTTP_11 => {
+                    hyper::server::conn::http1::Builder::new()
+                        .serve_connection(TokioIo::new(server_io), service)
+                        .await
+                }
+                Version::HTTP_2 => {
+                    hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                        .serve_connection(TokioIo::new(server_io), service)
+                        .await
+                }
+                _ => unreachable!(),
+            }
+            .expect("wire-test server connection must succeed");
+        });
+
+        let uri = if case.method == Method::CONNECT {
+            "localhost:80"
+        } else {
+            "http://localhost/"
+        };
+        let (response, connection) = match version {
+            Version::HTTP_11 => {
+                let (mut sender, connection) =
+                    hyper::client::conn::http1::handshake(TokioIo::new(client_io))
+                        .await
+                        .unwrap();
+                let connection = tokio::spawn(connection);
+                let request = hyper::Request::builder()
+                    .method(case.method)
+                    .uri(uri)
+                    .body(Full::new(Bytes::new()))
+                    .unwrap();
+                let response = sender.send_request(request).await.unwrap();
+                drop(sender);
+                (response, connection)
+            }
+            Version::HTTP_2 => {
+                let (mut sender, connection) =
+                    hyper::client::conn::http2::handshake::<_, _, Full<Bytes>>(
+                        TokioExecutor::new(),
+                        TokioIo::new(client_io),
+                    )
+                    .await
+                    .unwrap();
+                let connection = tokio::spawn(connection);
+                let request = hyper::Request::builder()
+                    .method(case.method)
+                    .uri(uri)
+                    .body(Full::new(Bytes::new()))
+                    .unwrap();
+                let response = sender.send_request(request).await.unwrap();
+                drop(sender);
+                (response, connection)
+            }
+            _ => unreachable!(),
+        };
+        let status = response.status();
+        let headers = response.headers().clone();
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        connection.abort();
+        server.abort();
+        (status, headers, body)
+    }
+
+    fn conformance_cases() -> Vec<ApplicationCase> {
+        let mut cases = vec![
+            ApplicationCase::valid(
+                "inferred framing",
+                Method::GET,
+                200,
+                vec![("x-result", "valid")],
+                b"abc",
+                b"abc",
+                Some(3),
+            ),
+            ApplicationCase::valid(
+                "correct Content-Length",
+                Method::GET,
+                200,
+                vec![("Content-Length", "3")],
+                b"abc",
+                b"abc",
+                Some(3),
+            ),
+            ApplicationCase::valid(
+                "repeated identical Content-Length",
+                Method::GET,
+                200,
+                vec![("Content-Length", "3"), ("content-length", "3, 3")],
+                b"abc",
+                b"abc",
+                Some(3),
+            ),
+            ApplicationCase::invalid(
+                "conflicting Content-Length",
+                Method::GET,
+                200,
+                vec![("Content-Length", "3"), ("Content-Length", "4")],
+                b"abc",
+            ),
+            ApplicationCase::invalid(
+                "too-small Content-Length",
+                Method::GET,
+                200,
+                vec![("Content-Length", "2")],
+                b"abc",
+            ),
+            ApplicationCase::invalid(
+                "too-large Content-Length",
+                Method::GET,
+                200,
+                vec![("Content-Length", "4")],
+                b"abc",
+            ),
+            ApplicationCase::invalid(
+                "malformed Content-Length",
+                Method::GET,
+                200,
+                vec![("Content-Length", "+3")],
+                b"abc",
+            ),
+            ApplicationCase::invalid(
+                "invalid header name",
+                Method::GET,
+                200,
+                vec![("bad name", "value")],
+                b"",
+            ),
+            ApplicationCase::invalid(
+                "CR in header value",
+                Method::GET,
+                200,
+                vec![("x-test", "before\rafter")],
+                b"",
+            ),
+            ApplicationCase::invalid(
+                "LF in header value",
+                Method::GET,
+                200,
+                vec![("x-test", "before\nafter")],
+                b"",
+            ),
+            ApplicationCase::invalid(
+                "NUL in header value",
+                Method::GET,
+                200,
+                vec![("x-test", "before\0after")],
+                b"",
+            ),
+            ApplicationCase::invalid(
+                "Connection-nominated field",
+                Method::GET,
+                200,
+                vec![("Connection", "x-private"), ("x-private", "secret")],
+                b"",
+            ),
+            ApplicationCase::valid(
+                "HEAD representation",
+                Method::HEAD,
+                200,
+                vec![],
+                b"abc",
+                b"",
+                Some(3),
+            ),
+            ApplicationCase::valid("empty 204", Method::GET, 204, vec![], b"", b"", None),
+            ApplicationCase::invalid("204 with content", Method::GET, 204, vec![], b"abc"),
+            ApplicationCase::invalid(
+                "204 with Content-Length",
+                Method::GET,
+                204,
+                vec![("Content-Length", "0")],
+                b"",
+            ),
+            ApplicationCase::valid("empty 304", Method::GET, 304, vec![], b"", b"", None),
+            ApplicationCase::invalid("304 with content", Method::GET, 304, vec![], b"abc"),
+            ApplicationCase::valid("empty 205", Method::GET, 205, vec![], b"", b"", Some(0)),
+            ApplicationCase::invalid("205 with content", Method::GET, 205, vec![], b"abc"),
+            ApplicationCase::invalid("informational outcome", Method::GET, 103, vec![], b""),
+            ApplicationCase::invalid("successful CONNECT", Method::CONNECT, 200, vec![], b""),
+            ApplicationCase::valid(
+                "failed CONNECT",
+                Method::CONNECT,
+                403,
+                vec![],
+                b"denied",
+                b"denied",
+                Some(6),
+            ),
+            ApplicationCase::valid(
+                "Proxy-Authenticate is response semantics",
+                Method::GET,
+                407,
+                vec![("Proxy-Authenticate", "Basic realm=\"proxy\"")],
+                b"authenticate",
+                b"authenticate",
+                Some(12),
+            ),
+            ApplicationCase::valid(
+                "Proxy-Authorization is not host framing",
+                Method::GET,
+                200,
+                vec![("Proxy-Authorization", "Basic token")],
+                b"",
+                b"",
+                Some(0),
+            ),
+            ApplicationCase::invalid(
+                "unsupported response trailers",
+                Method::GET,
+                200,
+                vec![("Trailer", "Digest")],
+                b"",
+            ),
+        ];
+        for field in CONNECTION_SPECIFIC_FIELDS {
+            cases.push(ApplicationCase::invalid(
+                field,
+                Method::GET,
+                200,
+                vec![(field, if *field == "te" { "trailers" } else { "value" })],
+                b"",
+            ));
+        }
+        cases
+    }
+
+    #[tokio::test]
+    async fn application_conformance_matrix_is_enforced_on_http1_and_http2_wire() {
+        for version in [Version::HTTP_11, Version::HTTP_2] {
+            for case in conformance_cases() {
+                let name = case.name;
+                let expected_status = case.expected_status;
+                let expected_body = case.expected_body;
+                let expected_content_length = case.expected_content_length;
+                let (status, headers, body) = wire_exchange(version, case).await;
+                assert_eq!(status, expected_status, "{version:?} {name}");
+                assert_eq!(body.as_ref(), expected_body, "{version:?} {name}");
+                let lengths = headers.get_all(CONTENT_LENGTH).iter().collect::<Vec<_>>();
+                match expected_content_length {
+                    Some(expected) => {
+                        assert_eq!(lengths.len(), 1, "{version:?} {name}");
+                        assert_eq!(
+                            lengths[0].to_str().unwrap(),
+                            expected.to_string(),
+                            "{version:?} {name}"
+                        );
+                    }
+                    None => assert!(lengths.is_empty(), "{version:?} {name}"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn native_head_response_preserves_representation_length_and_suppresses_content() {
+        let semantics = RequestSemantics {
+            method: Method::HEAD,
+            version: Version::HTTP_2,
+        };
+        let mut response = hyper::Response::new(empty_body());
+        response
+            .headers_mut()
+            .insert(CONTENT_LENGTH, HeaderValue::from_static("123"));
+        let response = finalize_response(response, &semantics).unwrap();
+        assert_eq!(response.headers()[CONTENT_LENGTH], "123");
+        assert_eq!(response.body().size_hint().exact(), Some(0));
+    }
+
+    #[test]
+    fn native_head_response_omits_an_unknown_encoded_length() {
+        let semantics = RequestSemantics {
+            method: Method::HEAD,
+            version: Version::HTTP_11,
+        };
+        let response = finalize_response(hyper::Response::new(empty_body()), &semantics).unwrap();
+        assert!(!response.headers().contains_key(CONTENT_LENGTH));
+        assert_eq!(response.body().size_hint().exact(), Some(0));
+    }
+
+    #[test]
+    fn native_response_cannot_bypass_shared_framing_checks() {
+        let semantics = RequestSemantics {
+            method: Method::GET,
+            version: Version::HTTP_11,
+        };
+        let mut response = hyper::Response::new(full_body(Bytes::from_static(b"abc")));
+        response
+            .headers_mut()
+            .insert(CONTENT_LENGTH, HeaderValue::from_static("2"));
+        assert_eq!(
+            finalize_response(response, &semantics)
+                .unwrap_err()
+                .to_string(),
+            "Content-Length 2 does not match the 3-byte response body"
+        );
+    }
+
+    struct UnknownLengthBody;
+
+    impl Body for UnknownLengthBody {
+        type Data = Bytes;
+        type Error = io::Error;
+
+        fn poll_frame(
+            self: std::pin::Pin<&mut Self>,
+            _context: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+            std::task::Poll::Ready(None)
+        }
+    }
+
+    #[test]
+    fn native_stream_can_use_protocol_framing_only_without_content_length() {
+        let semantics = RequestSemantics {
+            method: Method::GET,
+            version: Version::HTTP_2,
+        };
+        let response = hyper::Response::new(UnknownLengthBody.boxed_unsync());
+        let response = finalize_response(response, &semantics).unwrap();
+        assert!(!response.headers().contains_key(CONTENT_LENGTH));
+
+        let mut incorrectly_framed = hyper::Response::new(UnknownLengthBody.boxed_unsync());
+        incorrectly_framed
+            .headers_mut()
+            .insert(CONTENT_LENGTH, HeaderValue::from_static("1"));
+        assert_eq!(
+            finalize_response(incorrectly_framed, &semantics)
+                .unwrap_err()
+                .to_string(),
+            "Content-Length cannot frame a response body with an unknown encoded length"
+        );
+    }
+}


### PR DESCRIPTION
Closes #181

## Summary
- centralize ordinary, native, and host-generated responses behind one protocol-neutral validation and finalization boundary
- validate status/header syntax and reject application framing, connection-specific, trailer, and connection-nominated fields before Hyper sees them
- make the host own canonical Content-Length and HTTP/1 vs HTTP/2 wire framing while preserving unknown-length native streaming
- define method/status semantics for HEAD, informational responses, 204, 205, 304, and CONNECT, with a bounded static 500 fallback for invalid responses (including StopAfter)
- integrate validation with response compression: application lengths describe the returned representation, then the host emits the encoded transmitted length
- record the enduring ownership and framing invariants in design.md and the application-facing contract in the Roc API
- add a real Hyper HTTP/1.1 and HTTP/2 conformance matrix plus native-response invariant tests

## Deliberate contract choices
- ordinary applications cannot emit standalone 1xx responses or successful CONNECT responses through the one-response API
- 204 and 304 require an empty body and no Content-Length; 205 requires an empty body and canonical length zero
- identical repeated/comma-separated application lengths are accepted and canonicalized; malformed, conflicting, or body-mismatched lengths become a safe 500
- HEAD validates and content-codes the representation before suppressing content; unknown encoded native lengths are omitted
- applications cannot provide Trailer; streaming native responses may omit length and use protocol framing, but cannot assert an unverifiable length

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test (123 passed)
- roc fmt --check platform
- roc test platform/main.roc (215 passed)
- python3 -m unittest scripts.test_harness_test (23 passed)
- python3 scripts/build.py (native x64musl host library built)
- python3 scripts/test.py reaches the unchanged examples/sqlite.roc check and is blocked by the current PATH compiler missing derived RowEncoding.parse_record_start / parser_for; this branch has no diff from origin/main in that example or the relevant platform/Sqlite.roc API
