### PR TITLE
Add bounded request completion telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,6 +630,8 @@ dependencies = [
  "libc",
  "libsqlite3-sys",
  "rustls",
+ "serde",
+ "serde_json",
  "tokio",
  "tower-service",
  "windows-sys 0.59.0",
@@ -697,6 +699,44 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "untrusted",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ hyper-util = { version = "=0.1.12", features = ["tokio", "client", "client-legac
 # backend, and WebPKI roots keep the static host self-contained for Roc linking.
 hyper-rustls = { version = "=0.27.6", default-features = false, features = ["http1", "http2", "tls12", "webpki-tokio", "ring"] }
 rustls = { version = "=0.23.41", default-features = false }
+serde = { version = "=1.0.219", features = ["derive"] }
+serde_json = "=1.0.140"
 tokio = { version = "=1.45.0", features = ["rt", "rt-multi-thread", "macros", "net", "signal", "sync", "time"] }
 tower-service = "=0.3.3"
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,31 @@ then converted to a generic HTTP 500 response. Errors from `init!` and
 `shutdown!` are logged before the process exits. A Roc `crash` exits the whole
 server process.
 
+### Operational telemetry
+
+Access logging and metrics are opt-in host facilities configured during
+`init!`. The host observes a request through response-body end-of-stream,
+failure, or drop, so one terminal event covers Roc responses, native files,
+overload, early rejection, disconnect, and shutdown. End-of-stream means that
+the response body reached its terminal producer state; representation frames
+have been handed to Hyper, not confirmed on the physical network.
+
+`Server.json_lines_access_log` writes structured JSON Lines to standard error
+through a finite non-blocking queue. The default target policy logs no target;
+the optional path policy includes a length-bounded parsed path without its
+query string. Bodies, credentials, cookies, arbitrary headers, peer identity,
+user agents, and client-supplied request or trace identifiers are never
+included. Shutdown gives the queue one second to drain and does not wait
+indefinitely for a blocked standard-error sink.
+
+`Server.open_metrics` installs one native exact OpenMetrics route. Its labels
+come only from finite host enums: unknown methods collapse to `_OTHER`, Roc
+fallback uses one route class, and raw targets or other network-controlled
+values are never labels. The endpoint reports terminal request outcomes,
+duration, response representation bytes, active/high-water connections,
+requests, Roc handlers, handler queueing, native file transfers, rejection
+reasons, and dropped access-log events.
+
 ## Platform facilities
 
 The platform exposes typed modules for:

--- a/examples/hello-web.roc
+++ b/examples/hello-web.roc
@@ -1,12 +1,10 @@
-## Logs each request and responds with a simple HTML greeting.
+## Uses host-owned operational telemetry and responds with a simple HTML greeting.
 app [Context, program] {
-	pf: platform "https://github.com/roc-lang/basic-webserver/releases/download/0.14.0/9mrSfhWKEXsrPUW2oHdZZGov1oMRryvvACDT8p7E97PY.tar.zst",
+	pf: platform "../platform/main.roc",
 	http: "https://github.com/roc-lang/http/releases/download/1.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
 }
 
 import pf.Server
-import pf.Stdout
-import pf.Utc
 import http.Response
 
 # `init!` produces this immutable context once, and every request receives it.
@@ -17,15 +15,20 @@ program = { init!, respond!, shutdown! }
 # `init!` can validate configuration, run migrations, or prepare immutable
 # startup data. This example has no startup data, so its context is `{}`.
 init! : () => Try({ config : Server.Config, context : Context }, [Exit(I64), ..])
-init! = || Ok({ config: Server.default_config, context: {} })
+init! = || {
+	config = Server.default_config
+		.with_access_log(
+			Server.json_lines_access_log({
+				target: Server.path_without_query,
+				max_buffered_events: 128,
+			}),
+		)
+		.with_metrics(Server.open_metrics({ at: "/metrics" }))
+	Ok({ config, context: {} })
+}
 
 respond! : Server.Request, Context => Try(Server.Outcome, [ServerErr(Str), ..])
-respond! = |request, _context| {
-	datetime = Utc.to_iso_8601(Utc.now!())
-
-	Stdout.line!("${datetime} ${Str.inspect(request.method())} ${request.target()}")
-		? |err| ServerErr("Failed to log request: ${Str.inspect(err)}")
-
+respond! = |_request, _context| {
 	Ok(Server.respond(Response.from_status(200).with_body(Str.to_utf8("<b>Hello from server</b><br>"))))
 }
 

--- a/platform/InternalServer.roc
+++ b/platform/InternalServer.roc
@@ -71,6 +71,11 @@ InternalServer :: [].{
 		),
 		file_max_concurrent : U16,
 		file_chunk_bytes : U32,
+		access_log_enabled : Bool,
+		access_log_target : U8,
+		access_log_buffer_events : U16,
+		metrics_enabled : Bool,
+		metrics_path : Str,
 	}
 
 	ShutdownReasonFromHost : {

--- a/platform/Server.roc
+++ b/platform/Server.roc
@@ -305,6 +305,87 @@ Server :: [].{
 			cache: Override(cache),
 		})
 
+	## Privacy policy for the request target in structured access logs.
+	##
+	## Query strings are never logged. `PathWithoutQuery` records only the
+	## parsed URI path, truncated by the host to a finite byte limit.
+	LogTarget := [NoTarget, PathWithoutQuery].{
+
+		## Platform ABI conversion hook; not an application API.
+		to_host : LogTarget -> U8
+		to_host = |policy|
+			match policy {
+				NoTarget => 0
+				PathWithoutQuery => 1
+			}
+	}
+
+	## Do not include a request target in access logs.
+	no_log_target : LogTarget
+	no_log_target = NoTarget
+
+	## Include the bounded parsed path, never its query string, in access logs.
+	path_without_query : LogTarget
+	path_without_query = PathWithoutQuery
+
+	## Host-owned access logging configuration.
+	##
+	## JSON Lines are written to standard error by a dedicated host thread.
+	## Request transport never waits for that thread: terminal events enter a
+	## finite queue, and overflow is counted by the metrics exporter. Shutdown
+	## gives the queue one second to drain; a blocked standard-error sink is
+	## detached so it cannot defeat the server's finite shutdown deadlines.
+	AccessLog := [
+		AccessLogOff,
+		JsonLines({ target : LogTarget, max_buffered_events : U16 }),
+	].{
+
+		## Platform ABI conversion hook; not an application API.
+		to_host : AccessLog -> { enabled : Bool, target : U8, buffer_events : U16 }
+		to_host = |access_log|
+			match access_log {
+				AccessLogOff => { enabled: Bool.False, target: 0, buffer_events: 0 }
+				JsonLines({ target, max_buffered_events }) => {
+					enabled: Bool.True,
+					target: LogTarget.to_host(target),
+					buffer_events: max_buffered_events,
+				}
+			}
+	}
+
+	## Disable access logging. This is the default.
+	no_access_log : AccessLog
+	no_access_log = AccessLogOff
+
+	## Write bounded structured request-completion events as JSON Lines to
+	## standard error. The buffer capacity must be non-zero.
+	json_lines_access_log : { target : LogTarget, max_buffered_events : U16 } -> AccessLog
+	json_lines_access_log = |config| JsonLines(config)
+
+	## Host-owned fixed-cardinality metrics export configuration.
+	Metrics := [MetricsOff, OpenMetrics({ at : Str })].{
+
+		## Platform ABI conversion hook; not an application API.
+		to_host : Metrics -> { enabled : Bool, path : Str }
+		to_host = |metrics|
+			match metrics {
+				MetricsOff => { enabled: Bool.False, path: "" }
+				OpenMetrics({ at }) => { enabled: Bool.True, path: at }
+			}
+	}
+
+	## Disable the native metrics exporter. This is the default.
+	no_metrics : Metrics
+	no_metrics = MetricsOff
+
+	## Expose fixed-cardinality host metrics on one native exact path.
+	##
+	## The path must satisfy the same startup validation as native file routes
+	## and must not overlap one. GET and HEAD are supported; the response uses
+	## the OpenMetrics content type and `Cache-Control: no-store`.
+	open_metrics : { at : Str } -> Metrics
+	open_metrics = |config| OpenMetrics(config)
+
 	## Opaque runtime configuration returned from the application's `init!`
 	## function. Use the builders below so future server settings can be added
 	## without invalidating application record construction.
@@ -340,6 +421,10 @@ Server :: [].{
 				file_transfers : {
 					max_concurrent : U16,
 					chunk_bytes : U32,
+				},
+				operations : {
+					access_log : AccessLog,
+					metrics : Metrics,
 				},
 			},
 		),
@@ -383,22 +468,36 @@ Server :: [].{
 			),
 			file_max_concurrent : U16,
 			file_chunk_bytes : U32,
+			access_log_enabled : Bool,
+			access_log_target : U8,
+			access_log_buffer_events : U16,
+			metrics_enabled : Bool,
+			metrics_path : Str,
 		}
 		to_host = |Config(config)| {
-			host: config.listen.host,
-			port: config.listen.port,
-			body_max_bytes: config.request_bodies.max_bytes,
-			body_chunk_bytes: config.request_bodies.chunk_bytes,
-			body_buffered_chunks: config.request_bodies.buffered_chunks,
-			drain_timeout_ms: config.graceful_shutdown.drain_timeout_ms,
-			hook_timeout_ms: config.graceful_shutdown.hook_timeout_ms,
-			max_connections: config.limits.max_connections,
-			max_handlers: config.limits.max_handlers,
-			max_queued_handlers: config.limits.max_queued_handlers,
-			file_roots: config.file_roots.map(FileRoot.to_host),
-			native_routes: config.native_routes.map(NativeRoute.to_host),
-			file_max_concurrent: config.file_transfers.max_concurrent,
-			file_chunk_bytes: config.file_transfers.chunk_bytes,
+			access_log = AccessLog.to_host(config.operations.access_log)
+			metrics = Metrics.to_host(config.operations.metrics)
+			{
+				host: config.listen.host,
+				port: config.listen.port,
+				body_max_bytes: config.request_bodies.max_bytes,
+				body_chunk_bytes: config.request_bodies.chunk_bytes,
+				body_buffered_chunks: config.request_bodies.buffered_chunks,
+				drain_timeout_ms: config.graceful_shutdown.drain_timeout_ms,
+				hook_timeout_ms: config.graceful_shutdown.hook_timeout_ms,
+				max_connections: config.limits.max_connections,
+				max_handlers: config.limits.max_handlers,
+				max_queued_handlers: config.limits.max_queued_handlers,
+				file_roots: config.file_roots.map(FileRoot.to_host),
+				native_routes: config.native_routes.map(NativeRoute.to_host),
+				file_max_concurrent: config.file_transfers.max_concurrent,
+				file_chunk_bytes: config.file_transfers.chunk_bytes,
+				access_log_enabled: access_log.enabled,
+				access_log_target: access_log.target,
+				access_log_buffer_events: access_log.buffer_events,
+				metrics_enabled: metrics.enabled,
+				metrics_path: metrics.path,
+			}
 		}
 	}
 
@@ -429,6 +528,10 @@ Server :: [].{
 		file_transfers: {
 			max_concurrent: default_max_file_transfers,
 			chunk_bytes: default_file_chunk_bytes,
+		},
+		operations: {
+			access_log: AccessLogOff,
+			metrics: MetricsOff,
 		},
 	})
 
@@ -467,6 +570,16 @@ Server :: [].{
 	## owns at most one queued chunk and one active read buffer.
 	with_file_transfer_limits : Config, { max_concurrent : U16, chunk_bytes : U32 } -> Config
 	with_file_transfer_limits = |Config(config), file_transfers| Config({ ..config, file_transfers })
+
+	## Configure host-owned structured request-completion logging.
+	with_access_log : Config, AccessLog -> Config
+	with_access_log = |Config(config), access_log|
+		Config({ ..config, operations: { ..config.operations, access_log } })
+
+	## Configure the host-owned fixed-cardinality metrics exporter.
+	with_metrics : Config, Metrics -> Config
+	with_metrics = |Config(config), metrics|
+		Config({ ..config, operations: { ..config.operations, metrics } })
 
 	## A request-scoped inbound body. The host expires this capability when the
 	## request handler returns, and permits only one active reader at a time.

--- a/scripts/test_spec.json
+++ b/scripts/test_spec.json
@@ -413,10 +413,23 @@
               "method": "GET",
               "target": "/",
               "expect_body": "<b>Hello from server</b><br>"
+            },
+            {
+              "method": "GET",
+              "target": "/metrics",
+              "body_contains": [
+                "basic_webserver_http_requests_total{method=\"GET\",destination=\"roc\",completion=\"end_of_stream\"} 1",
+                "basic_webserver_http_requests_active 1",
+                "# EOF"
+              ],
+              "response_headers": {
+                "Content-Type": "application/openmetrics-text; version=1.0.0; charset=utf-8",
+                "Cache-Control": "no-store"
+              }
             }
           ],
-          "stdout_regex": [
-            "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z GET /"
+          "stderr_regex": [
+            "\\{\"timestamp_unix_ms\":[0-9]+,\"duration_us\":[0-9]+,\"request_id\":\"[0-9a-f]{32}\",\"method\":\"GET\",\"status\":200,\"destination\":\"roc\",\"completion\":\"end_of_stream\"[^\\n]+\"target_path\":\"/\"\\}"
           ]
         },
         {

--- a/src/file_server.rs
+++ b/src/file_server.rs
@@ -5,6 +5,7 @@ use crate::compression::{
     AcceptedEncodings, ContentCoding, ContentEncoder,
 };
 use crate::shutdown::ActiveRequest;
+use crate::telemetry::{ActiveGaugeGuard, Metrics};
 use bytes::Bytes;
 use cap_primitives::fs::{open, open_ambient_dir, open_dir_nofollow, FollowSymlinks, OpenOptions};
 use http_body_util::{combinators::UnsyncBoxBody, BodyExt, Empty, Full};
@@ -20,7 +21,6 @@ use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -113,6 +113,13 @@ pub(crate) struct FilePlan {
     cache: Option<CachePolicy>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum FileServeFailure {
+    Overloaded,
+    InvalidPlan,
+    StartFailed,
+}
+
 impl FilePlan {
     pub(crate) fn authorized(
         root_id: String,
@@ -152,7 +159,7 @@ pub(crate) struct FileService {
     prefix_routes: Arc<Vec<NativeRoute>>,
     transfers: Arc<Semaphore>,
     chunk_bytes: usize,
-    diagnostics: Arc<TransferDiagnostics>,
+    metrics: Arc<Metrics>,
 }
 
 impl FileService {
@@ -161,6 +168,7 @@ impl FileService {
         route_specs: Vec<NativeRouteSpec>,
         max_concurrent: usize,
         chunk_bytes: usize,
+        metrics: Arc<Metrics>,
     ) -> Result<Self, String> {
         if root_specs.len() > MAX_FILE_ROOTS {
             return Err(format!(
@@ -261,7 +269,7 @@ impl FileService {
             prefix_routes: Arc::new(prefix_routes),
             transfers: Arc::new(Semaphore::new(max_concurrent)),
             chunk_bytes,
-            diagnostics: Arc::new(TransferDiagnostics::default()),
+            metrics,
         })
     }
 
@@ -297,12 +305,15 @@ impl FileService {
         method: Method,
         headers: HeaderMap,
         active_request: Arc<ActiveRequest>,
-    ) -> ServerResponse {
+    ) -> (ServerResponse, Option<FileServeFailure>) {
         if method != Method::GET && method != Method::HEAD {
-            return simple_response(
-                StatusCode::METHOD_NOT_ALLOWED,
-                &[(ALLOW, "GET, HEAD")],
-                Bytes::from_static(b"Method Not Allowed"),
+            return (
+                simple_response(
+                    StatusCode::METHOD_NOT_ALLOWED,
+                    &[(ALLOW, "GET, HEAD")],
+                    Bytes::from_static(b"Method Not Allowed"),
+                ),
+                None,
             );
         }
         let root = match self.roots.get(&plan.root_id) {
@@ -312,24 +323,31 @@ impl FileService {
                     "Roc returned a file response for undeclared root {:?}",
                     plan.root_id
                 );
-                return simple_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    &[],
-                    Bytes::from_static(b"Internal Server Error"),
+                return (
+                    simple_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        &[],
+                        Bytes::from_static(b"Internal Server Error"),
+                    ),
+                    Some(FileServeFailure::InvalidPlan),
                 );
             }
         };
         let permit = match Arc::clone(&self.transfers).try_acquire_owned() {
             Ok(permit) => permit,
             Err(_) => {
-                return simple_response(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    &[],
-                    Bytes::from_static(b"Native file transfer capacity is exhausted"),
+                return (
+                    simple_response(
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        &[],
+                        Bytes::from_static(b"Native file transfer capacity is exhausted"),
+                    ),
+                    Some(FileServeFailure::Overloaded),
                 );
             }
         };
-        let lease = TransferLease::new(permit, active_request, Arc::clone(&self.diagnostics));
+        let lease =
+            TransferLease::new(permit, active_request, self.metrics.file_transfer_started());
         let chunk_bytes = self.chunk_bytes;
         let (prepared_sender, prepared_receiver) = oneshot::channel();
         let spawn_result = std::thread::Builder::new()
@@ -346,29 +364,35 @@ impl FileService {
                 );
             });
         if let Err(error) = spawn_result {
-            return simple_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &[],
-                Bytes::from(format!("Failed to start file transfer: {error}")),
+            return (
+                simple_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &[],
+                    Bytes::from(format!("Failed to start file transfer: {error}")),
+                ),
+                Some(FileServeFailure::StartFailed),
             );
         }
 
         match prepared_receiver.await {
-            Ok(prepared) => prepared.into_response(),
-            Err(_) => simple_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &[],
-                Bytes::from_static(b"File transfer failed before producing a response"),
+            Ok(prepared) => (prepared.into_response(), None),
+            Err(_) => (
+                simple_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &[],
+                    Bytes::from_static(b"File transfer failed before producing a response"),
+                ),
+                Some(FileServeFailure::StartFailed),
             ),
         }
     }
 
     pub(crate) fn active_transfers(&self) -> usize {
-        self.diagnostics.active.load(Ordering::Acquire)
+        self.metrics.active_file_transfers()
     }
 
     pub(crate) fn high_water_transfers(&self) -> usize {
-        self.diagnostics.high_water.load(Ordering::Acquire)
+        self.metrics.high_water_file_transfers()
     }
 }
 
@@ -388,38 +412,23 @@ impl NativeRoute {
     }
 }
 
-#[derive(Debug, Default)]
-struct TransferDiagnostics {
-    active: AtomicUsize,
-    high_water: AtomicUsize,
-}
-
 struct TransferLease {
     _permit: OwnedSemaphorePermit,
     _active_request: Arc<ActiveRequest>,
-    diagnostics: Arc<TransferDiagnostics>,
+    _metrics: ActiveGaugeGuard,
 }
 
 impl TransferLease {
     fn new(
         permit: OwnedSemaphorePermit,
         active_request: Arc<ActiveRequest>,
-        diagnostics: Arc<TransferDiagnostics>,
+        metrics: ActiveGaugeGuard,
     ) -> Arc<Self> {
-        let active = diagnostics.active.fetch_add(1, Ordering::AcqRel) + 1;
-        diagnostics.high_water.fetch_max(active, Ordering::AcqRel);
         Arc::new(Self {
             _permit: permit,
             _active_request: active_request,
-            diagnostics,
+            _metrics: metrics,
         })
-    }
-}
-
-impl Drop for TransferLease {
-    fn drop(&mut self) {
-        let previous = self.diagnostics.active.fetch_sub(1, Ordering::AcqRel);
-        debug_assert!(previous > 0, "file transfer accounting underflow");
     }
 }
 
@@ -782,7 +791,7 @@ fn validate_root_id(id: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn validate_route_path(path: &str) -> Result<(), String> {
+pub(crate) fn validate_route_path(path: &str) -> Result<(), String> {
     if !path.starts_with('/')
         || path.len() > MAX_ROUTE_PATH_BYTES
         || (path.len() > 1 && path.ends_with('/'))
@@ -1172,6 +1181,7 @@ fn parse_range(headers: &HeaderMap, length: u64) -> RangeSelection {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::telemetry::Metrics;
     use std::fs;
     use std::io::Read;
 
@@ -1209,6 +1219,7 @@ mod tests {
             ],
             2,
             1024,
+            Metrics::new(),
         )
         .unwrap();
 
@@ -1247,6 +1258,7 @@ mod tests {
             Vec::new(),
             1,
             1,
+            Metrics::new(),
         );
         assert!(duplicate_root
             .unwrap_err()
@@ -1261,6 +1273,7 @@ mod tests {
             Vec::new(),
             1,
             1,
+            Metrics::new(),
         );
         assert!(absent.unwrap_err().contains("missing, inaccessible"));
 
@@ -1288,6 +1301,7 @@ mod tests {
             ],
             1,
             1,
+            Metrics::new(),
         );
         assert!(duplicate
             .unwrap_err()
@@ -1304,6 +1318,7 @@ mod tests {
             }],
             1,
             1,
+            Metrics::new(),
         );
         assert!(missing.unwrap_err().contains("undeclared file root"));
         fs::remove_dir(temp).unwrap();
@@ -1434,6 +1449,7 @@ mod tests {
             Vec::new(),
             1,
             1024,
+            Metrics::new(),
         )
         .unwrap();
         let tracker = RequestTracker::new();
@@ -1446,7 +1462,7 @@ mod tests {
             )
         };
 
-        let first = service
+        let (first, first_failure) = service
             .serve(
                 plan(),
                 Method::GET,
@@ -1454,10 +1470,11 @@ mod tests {
                 Arc::new(tracker.begin().unwrap()),
             )
             .await;
+        assert_eq!(first_failure, None);
         assert_eq!(first.status(), StatusCode::OK);
         assert_eq!(service.active_transfers(), 1);
 
-        let saturated = service
+        let (saturated, saturated_failure) = service
             .serve(
                 plan(),
                 Method::GET,
@@ -1465,6 +1482,7 @@ mod tests {
                 Arc::new(tracker.begin().unwrap()),
             )
             .await;
+        assert_eq!(saturated_failure, Some(FileServeFailure::Overloaded));
         assert_eq!(saturated.status(), StatusCode::SERVICE_UNAVAILABLE);
         drop(saturated);
         drop(first);
@@ -1497,6 +1515,7 @@ mod tests {
             Vec::new(),
             1,
             1024,
+            Metrics::new(),
         )
         .unwrap();
         let tracker = RequestTracker::new();
@@ -1513,7 +1532,7 @@ mod tests {
             hyper::header::ACCEPT_ENCODING,
             "gzip, br, zstd".parse().unwrap(),
         );
-        let compressed = service
+        let (compressed, compressed_failure) = service
             .serve(
                 plan(),
                 Method::GET,
@@ -1521,6 +1540,7 @@ mod tests {
                 Arc::new(tracker.begin().unwrap()),
             )
             .await;
+        assert_eq!(compressed_failure, None);
         assert_eq!(compressed.status(), StatusCode::OK);
         assert_eq!(compressed.headers()[CONTENT_ENCODING], "zstd");
         assert_eq!(compressed.headers()[hyper::header::VARY], "Accept-Encoding");
@@ -1538,7 +1558,7 @@ mod tests {
         let mut conditional_headers = HeaderMap::new();
         conditional_headers.insert(hyper::header::ACCEPT_ENCODING, "zstd".parse().unwrap());
         conditional_headers.insert(IF_NONE_MATCH, compressed_etag);
-        let not_modified = service
+        let (not_modified, not_modified_failure) = service
             .serve(
                 plan(),
                 Method::GET,
@@ -1546,6 +1566,7 @@ mod tests {
                 Arc::new(tracker.begin().unwrap()),
             )
             .await;
+        assert_eq!(not_modified_failure, None);
         assert_eq!(not_modified.status(), StatusCode::NOT_MODIFIED);
         assert_eq!(not_modified.headers()[CONTENT_ENCODING], "zstd");
         assert_eq!(
@@ -1566,7 +1587,7 @@ mod tests {
             "gzip, br, zstd".parse().unwrap(),
         );
         range_headers.insert(RANGE, "bytes=0-10".parse().unwrap());
-        let ranged = service
+        let (ranged, ranged_failure) = service
             .serve(
                 plan(),
                 Method::GET,
@@ -1574,6 +1595,7 @@ mod tests {
                 Arc::new(tracker.begin().unwrap()),
             )
             .await;
+        assert_eq!(ranged_failure, None);
         assert_eq!(ranged.status(), StatusCode::PARTIAL_CONTENT);
         assert!(!ranged.headers().contains_key(CONTENT_ENCODING));
         assert_eq!(ranged.headers()[CONTENT_LENGTH], "11");

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -9,15 +9,19 @@ use crate::compression::{
     AcceptedEncodings, MAX_BUFFERED_COMPRESSION_BYTES,
 };
 use crate::file_server::{
-    full_body, CachePolicy, Disposition, FilePlan, FileRootSpec, FileService, NativeRouteKind,
-    NativeRouteSpec, ServerResponse,
+    full_body, validate_route_path, CachePolicy, Disposition, FilePlan, FileRootSpec,
+    FileServeFailure, FileService, NativeRouteKind, NativeRouteSpec, ServerResponse,
 };
 use crate::request_body::{register as register_body, PumpError};
 use crate::request_parts::{request_target, RequestPartsBacking};
 use crate::roc_platform_abi::*;
 use crate::shutdown::{RequestTracker, ShutdownController, ShutdownReason};
+use crate::telemetry::{
+    AccessLogConfig, ActiveGaugeGuard, Destination, LogTarget, Metrics, RejectionReason, Telemetry,
+    TelemetryConfig, TelemetryHandle,
+};
 use bytes::Bytes;
-use futures::{Future, FutureExt, StreamExt};
+use futures::{FutureExt, StreamExt};
 use http_body_util::BodyExt;
 #[cfg(test)]
 use http_body_util::Full;
@@ -29,7 +33,7 @@ use std::net::SocketAddr;
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::{spawn_blocking, JoinSet};
 
@@ -46,6 +50,8 @@ struct RuntimeConfig {
     drain_timeout: Duration,
     hook_timeout: Duration,
     files: FileService,
+    telemetry: TelemetryConfig,
+    metrics: Arc<Metrics>,
 }
 
 impl RuntimeConfig {
@@ -74,12 +80,46 @@ impl RuntimeConfig {
                 .iter()
                 .map(native_route_from_roc)
                 .collect::<Result<Vec<_>, _>>()?;
+            let metrics = Metrics::new();
             let files = FileService::activate(
                 roots,
                 routes,
                 config.file_max_concurrent as usize,
                 config.file_chunk_bytes as usize,
+                Arc::clone(&metrics),
             )?;
+            let access_log = if config.access_log_enabled {
+                let target = match config.access_log_target {
+                    0 => LogTarget::None,
+                    1 => LogTarget::PathWithoutQuery,
+                    _ => return Err("invalid access log target policy".to_owned()),
+                };
+                if config.access_log_buffer_events == 0 {
+                    return Err("access log buffer capacity must be non-zero".to_owned());
+                }
+                Some(AccessLogConfig {
+                    target,
+                    buffer_events: config.access_log_buffer_events as usize,
+                })
+            } else if config.access_log_target == 0 && config.access_log_buffer_events == 0 {
+                None
+            } else {
+                return Err("malformed disabled access log configuration".to_owned());
+            };
+            let metrics_path = if config.metrics_enabled {
+                let path = config.metrics_path.as_str().to_owned();
+                validate_route_path(&path)?;
+                if files.route(&path).is_some() {
+                    return Err(format!(
+                        "OpenMetrics route {path:?} conflicts with a native file route"
+                    ));
+                }
+                Some(path)
+            } else if config.metrics_path.is_empty() {
+                None
+            } else {
+                return Err("malformed disabled metrics configuration".to_owned());
+            };
             Ok(Self {
                 host: config.host.as_str().to_owned(),
                 port: config.port,
@@ -92,6 +132,11 @@ impl RuntimeConfig {
                 drain_timeout: Duration::from_millis(config.drain_timeout_ms),
                 hook_timeout: Duration::from_millis(config.hook_timeout_ms),
                 files,
+                telemetry: TelemetryConfig {
+                    access_log,
+                    metrics_path,
+                },
+                metrics,
             })
         })();
         // SAFETY: every Roc-owned field in the ABI config is borrowed only
@@ -212,33 +257,60 @@ fn validate_concurrency_limits(
 struct HandlerAdmission {
     active: Arc<Semaphore>,
     queued: Arc<Semaphore>,
+    metrics: Arc<Metrics>,
 }
 
 impl HandlerAdmission {
-    fn new(max_handlers: usize, max_queued_handlers: usize) -> Self {
+    fn new(max_handlers: usize, max_queued_handlers: usize, metrics: Arc<Metrics>) -> Self {
         Self {
             active: Arc::new(Semaphore::new(max_handlers)),
             queued: Arc::new(Semaphore::new(max_queued_handlers)),
+            metrics,
         }
     }
 
-    async fn admit(&self) -> Option<ActiveHandler> {
+    async fn admit(&self) -> Option<AdmittedHandler> {
         if let Ok(active) = Arc::clone(&self.active).try_acquire_owned() {
-            return Some(ActiveHandler { _permit: active });
+            let queue_wait = Duration::ZERO;
+            self.metrics.record_handler_queue_wait(queue_wait);
+            return Some(AdmittedHandler {
+                active: ActiveHandler {
+                    _permit: active,
+                    _metrics: self.metrics.handler_started(),
+                },
+                queue_wait,
+            });
         }
 
         let queued = Arc::clone(&self.queued).try_acquire_owned().ok()?;
+        let queued_metrics = self.metrics.handler_queued();
+        let queued_at = Instant::now();
         let active = Arc::clone(&self.active)
             .acquire_owned()
             .await
             .expect("handler admission semaphore is never closed");
         drop(queued);
-        Some(ActiveHandler { _permit: active })
+        drop(queued_metrics);
+        let queue_wait = queued_at.elapsed();
+        self.metrics.record_handler_queue_wait(queue_wait);
+        Some(AdmittedHandler {
+            active: ActiveHandler {
+                _permit: active,
+                _metrics: self.metrics.handler_started(),
+            },
+            queue_wait,
+        })
     }
+}
+
+struct AdmittedHandler {
+    active: ActiveHandler,
+    queue_wait: Duration,
 }
 
 struct ActiveHandler {
     _permit: OwnedSemaphorePermit,
+    _metrics: ActiveGaugeGuard,
 }
 
 /// The one Roc-owned application context retained for the server lifetime.
@@ -279,6 +351,7 @@ struct ServerContext {
     handlers: HandlerAdmission,
     requests: RequestTracker,
     shutdown: ShutdownController,
+    telemetry: TelemetryHandle,
 }
 
 pub fn start() -> i32 {
@@ -307,14 +380,30 @@ fn start_inner() -> i32 {
         }
     };
 
+    let telemetry = match Telemetry::activate(config.telemetry.clone(), Arc::clone(&config.metrics))
+    {
+        Ok(telemetry) => telemetry,
+        Err(detail) => {
+            return finish_shutdown(
+                ShutdownReason::StartupFailed(detail),
+                raw_context,
+                config.hook_timeout,
+            );
+        }
+    };
     let roc_context = Arc::new(RocContext::new(raw_context));
     let shutdown = ShutdownController::new();
     let context = ServerContext {
         config: Arc::new(config.clone()),
         roc_context: Arc::clone(&roc_context),
-        handlers: HandlerAdmission::new(config.max_handlers, config.max_queued_handlers),
+        handlers: HandlerAdmission::new(
+            config.max_handlers,
+            config.max_queued_handlers,
+            Arc::clone(&config.metrics),
+        ),
         requests: RequestTracker::new(),
         shutdown: shutdown.clone(),
+        telemetry: telemetry.handle(),
     };
 
     let reason = match tokio::runtime::Builder::new_multi_thread()
@@ -327,6 +416,7 @@ fn start_inner() -> i32 {
             ShutdownReason::RuntimeFailed(format!("failed to initialize Tokio runtime: {error}"))
         }
     };
+    telemetry.shutdown();
 
     debug_assert_eq!(
         Arc::strong_count(&roc_context),
@@ -522,9 +612,11 @@ fn call_roc(
     request: ServerRequest,
     context: RocBox,
     accepted_encodings: AcceptedEncodings,
-) -> RocOutcome {
+) -> (RocOutcome, Duration) {
+    let started = Instant::now();
     let response = unsafe { roc_respond_for_host(request, context) };
-    outcome_from_roc(response, accepted_encodings)
+    let roc_duration = started.elapsed();
+    (outcome_from_roc(response, accepted_encodings), roc_duration)
 }
 
 enum RocOutcome {
@@ -698,35 +790,57 @@ fn payload_too_large(limit: u64) -> ServerResponse {
 async fn handle_req(
     request: hyper::Request<hyper::body::Incoming>,
     context: ServerContext,
+    telemetry: crate::telemetry::RequestTelemetry,
 ) -> ServerResponse {
     let active_request = match context.requests.begin() {
         Some(active) => Arc::new(active),
-        None => return service_unavailable(),
+        None => {
+            telemetry.reject(RejectionReason::Shutdown);
+            return service_unavailable();
+        }
     };
 
-    if let Some(plan) = context.config.files.route(request.uri().path()) {
+    if context.telemetry.is_metrics_path(request.uri().path()) {
+        telemetry.set_destination(Destination::NativeMetrics);
         let (parts, body) = request.into_parts();
         drop(body);
-        return context
+        return context.telemetry.metrics_response(&parts.method);
+    }
+
+    if let Some(plan) = context.config.files.route(request.uri().path()) {
+        telemetry.set_destination(Destination::NativeFile);
+        let (parts, body) = request.into_parts();
+        drop(body);
+        let (response, failure) = context
             .config
             .files
             .serve(plan, parts.method, parts.headers, active_request)
             .await;
+        record_file_failure(&telemetry, failure);
+        return response;
     }
 
     if !request_headers_are_utf8(request.headers()) {
+        telemetry.reject(RejectionReason::InvalidHeaders);
         return invalid_request_headers();
     }
 
     let declared_length = content_length(request.headers());
     if declared_length.is_some_and(|length| length > context.config.body_max_bytes) {
+        telemetry.reject(RejectionReason::BodyTooLarge);
         return payload_too_large(context.config.body_max_bytes);
     }
 
-    let active_handler = match context.handlers.admit().await {
-        Some(active) => active,
-        None => return overloaded(),
+    let admitted = match context.handlers.admit().await {
+        Some(admitted) => admitted,
+        None => {
+            telemetry.reject(RejectionReason::HandlerOverload);
+            return overloaded();
+        }
     };
+    telemetry.set_destination(Destination::Roc);
+    let active_handler = admitted.active;
+    let handler_queue_wait = admitted.queue_wait;
 
     let (parts, body) = request.into_parts();
     let file_method = parts.method.clone();
@@ -748,6 +862,8 @@ async fn handle_req(
     let body_handle = registration.handle;
     let roc_context = Arc::clone(&context.roc_context);
     let handler_request = Arc::clone(&active_request);
+    let handler_metrics = context.telemetry.metrics();
+    let handler_telemetry = telemetry.clone();
     let handled = spawn_blocking(move || {
         // These guards intentionally live in the non-cancellable blocking task.
         // Aborting its Tokio JoinHandle must not make shutdown believe Roc has
@@ -762,7 +878,9 @@ async fn handle_req(
             declared_length,
         );
         let request_context = roc_context.retain_for_request();
-        let result = call_roc(roc_request, request_context, accepted_encodings);
+        let (result, handler_duration) = call_roc(roc_request, request_context, accepted_encodings);
+        handler_metrics.record_handler_duration(handler_duration);
+        handler_telemetry.record_handler(handler_queue_wait, handler_duration);
         body_handle.expire();
         result
     })
@@ -777,30 +895,65 @@ async fn handle_req(
         }
         Ok(RocOutcome::Ordinary(response, None)) => response,
         Ok(RocOutcome::File(plan)) => {
-            context
+            telemetry.set_destination(Destination::NativeFile);
+            let (response, failure) = context
                 .config
                 .files
                 .serve(plan, file_method, file_headers, active_request)
-                .await
+                .await;
+            record_file_failure(&telemetry, failure);
+            response
         }
         Ok(RocOutcome::Invalid(detail)) => {
+            telemetry.reject(RejectionReason::InvalidRocResponse);
             eprintln!("Invalid Roc response plan: {detail}");
             internal_server_error("500 Internal Server Error")
         }
         Err(error) => {
+            telemetry.reject(if error.is_panic() {
+                RejectionReason::RocPanic
+            } else {
+                RejectionReason::HostPanic
+            });
             eprintln!("Recovered from calling Roc: {error:?}");
             internal_server_error("500 Internal Server Error")
         }
     }
 }
 
-async fn handle_panics(
-    future: impl Future<Output = ServerResponse>,
-) -> Result<ServerResponse, Infallible> {
-    match AssertUnwindSafe(future).catch_unwind().await {
-        Ok(response) => Ok(response),
-        Err(_) => Ok(internal_server_error("Panic detected")),
+fn record_file_failure(
+    telemetry: &crate::telemetry::RequestTelemetry,
+    failure: Option<FileServeFailure>,
+) {
+    match failure {
+        Some(FileServeFailure::Overloaded) => {
+            telemetry.reject_for_destination(Destination::NativeFile, RejectionReason::FileOverload)
+        }
+        Some(FileServeFailure::InvalidPlan) => telemetry
+            .reject_for_destination(Destination::NativeFile, RejectionReason::InvalidRocResponse),
+        Some(FileServeFailure::StartFailed) => {
+            telemetry.reject_for_destination(Destination::NativeFile, RejectionReason::FileFailure)
+        }
+        None => {}
     }
+}
+
+async fn serve_request(
+    request: hyper::Request<hyper::body::Incoming>,
+    context: ServerContext,
+) -> Result<ServerResponse, Infallible> {
+    let telemetry = context
+        .telemetry
+        .start_request(request.method(), request.uri().path());
+    let future = handle_req(request, context, telemetry.clone());
+    let response = match AssertUnwindSafe(future).catch_unwind().await {
+        Ok(response) => response,
+        Err(_) => {
+            telemetry.reject(RejectionReason::HostPanic);
+            internal_server_error("Panic detected")
+        }
+    };
+    Ok(telemetry.instrument(response))
 }
 
 fn connection_builder(max_http2_streams: u32) -> auto::Builder<TokioExecutor> {
@@ -810,14 +963,13 @@ fn connection_builder(max_http2_streams: u32) -> auto::Builder<TokioExecutor> {
 }
 
 async fn serve_connection(stream: tokio::net::TcpStream, context: ServerContext) {
+    let _connection_metrics = context.telemetry.connection_started();
     let io = TokioIo::new(stream);
     let service_context = context.clone();
     let builder = connection_builder(context.config.max_http2_streams_per_connection());
     let connection = builder.serve_connection(
         io,
-        hyper::service::service_fn(move |request| {
-            handle_panics(handle_req(request, service_context.clone()))
-        }),
+        hyper::service::service_fn(move |request| serve_request(request, service_context.clone())),
     );
     tokio::pin!(connection);
 
@@ -1291,7 +1443,7 @@ mod tests {
 
     #[tokio::test]
     async fn handler_admission_bounds_active_and_queued_work() {
-        let admission = HandlerAdmission::new(1, 1);
+        let admission = HandlerAdmission::new(1, 1, Metrics::new());
         let first = admission.admit().await.unwrap();
 
         let waiting = {
@@ -1325,7 +1477,7 @@ mod tests {
 
     #[tokio::test]
     async fn zero_handler_queue_rejects_immediately_at_saturation() {
-        let admission = HandlerAdmission::new(1, 0);
+        let admission = HandlerAdmission::new(1, 0, Metrics::new());
         let active = admission.admit().await.unwrap();
         assert!(admission.admit().await.is_none());
         drop(active);
@@ -1348,6 +1500,7 @@ mod tests {
 
     #[test]
     fn http2_stream_limit_matches_the_complete_handler_budget() {
+        let metrics = Metrics::new();
         let config = RuntimeConfig {
             host: "127.0.0.1".to_owned(),
             port: 8000,
@@ -1359,7 +1512,13 @@ mod tests {
             body_buffered_chunks: 1,
             drain_timeout: Duration::from_secs(30),
             hook_timeout: Duration::from_secs(10),
-            files: FileService::activate(Vec::new(), Vec::new(), 1, 1024).unwrap(),
+            files: FileService::activate(Vec::new(), Vec::new(), 1, 1024, Arc::clone(&metrics))
+                .unwrap(),
+            telemetry: TelemetryConfig {
+                access_log: None,
+                metrics_path: None,
+            },
+            metrics,
         };
         assert_eq!(config.max_http2_streams_per_connection(), 96);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ mod shutdown;
 mod sqlite;
 mod stdio;
 mod tcp;
+mod telemetry;
 mod time;
 
 #[cfg(not(test))]

--- a/src/roc_platform_abi.rs
+++ b/src/roc_platform_abi.rs
@@ -1320,83 +1320,93 @@ const _: () = assert!(core::mem::size_of::<AnonStruct1f12a65955b54fe1>() == 12, 
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(core::mem::align_of::<AnonStruct1f12a65955b54fe1>() == 4, "AnonStruct1f12a65955b54fe1 alignment mismatch");
 
-/// Element type for __AnonStruct_9d4feaaa75529fdc
+/// Element type for __AnonStruct_162a5dfbeef84fe5
 #[cfg(target_pointer_width = "32")]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStruct9d4feaaa75529fdc {
-    pub config: AnonStructAeeb7f2cfe80f10,
+pub struct AnonStruct162a5dfbeef84fe5 {
+    pub config: AnonStruct6342046c74b98169,
     pub context: RocBox,
 }
 
-/// Element type for __AnonStruct_9d4feaaa75529fdc
+/// Element type for __AnonStruct_162a5dfbeef84fe5
 #[cfg(not(target_pointer_width = "32"))]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStruct9d4feaaa75529fdc {
-    pub config: AnonStructAeeb7f2cfe80f10,
+pub struct AnonStruct162a5dfbeef84fe5 {
+    pub config: AnonStruct6342046c74b98169,
     pub context: RocBox,
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<AnonStruct9d4feaaa75529fdc>() == 128, "AnonStruct9d4feaaa75529fdc size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStruct162a5dfbeef84fe5>() == 160, "AnonStruct162a5dfbeef84fe5 size mismatch");
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::align_of::<AnonStruct9d4feaaa75529fdc>() == 8, "AnonStruct9d4feaaa75529fdc alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStruct162a5dfbeef84fe5>() == 8, "AnonStruct162a5dfbeef84fe5 alignment mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::size_of::<AnonStruct9d4feaaa75529fdc>() == 96, "AnonStruct9d4feaaa75529fdc size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStruct162a5dfbeef84fe5>() == 112, "AnonStruct162a5dfbeef84fe5 size mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::align_of::<AnonStruct9d4feaaa75529fdc>() == 8, "AnonStruct9d4feaaa75529fdc alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStruct162a5dfbeef84fe5>() == 8, "AnonStruct162a5dfbeef84fe5 alignment mismatch");
 
-/// Element type for __AnonStruct_aeeb7f2cfe80f10
+/// Element type for __AnonStruct_6342046c74b98169
 #[cfg(target_pointer_width = "32")]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStructAeeb7f2cfe80f10 {
+pub struct AnonStruct6342046c74b98169 {
     pub body_max_bytes: u64,
     pub drain_timeout_ms: u64,
     pub hook_timeout_ms: u64,
     pub file_roots: RocList<AnonStruct3b01e35488cb00dc>,
     pub host: RocStr,
+    pub metrics_path: RocStr,
     pub native_routes: RocList<AnonStructFf6f93028827ced0>,
     pub body_chunk_bytes: u32,
     pub file_chunk_bytes: u32,
     pub max_connections: u32,
+    pub access_log_buffer_events: u16,
     pub body_buffered_chunks: u16,
     pub file_max_concurrent: u16,
     pub max_handlers: u16,
     pub max_queued_handlers: u16,
     pub port: u16,
+    pub access_log_enabled: bool,
+    pub access_log_target: u8,
+    pub metrics_enabled: bool,
 }
 
-/// Element type for __AnonStruct_aeeb7f2cfe80f10
+/// Element type for __AnonStruct_6342046c74b98169
 #[cfg(not(target_pointer_width = "32"))]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStructAeeb7f2cfe80f10 {
+pub struct AnonStruct6342046c74b98169 {
     pub body_max_bytes: u64,
     pub drain_timeout_ms: u64,
     pub hook_timeout_ms: u64,
     pub file_roots: RocList<AnonStruct3b01e35488cb00dc>,
     pub host: RocStr,
+    pub metrics_path: RocStr,
     pub native_routes: RocList<AnonStructFf6f93028827ced0>,
     pub body_chunk_bytes: u32,
     pub file_chunk_bytes: u32,
     pub max_connections: u32,
+    pub access_log_buffer_events: u16,
     pub body_buffered_chunks: u16,
     pub file_max_concurrent: u16,
     pub max_handlers: u16,
     pub max_queued_handlers: u16,
     pub port: u16,
+    pub access_log_enabled: bool,
+    pub access_log_target: u8,
+    pub metrics_enabled: bool,
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<AnonStructAeeb7f2cfe80f10>() == 120, "AnonStructAeeb7f2cfe80f10 size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStruct6342046c74b98169>() == 152, "AnonStruct6342046c74b98169 size mismatch");
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::align_of::<AnonStructAeeb7f2cfe80f10>() == 8, "AnonStructAeeb7f2cfe80f10 alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStruct6342046c74b98169>() == 8, "AnonStruct6342046c74b98169 alignment mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::size_of::<AnonStructAeeb7f2cfe80f10>() == 88, "AnonStructAeeb7f2cfe80f10 size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStruct6342046c74b98169>() == 104, "AnonStruct6342046c74b98169 size mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::align_of::<AnonStructAeeb7f2cfe80f10>() == 8, "AnonStructAeeb7f2cfe80f10 alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStruct6342046c74b98169>() == 8, "AnonStruct6342046c74b98169 alignment mismatch");
 
 /// Element type for __AnonStruct_3b01e35488cb00dc
 #[cfg(target_pointer_width = "32")]
@@ -4912,7 +4922,7 @@ pub enum InitForHostResultTag {
 #[derive(Clone, Copy)]
 pub union InitForHostResultPayload {
     pub err: core::mem::ManuallyDrop<i64>,
-    pub ok: core::mem::ManuallyDrop<AnonStruct9d4feaaa75529fdc>,
+    pub ok: core::mem::ManuallyDrop<AnonStruct162a5dfbeef84fe5>,
 }
 
 #[cfg(target_pointer_width = "32")]
@@ -4926,7 +4936,7 @@ pub struct InitForHostResultPayloadAlignment;
 #[derive(Clone, Copy)]
 pub struct InitForHostResult {
     pub _payload_alignment: [InitForHostResultPayloadAlignment; 0],
-    pub payload: [u8; 96],
+    pub payload: [u8; 112],
     pub tag: InitForHostResultTag,
 }
 
@@ -4951,29 +4961,29 @@ impl InitForHostResult {
     }
 
     #[cfg(target_pointer_width = "32")]
-    pub fn payload_ok(&self) -> AnonStruct9d4feaaa75529fdc {
-        unsafe { core::ptr::read(self.payload.as_ptr() as *const AnonStruct9d4feaaa75529fdc) }
+    pub fn payload_ok(&self) -> AnonStruct162a5dfbeef84fe5 {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const AnonStruct162a5dfbeef84fe5) }
     }
 
     #[cfg(not(target_pointer_width = "32"))]
-    pub fn payload_ok(&self) -> AnonStruct9d4feaaa75529fdc {
+    pub fn payload_ok(&self) -> AnonStruct162a5dfbeef84fe5 {
         unsafe { core::mem::ManuallyDrop::into_inner(self.payload.ok) }
     }
 
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<InitForHostResult>() == 136, "InitForHostResult size mismatch");
+const _: () = assert!(core::mem::size_of::<InitForHostResult>() == 168, "InitForHostResult size mismatch");
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(core::mem::align_of::<InitForHostResult>() == 8, "InitForHostResult alignment mismatch");
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::offset_of!(InitForHostResult, tag) == 128, "InitForHostResult tag offset mismatch");
+const _: () = assert!(core::mem::offset_of!(InitForHostResult, tag) == 160, "InitForHostResult tag offset mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::size_of::<InitForHostResult>() == 104, "InitForHostResult size mismatch");
+const _: () = assert!(core::mem::size_of::<InitForHostResult>() == 120, "InitForHostResult size mismatch");
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(core::mem::align_of::<InitForHostResult>() == 8, "InitForHostResult alignment mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::offset_of!(InitForHostResult, tag) == 96, "InitForHostResult tag offset mismatch");
+const _: () = assert!(core::mem::offset_of!(InitForHostResult, tag) == 112, "InitForHostResult tag offset mismatch");
 
 /// Tag discriminant for Try.
 #[repr(u8)]
@@ -6225,8 +6235,8 @@ pub type HostTcpReadUntilResultTag = HostTcpReadExactlyResultTag;
 pub type HostTcpReadUpToResult = HostTcpReadExactlyResult;
 pub type HostTcpReadUpToResultPayload = HostTcpReadExactlyResultPayload;
 pub type HostTcpReadUpToResultTag = HostTcpReadExactlyResultTag;
-pub type InitForHostOk = AnonStruct9d4feaaa75529fdc;
-pub type InitForHostOkConfig = AnonStructAeeb7f2cfe80f10;
+pub type InitForHostOk = AnonStruct162a5dfbeef84fe5;
+pub type InitForHostOkConfig = AnonStruct6342046c74b98169;
 pub type InitForHostOkConfigFileRoots = AnonStruct3b01e35488cb00dc;
 pub type InitForHostOkConfigNativeRoutes = AnonStructFf6f93028827ced0;
 pub type RespondForHostArg0 = AnonStruct9bfbda88f35e6056;
@@ -8546,7 +8556,7 @@ impl InitForHostResult {
     }
 }
 
-impl AnonStruct9d4feaaa75529fdc {
+impl AnonStruct162a5dfbeef84fe5 {
     /// Recursively decrement Roc-owned fields.
     ///
     /// # Safety
@@ -8569,7 +8579,7 @@ impl AnonStruct9d4feaaa75529fdc {
     }
 }
 
-impl AnonStructAeeb7f2cfe80f10 {
+impl AnonStruct6342046c74b98169 {
     /// Recursively decrement Roc-owned fields.
     ///
     /// # Safety
@@ -8587,6 +8597,7 @@ impl AnonStructAeeb7f2cfe80f10 {
             unsafe { list.decref(roc_host); }
         }
         unsafe { value.host.decref(roc_host); }
+        unsafe { value.metrics_path.decref(roc_host); }
         {
             let list = value.native_routes;
             if list.has_one_ref() {
@@ -8608,6 +8619,7 @@ impl AnonStructAeeb7f2cfe80f10 {
         let value = self;
         unsafe { value.file_roots.incref(amount); }
         unsafe { value.host.incref(amount); }
+        unsafe { value.metrics_path.incref(amount); }
         unsafe { value.native_routes.incref(amount); }
     }
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,1354 @@
+//! Bounded host-owned request completion telemetry and operational metrics.
+//!
+//! A request remains active until its response body reaches end-of-stream,
+//! fails, or is dropped. The body wrapper below is the single terminal-event
+//! boundary for Roc responses, native responses, and host rejections.
+
+use crate::file_server::{full_body, ServerBody, ServerResponse};
+use bytes::Bytes;
+use http_body_util::BodyExt;
+use hyper::body::{Body, Frame, SizeHint};
+use hyper::header::{HeaderValue, CACHE_CONTROL, CONTENT_LENGTH, CONTENT_TYPE};
+use hyper::{Method, StatusCode};
+use serde::Serialize;
+use std::fmt::Write as _;
+use std::io::{self, BufWriter, Write as _};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::task::{Context, Poll};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const MAX_LOGGED_PATH_BYTES: usize = 2 * 1024;
+const ACCESS_LOG_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
+const OPENMETRICS_CONTENT_TYPE: &str = "application/openmetrics-text; version=1.0.0; charset=utf-8";
+const DURATION_BUCKETS_SECONDS: [f64; 14] = [
+    0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+];
+const DURATION_BUCKETS_MICROS: [u64; 14] = [
+    5_000, 10_000, 25_000, 50_000, 75_000, 100_000, 250_000, 500_000, 750_000, 1_000_000,
+    2_500_000, 5_000_000, 7_500_000, 10_000_000,
+];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LogTarget {
+    None,
+    PathWithoutQuery,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TelemetryConfig {
+    pub(crate) access_log: Option<AccessLogConfig>,
+    pub(crate) metrics_path: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AccessLogConfig {
+    pub(crate) target: LogTarget,
+    pub(crate) buffer_events: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Destination {
+    Roc,
+    NativeFile,
+    NativeMetrics,
+    HostRejection,
+}
+
+impl Destination {
+    const COUNT: usize = 4;
+
+    fn index(self) -> usize {
+        match self {
+            Self::Roc => 0,
+            Self::NativeFile => 1,
+            Self::NativeMetrics => 2,
+            Self::HostRejection => 3,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Roc => "roc",
+            Self::NativeFile => "native_file",
+            Self::NativeMetrics => "native_metrics",
+            Self::HostRejection => "host_rejection",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RejectionReason {
+    Shutdown,
+    InvalidHeaders,
+    BodyTooLarge,
+    HandlerOverload,
+    FileOverload,
+    InvalidRocResponse,
+    RocPanic,
+    HostPanic,
+    FileFailure,
+}
+
+impl RejectionReason {
+    const COUNT: usize = 9;
+    const ALL: [Self; Self::COUNT] = [
+        Self::Shutdown,
+        Self::InvalidHeaders,
+        Self::BodyTooLarge,
+        Self::HandlerOverload,
+        Self::FileOverload,
+        Self::InvalidRocResponse,
+        Self::RocPanic,
+        Self::HostPanic,
+        Self::FileFailure,
+    ];
+
+    fn index(self) -> usize {
+        match self {
+            Self::Shutdown => 0,
+            Self::InvalidHeaders => 1,
+            Self::BodyTooLarge => 2,
+            Self::HandlerOverload => 3,
+            Self::FileOverload => 4,
+            Self::InvalidRocResponse => 5,
+            Self::RocPanic => 6,
+            Self::HostPanic => 7,
+            Self::FileFailure => 8,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Shutdown => "shutdown",
+            Self::InvalidHeaders => "invalid_headers",
+            Self::BodyTooLarge => "body_too_large",
+            Self::HandlerOverload => "handler_overload",
+            Self::FileOverload => "file_overload",
+            Self::InvalidRocResponse => "invalid_roc_response",
+            Self::RocPanic => "roc_panic",
+            Self::HostPanic => "host_panic",
+            Self::FileFailure => "file_failure",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Completion {
+    EndOfStream,
+    BodyFailure,
+    BodyDropped,
+}
+
+impl Completion {
+    const COUNT: usize = 3;
+    const ALL: [Self; Self::COUNT] = [Self::EndOfStream, Self::BodyFailure, Self::BodyDropped];
+
+    fn index(self) -> usize {
+        match self {
+            Self::EndOfStream => 0,
+            Self::BodyFailure => 1,
+            Self::BodyDropped => 2,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::EndOfStream => "end_of_stream",
+            Self::BodyFailure => "body_failure",
+            Self::BodyDropped => "body_dropped",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MethodClass {
+    Connect,
+    Delete,
+    Get,
+    Head,
+    Options,
+    Patch,
+    Post,
+    Put,
+    Trace,
+    Query,
+    Other,
+}
+
+impl MethodClass {
+    const COUNT: usize = 11;
+    const ALL: [Self; Self::COUNT] = [
+        Self::Connect,
+        Self::Delete,
+        Self::Get,
+        Self::Head,
+        Self::Options,
+        Self::Patch,
+        Self::Post,
+        Self::Put,
+        Self::Trace,
+        Self::Query,
+        Self::Other,
+    ];
+
+    fn from_method(method: &Method) -> Self {
+        match *method {
+            Method::CONNECT => Self::Connect,
+            Method::DELETE => Self::Delete,
+            Method::GET => Self::Get,
+            Method::HEAD => Self::Head,
+            Method::OPTIONS => Self::Options,
+            Method::PATCH => Self::Patch,
+            Method::POST => Self::Post,
+            Method::PUT => Self::Put,
+            Method::TRACE => Self::Trace,
+            _ if method.as_str() == "QUERY" => Self::Query,
+            _ => Self::Other,
+        }
+    }
+
+    fn index(self) -> usize {
+        match self {
+            Self::Connect => 0,
+            Self::Delete => 1,
+            Self::Get => 2,
+            Self::Head => 3,
+            Self::Options => 4,
+            Self::Patch => 5,
+            Self::Post => 6,
+            Self::Put => 7,
+            Self::Trace => 8,
+            Self::Query => 9,
+            Self::Other => 10,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Connect => "CONNECT",
+            Self::Delete => "DELETE",
+            Self::Get => "GET",
+            Self::Head => "HEAD",
+            Self::Options => "OPTIONS",
+            Self::Patch => "PATCH",
+            Self::Post => "POST",
+            Self::Put => "PUT",
+            Self::Trace => "TRACE",
+            Self::Query => "QUERY",
+            Self::Other => "_OTHER",
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct ActiveGauge {
+    current: AtomicUsize,
+    high_water: AtomicUsize,
+}
+
+impl ActiveGauge {
+    fn increment(&self) {
+        let current = self.current.fetch_add(1, Ordering::AcqRel) + 1;
+        self.high_water.fetch_max(current, Ordering::AcqRel);
+    }
+
+    fn guard(self: &Arc<Self>) -> ActiveGaugeGuard {
+        self.increment();
+        ActiveGaugeGuard {
+            gauge: Arc::clone(self),
+        }
+    }
+
+    fn decrement(&self) {
+        let previous = self.current.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "operational metric accounting underflow");
+    }
+
+    fn current(&self) -> usize {
+        self.current.load(Ordering::Acquire)
+    }
+
+    fn high_water(&self) -> usize {
+        self.high_water.load(Ordering::Acquire)
+    }
+}
+
+pub(crate) struct ActiveGaugeGuard {
+    gauge: Arc<ActiveGauge>,
+}
+
+impl Drop for ActiveGaugeGuard {
+    fn drop(&mut self) {
+        self.gauge.decrement();
+    }
+}
+
+#[derive(Debug)]
+struct Histogram {
+    buckets: [AtomicU64; DURATION_BUCKETS_MICROS.len()],
+    count: AtomicU64,
+    sum_micros: AtomicU64,
+}
+
+impl Default for Histogram {
+    fn default() -> Self {
+        Self {
+            buckets: std::array::from_fn(|_| AtomicU64::new(0)),
+            count: AtomicU64::new(0),
+            sum_micros: AtomicU64::new(0),
+        }
+    }
+}
+
+impl Histogram {
+    fn record(&self, duration: Duration) {
+        let micros = duration.as_micros().min(u64::MAX as u128) as u64;
+        self.count.fetch_add(1, Ordering::Relaxed);
+        self.sum_micros.fetch_add(micros, Ordering::Relaxed);
+        for (upper, bucket) in DURATION_BUCKETS_MICROS.iter().zip(&self.buckets) {
+            if micros <= *upper {
+                bucket.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    fn render(&self, output: &mut String, name: &str, help: &str) {
+        let _ = writeln!(output, "# HELP {name} {help}");
+        let _ = writeln!(output, "# TYPE {name} histogram");
+        for (upper, bucket) in DURATION_BUCKETS_SECONDS.iter().zip(&self.buckets) {
+            let _ = writeln!(
+                output,
+                "{name}_bucket{{le=\"{upper}\"}} {}",
+                bucket.load(Ordering::Acquire)
+            );
+        }
+        let count = self.count.load(Ordering::Acquire);
+        let _ = writeln!(output, "{name}_bucket{{le=\"+Inf\"}} {count}");
+        let sum = self.sum_micros.load(Ordering::Acquire) as f64 / 1_000_000.0;
+        let _ = writeln!(output, "{name}_sum {sum}");
+        let _ = writeln!(output, "{name}_count {count}");
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Metrics {
+    requests: Arc<ActiveGauge>,
+    connections: Arc<ActiveGauge>,
+    handlers_active: Arc<ActiveGauge>,
+    handlers_queued: Arc<ActiveGauge>,
+    file_transfers: Arc<ActiveGauge>,
+    request_totals: Box<[AtomicU64]>,
+    response_bytes: [AtomicU64; Destination::COUNT],
+    rejections: [AtomicU64; RejectionReason::COUNT],
+    request_duration: Histogram,
+    handler_queue_wait: Histogram,
+    handler_duration: Histogram,
+    access_log_dropped: AtomicU64,
+    access_log_write_failures: AtomicU64,
+}
+
+impl Metrics {
+    pub(crate) fn new() -> Arc<Self> {
+        let request_series = Destination::COUNT * MethodClass::COUNT * Completion::COUNT;
+        Arc::new(Self {
+            requests: Arc::new(ActiveGauge::default()),
+            connections: Arc::new(ActiveGauge::default()),
+            handlers_active: Arc::new(ActiveGauge::default()),
+            handlers_queued: Arc::new(ActiveGauge::default()),
+            file_transfers: Arc::new(ActiveGauge::default()),
+            request_totals: (0..request_series).map(|_| AtomicU64::new(0)).collect(),
+            response_bytes: std::array::from_fn(|_| AtomicU64::new(0)),
+            rejections: std::array::from_fn(|_| AtomicU64::new(0)),
+            request_duration: Histogram::default(),
+            handler_queue_wait: Histogram::default(),
+            handler_duration: Histogram::default(),
+            access_log_dropped: AtomicU64::new(0),
+            access_log_write_failures: AtomicU64::new(0),
+        })
+    }
+
+    pub(crate) fn connection_started(&self) -> ActiveGaugeGuard {
+        self.connections.guard()
+    }
+
+    pub(crate) fn handler_started(&self) -> ActiveGaugeGuard {
+        self.handlers_active.guard()
+    }
+
+    pub(crate) fn handler_queued(&self) -> ActiveGaugeGuard {
+        self.handlers_queued.guard()
+    }
+
+    pub(crate) fn file_transfer_started(&self) -> ActiveGaugeGuard {
+        self.file_transfers.guard()
+    }
+
+    pub(crate) fn active_file_transfers(&self) -> usize {
+        self.file_transfers.current()
+    }
+
+    pub(crate) fn high_water_file_transfers(&self) -> usize {
+        self.file_transfers.high_water()
+    }
+
+    pub(crate) fn record_handler_queue_wait(&self, duration: Duration) {
+        self.handler_queue_wait.record(duration);
+    }
+
+    pub(crate) fn record_handler_duration(&self, duration: Duration) {
+        self.handler_duration.record(duration);
+    }
+
+    fn request_started(&self) {
+        self.requests.increment();
+    }
+
+    fn request_finished(
+        &self,
+        method: MethodClass,
+        destination: Destination,
+        completion: Completion,
+        rejection: Option<RejectionReason>,
+        duration: Duration,
+        response_bytes: u64,
+    ) {
+        let index = ((destination.index() * MethodClass::COUNT + method.index())
+            * Completion::COUNT)
+            + completion.index();
+        self.request_totals[index].fetch_add(1, Ordering::Relaxed);
+        self.response_bytes[destination.index()].fetch_add(response_bytes, Ordering::Relaxed);
+        if let Some(rejection) = rejection {
+            self.rejections[rejection.index()].fetch_add(1, Ordering::Relaxed);
+        }
+        self.request_duration.record(duration);
+        self.requests.decrement();
+    }
+
+    fn render_openmetrics(&self) -> String {
+        // The number of series and labels is compile-time fixed. Reserving a
+        // conservative bound avoids repeated growth while rendering.
+        let mut output = String::with_capacity(24 * 1024);
+        render_gauge(
+            &mut output,
+            "basic_webserver_http_requests_active",
+            "HTTP requests whose response bodies have not reached a terminal state.",
+            &self.requests,
+        );
+        render_gauge(
+            &mut output,
+            "basic_webserver_connections_active",
+            "Accepted HTTP connections currently owned by the server.",
+            &self.connections,
+        );
+        render_gauge(
+            &mut output,
+            "basic_webserver_roc_handlers_active",
+            "Roc handlers currently executing.",
+            &self.handlers_active,
+        );
+        render_gauge(
+            &mut output,
+            "basic_webserver_roc_handlers_queued",
+            "Requests waiting for Roc handler admission.",
+            &self.handlers_queued,
+        );
+        render_gauge(
+            &mut output,
+            "basic_webserver_native_file_transfers_active",
+            "Host-managed file transfers currently active.",
+            &self.file_transfers,
+        );
+
+        output.push_str(
+            "# HELP basic_webserver_http_requests_total Terminal HTTP response body outcomes.\n\
+             # TYPE basic_webserver_http_requests_total counter\n",
+        );
+        for destination in [
+            Destination::Roc,
+            Destination::NativeFile,
+            Destination::NativeMetrics,
+            Destination::HostRejection,
+        ] {
+            for method in MethodClass::ALL {
+                for completion in Completion::ALL {
+                    let index = ((destination.index() * MethodClass::COUNT + method.index())
+                        * Completion::COUNT)
+                        + completion.index();
+                    let _ = writeln!(
+                        output,
+                        "basic_webserver_http_requests_total{{method=\"{}\",destination=\"{}\",completion=\"{}\"}} {}",
+                        method.label(),
+                        destination.label(),
+                        completion.label(),
+                        self.request_totals[index].load(Ordering::Acquire)
+                    );
+                }
+            }
+        }
+
+        output.push_str(
+            "# HELP basic_webserver_http_response_body_bytes_total Response representation bytes produced by body streams.\n\
+             # TYPE basic_webserver_http_response_body_bytes_total counter\n",
+        );
+        for destination in [
+            Destination::Roc,
+            Destination::NativeFile,
+            Destination::NativeMetrics,
+            Destination::HostRejection,
+        ] {
+            let _ = writeln!(
+                output,
+                "basic_webserver_http_response_body_bytes_total{{destination=\"{}\"}} {}",
+                destination.label(),
+                self.response_bytes[destination.index()].load(Ordering::Acquire)
+            );
+        }
+
+        output.push_str(
+            "# HELP basic_webserver_rejections_total Requests rejected by a finite host reason.\n\
+             # TYPE basic_webserver_rejections_total counter\n",
+        );
+        for reason in RejectionReason::ALL {
+            let _ = writeln!(
+                output,
+                "basic_webserver_rejections_total{{reason=\"{}\"}} {}",
+                reason.label(),
+                self.rejections[reason.index()].load(Ordering::Acquire)
+            );
+        }
+
+        self.request_duration.render(
+            &mut output,
+            "basic_webserver_http_request_duration_seconds",
+            "Time from HTTP request construction to response body terminal state.",
+        );
+        self.handler_queue_wait.render(
+            &mut output,
+            "basic_webserver_roc_handler_queue_wait_seconds",
+            "Time a request waited for Roc handler admission.",
+        );
+        self.handler_duration.render(
+            &mut output,
+            "basic_webserver_roc_handler_duration_seconds",
+            "Time spent synchronously executing a Roc request handler.",
+        );
+
+        output.push_str(
+            "# HELP basic_webserver_access_log_dropped_total Access log events dropped because the finite queue was full.\n\
+             # TYPE basic_webserver_access_log_dropped_total counter\n",
+        );
+        let _ = writeln!(
+            output,
+            "basic_webserver_access_log_dropped_total {}",
+            self.access_log_dropped.load(Ordering::Acquire)
+        );
+        output.push_str(
+            "# HELP basic_webserver_access_log_write_failures_total Access log events lost after the log sink failed.\n\
+             # TYPE basic_webserver_access_log_write_failures_total counter\n",
+        );
+        let _ = writeln!(
+            output,
+            "basic_webserver_access_log_write_failures_total {}",
+            self.access_log_write_failures.load(Ordering::Acquire)
+        );
+        output.push_str("# EOF\n");
+        output
+    }
+}
+
+fn render_gauge(output: &mut String, name: &str, help: &str, gauge: &ActiveGauge) {
+    let _ = writeln!(output, "# HELP {name} {help}");
+    let _ = writeln!(output, "# TYPE {name} gauge");
+    let _ = writeln!(output, "{name} {}", gauge.current());
+    let high_water_name = format!("{name}_high_water");
+    let _ = writeln!(
+        output,
+        "# HELP {high_water_name} Highest observed value of {name}."
+    );
+    let _ = writeln!(output, "# TYPE {high_water_name} gauge");
+    let _ = writeln!(output, "{high_water_name} {}", gauge.high_water());
+}
+
+struct LogSender {
+    sender: mpsc::SyncSender<String>,
+    metrics: Arc<Metrics>,
+}
+
+impl LogSender {
+    fn send(&self, event: &AccessLogEvent) {
+        let encoded = match serde_json::to_string(event) {
+            Ok(encoded) => encoded,
+            Err(_) => {
+                self.metrics
+                    .access_log_write_failures
+                    .fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+        };
+        match self.sender.try_send(encoded) {
+            Ok(()) => {}
+            Err(mpsc::TrySendError::Full(_)) => {
+                self.metrics
+                    .access_log_dropped
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            Err(mpsc::TrySendError::Disconnected(_)) => {
+                self.metrics
+                    .access_log_write_failures
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+}
+
+struct Shared {
+    metrics: Arc<Metrics>,
+    logger: Option<LogSender>,
+    log_target: LogTarget,
+    metrics_path: Option<String>,
+    next_request_id: AtomicU64,
+    request_id_prefix: u64,
+}
+
+#[derive(Clone)]
+pub(crate) struct TelemetryHandle {
+    shared: Arc<Shared>,
+}
+
+pub(crate) struct Telemetry {
+    shared: Option<Arc<Shared>>,
+    log_worker: Option<LogWorker>,
+}
+
+struct LogWorker {
+    join: Option<JoinHandle<()>>,
+    finished: mpsc::Receiver<()>,
+}
+
+impl LogWorker {
+    fn stop(mut self) {
+        if self.finished.recv_timeout(ACCESS_LOG_DRAIN_TIMEOUT).is_ok() {
+            if let Some(join) = self.join.take() {
+                let _ = join.join();
+            }
+        }
+        // A sink such as a full stderr pipe may block inside the operating
+        // system indefinitely. Dropping the JoinHandle detaches only this
+        // context-free writer thread; server shutdown remains bounded and
+        // process exit reclaims it.
+    }
+}
+
+impl Telemetry {
+    pub(crate) fn activate(config: TelemetryConfig, metrics: Arc<Metrics>) -> Result<Self, String> {
+        let (logger, log_worker, log_target) = match config.access_log {
+            Some(access_log) => {
+                if access_log.buffer_events == 0 {
+                    return Err("access log buffer capacity must be non-zero".to_owned());
+                }
+                let (sender, receiver) = mpsc::sync_channel(access_log.buffer_events);
+                let worker_metrics = Arc::clone(&metrics);
+                let (finished_sender, finished_receiver) = mpsc::channel();
+                let join = std::thread::Builder::new()
+                    .name("basic-webserver-access-log".to_owned())
+                    .spawn(move || {
+                        write_access_log(receiver, worker_metrics);
+                        let _ = finished_sender.send(());
+                    })
+                    .map_err(|error| format!("failed to start access log writer: {error}"))?;
+                (
+                    Some(LogSender {
+                        sender,
+                        metrics: Arc::clone(&metrics),
+                    }),
+                    Some(LogWorker {
+                        join: Some(join),
+                        finished: finished_receiver,
+                    }),
+                    access_log.target,
+                )
+            }
+            None => (None, None, LogTarget::None),
+        };
+        let prefix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64
+            ^ u64::from(std::process::id()).rotate_left(32);
+        Ok(Self {
+            shared: Some(Arc::new(Shared {
+                metrics,
+                logger,
+                log_target,
+                metrics_path: config.metrics_path,
+                next_request_id: AtomicU64::new(1),
+                request_id_prefix: prefix,
+            })),
+            log_worker,
+        })
+    }
+
+    pub(crate) fn handle(&self) -> TelemetryHandle {
+        TelemetryHandle {
+            shared: Arc::clone(
+                self.shared
+                    .as_ref()
+                    .expect("telemetry handle requested after shutdown"),
+            ),
+        }
+    }
+
+    pub(crate) fn shutdown(mut self) {
+        debug_assert_eq!(
+            Arc::strong_count(
+                self.shared
+                    .as_ref()
+                    .expect("telemetry shutdown called more than once")
+            ),
+            1,
+            "all request and connection telemetry handles must drain before shutdown"
+        );
+        drop(self.shared.take());
+        if let Some(worker) = self.log_worker.take() {
+            worker.stop();
+        }
+    }
+}
+
+impl Drop for Telemetry {
+    fn drop(&mut self) {
+        // Normal server shutdown calls `shutdown` after all response bodies
+        // drain. This fallback still avoids detaching the writer on startup
+        // errors.
+        drop(self.shared.take());
+        if let Some(worker) = self.log_worker.take() {
+            worker.stop();
+        }
+    }
+}
+
+fn write_access_log(receiver: mpsc::Receiver<String>, metrics: Arc<Metrics>) {
+    let stderr = io::stderr();
+    let mut writer = BufWriter::new(stderr.lock());
+    while let Ok(line) = receiver.recv() {
+        if writeln!(writer, "{line}")
+            .and_then(|()| writer.flush())
+            .is_err()
+        {
+            metrics
+                .access_log_write_failures
+                .fetch_add(1, Ordering::Relaxed);
+            while receiver.recv().is_ok() {
+                metrics
+                    .access_log_write_failures
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            return;
+        }
+    }
+    if writer.flush().is_err() {
+        metrics
+            .access_log_write_failures
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+impl TelemetryHandle {
+    pub(crate) fn metrics(&self) -> Arc<Metrics> {
+        Arc::clone(&self.shared.metrics)
+    }
+
+    pub(crate) fn start_request(&self, method: &Method, path: &str) -> RequestTelemetry {
+        self.shared.metrics.request_started();
+        let sequence = self.shared.next_request_id.fetch_add(1, Ordering::Relaxed);
+        let target = match self.shared.log_target {
+            LogTarget::None => None,
+            LogTarget::PathWithoutQuery => Some(bounded_path(path)),
+        };
+        RequestTelemetry {
+            inner: Arc::new(RequestInner {
+                shared: Arc::clone(&self.shared),
+                started: Instant::now(),
+                timestamp: SystemTime::now(),
+                request_id_prefix: self.shared.request_id_prefix,
+                request_id_sequence: sequence,
+                method: MethodClass::from_method(method),
+                target,
+                details: Mutex::new(RequestDetails::default()),
+                finished: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    pub(crate) fn is_metrics_path(&self, path: &str) -> bool {
+        self.shared.metrics_path.as_deref() == Some(path)
+    }
+
+    pub(crate) fn metrics_response(&self, method: &Method) -> ServerResponse {
+        if method != Method::GET && method != Method::HEAD {
+            let mut response =
+                hyper::Response::new(full_body(Bytes::from_static(b"Method Not Allowed")));
+            *response.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
+            response
+                .headers_mut()
+                .insert(hyper::header::ALLOW, HeaderValue::from_static("GET, HEAD"));
+            response
+                .headers_mut()
+                .insert(CACHE_CONTROL, HeaderValue::from_static("no-store"));
+            return response;
+        }
+        let rendered = self.shared.metrics.render_openmetrics();
+        let representation_length = rendered.len();
+        let bytes = if method == Method::HEAD {
+            Bytes::new()
+        } else {
+            Bytes::from(rendered)
+        };
+        let mut response = hyper::Response::new(full_body(bytes));
+        response.headers_mut().insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static(OPENMETRICS_CONTENT_TYPE),
+        );
+        response
+            .headers_mut()
+            .insert(CACHE_CONTROL, HeaderValue::from_static("no-store"));
+        response.headers_mut().insert(
+            CONTENT_LENGTH,
+            representation_length
+                .to_string()
+                .parse()
+                .expect("bounded metrics representation length is a valid header"),
+        );
+        response
+    }
+
+    pub(crate) fn connection_started(&self) -> ActiveGaugeGuard {
+        self.shared.metrics.connection_started()
+    }
+}
+
+#[derive(Default)]
+struct RequestDetails {
+    destination: Option<Destination>,
+    rejection: Option<RejectionReason>,
+    status: Option<u16>,
+    handler_queue_wait: Option<Duration>,
+    handler_duration: Option<Duration>,
+}
+
+#[derive(Clone)]
+pub(crate) struct RequestTelemetry {
+    inner: Arc<RequestInner>,
+}
+
+struct RequestInner {
+    shared: Arc<Shared>,
+    started: Instant,
+    timestamp: SystemTime,
+    request_id_prefix: u64,
+    request_id_sequence: u64,
+    method: MethodClass,
+    target: Option<String>,
+    details: Mutex<RequestDetails>,
+    finished: AtomicBool,
+}
+
+impl RequestTelemetry {
+    pub(crate) fn set_destination(&self, destination: Destination) {
+        self.inner
+            .details
+            .lock()
+            .expect("request telemetry mutex poisoned")
+            .destination = Some(destination);
+    }
+
+    pub(crate) fn reject(&self, reason: RejectionReason) {
+        let mut details = self
+            .inner
+            .details
+            .lock()
+            .expect("request telemetry mutex poisoned");
+        details.destination = Some(Destination::HostRejection);
+        details.rejection = Some(reason);
+    }
+
+    pub(crate) fn reject_for_destination(&self, destination: Destination, reason: RejectionReason) {
+        let mut details = self
+            .inner
+            .details
+            .lock()
+            .expect("request telemetry mutex poisoned");
+        details.destination = Some(destination);
+        details.rejection = Some(reason);
+    }
+
+    pub(crate) fn record_handler(&self, queue_wait: Duration, handler_duration: Duration) {
+        let mut details = self
+            .inner
+            .details
+            .lock()
+            .expect("request telemetry mutex poisoned");
+        details.handler_queue_wait = Some(queue_wait);
+        details.handler_duration = Some(handler_duration);
+    }
+
+    pub(crate) fn instrument(self, response: ServerResponse) -> ServerResponse {
+        self.inner
+            .details
+            .lock()
+            .expect("request telemetry mutex poisoned")
+            .status = Some(response.status().as_u16());
+        let (parts, body) = response.into_parts();
+        let body = CompletionBody::new(body, self).boxed_unsync();
+        hyper::Response::from_parts(parts, body)
+    }
+
+    #[cfg(test)]
+    fn finish_for_test(&self, completion: Completion, response_bytes: u64) {
+        self.inner.finish(completion, response_bytes);
+    }
+}
+
+impl RequestInner {
+    fn finish(&self, completion: Completion, response_bytes: u64) {
+        if self
+            .finished
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        let duration = self.started.elapsed();
+        let details = self
+            .details
+            .lock()
+            .expect("request telemetry mutex poisoned");
+        let destination = details.destination.unwrap_or(Destination::HostRejection);
+        self.shared.metrics.request_finished(
+            self.method,
+            destination,
+            completion,
+            details.rejection,
+            duration,
+            response_bytes,
+        );
+        if let Some(logger) = &self.shared.logger {
+            let timestamp_unix_ms = self
+                .timestamp
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis()
+                .min(u64::MAX as u128) as u64;
+            logger.send(&AccessLogEvent {
+                timestamp_unix_ms,
+                duration_us: duration.as_micros().min(u64::MAX as u128) as u64,
+                request_id: format!(
+                    "{:016x}{:016x}",
+                    self.request_id_prefix, self.request_id_sequence
+                ),
+                method: self.method.label(),
+                status: details.status,
+                destination: destination.label(),
+                completion: completion.label(),
+                rejection: details.rejection.map(RejectionReason::label),
+                handler_queue_wait_us: details
+                    .handler_queue_wait
+                    .map(|value| value.as_micros().min(u64::MAX as u128) as u64),
+                roc_handler_duration_us: details
+                    .handler_duration
+                    .map(|value| value.as_micros().min(u64::MAX as u128) as u64),
+                response_body_bytes: response_bytes,
+                target_path: self.target.as_deref(),
+            });
+        }
+    }
+}
+
+impl Drop for RequestInner {
+    fn drop(&mut self) {
+        self.finish(Completion::BodyDropped, 0);
+    }
+}
+
+#[derive(Serialize)]
+struct AccessLogEvent<'a> {
+    timestamp_unix_ms: u64,
+    duration_us: u64,
+    request_id: String,
+    method: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<u16>,
+    destination: &'static str,
+    completion: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rejection: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    handler_queue_wait_us: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    roc_handler_duration_us: Option<u64>,
+    response_body_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target_path: Option<&'a str>,
+}
+
+fn bounded_path(path: &str) -> String {
+    if path.len() <= MAX_LOGGED_PATH_BYTES {
+        return path.to_owned();
+    }
+    let mut end = MAX_LOGGED_PATH_BYTES;
+    while !path.is_char_boundary(end) {
+        end -= 1;
+    }
+    path[..end].to_owned()
+}
+
+struct CompletionBody {
+    inner: ServerBody,
+    telemetry: RequestTelemetry,
+    response_bytes: u64,
+    finished: bool,
+}
+
+impl CompletionBody {
+    fn new(inner: ServerBody, telemetry: RequestTelemetry) -> Self {
+        let finished = inner.is_end_stream();
+        if finished {
+            telemetry.inner.finish(Completion::EndOfStream, 0);
+        }
+        Self {
+            inner,
+            telemetry,
+            response_bytes: 0,
+            finished,
+        }
+    }
+
+    fn finish(&mut self, completion: Completion) {
+        if !self.finished {
+            self.finished = true;
+            self.telemetry.inner.finish(completion, self.response_bytes);
+        }
+    }
+}
+
+impl Body for CompletionBody {
+    type Data = Bytes;
+    type Error = io::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        match Pin::new(&mut self.inner).poll_frame(context) {
+            Poll::Ready(Some(Ok(frame))) => {
+                if let Some(data) = frame.data_ref() {
+                    self.response_bytes = self
+                        .response_bytes
+                        .saturating_add(data.len().try_into().unwrap_or(u64::MAX));
+                }
+                // Hyper is allowed to stop polling as soon as `is_end_stream`
+                // becomes true. A body such as `Full` reaches that state while
+                // yielding its final data frame, so waiting for a later
+                // `poll_frame(None)` would misclassify successful responses as
+                // dropped.
+                if self.inner.is_end_stream() {
+                    self.finish(Completion::EndOfStream);
+                }
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Poll::Ready(Some(Err(error))) => {
+                self.finish(Completion::BodyFailure);
+                Poll::Ready(Some(Err(error)))
+            }
+            Poll::Ready(None) => {
+                self.finish(Completion::EndOfStream);
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.finished || self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+impl Drop for CompletionBody {
+    fn drop(&mut self) {
+        self.finish(Completion::BodyDropped);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+    use http_body_util::{BodyExt, StreamBody};
+    use std::collections::BTreeSet;
+    use std::convert::Infallible;
+
+    fn telemetry(access_log: Option<AccessLogConfig>, metrics_path: Option<&str>) -> Telemetry {
+        Telemetry::activate(
+            TelemetryConfig {
+                access_log,
+                metrics_path: metrics_path.map(str::to_owned),
+            },
+            Metrics::new(),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn response_body_emits_exactly_one_end_of_stream_event() {
+        let telemetry = telemetry(None, None);
+        let handle = telemetry.handle();
+        let request = handle.start_request(&Method::GET, "/");
+        request.set_destination(Destination::Roc);
+        let response = request
+            .clone()
+            .instrument(hyper::Response::new(full_body(Bytes::from_static(b"abc"))));
+        assert_eq!(
+            response.into_body().collect().await.unwrap().to_bytes(),
+            "abc"
+        );
+        request.finish_for_test(Completion::BodyDropped, 99);
+
+        let rendered = handle.shared.metrics.render_openmetrics();
+        assert!(rendered.contains(
+            "basic_webserver_http_requests_total{method=\"GET\",destination=\"roc\",completion=\"end_of_stream\"} 1"
+        ));
+        assert!(rendered.contains(
+            "basic_webserver_http_requests_total{method=\"GET\",destination=\"roc\",completion=\"body_dropped\"} 0"
+        ));
+        assert!(rendered.contains("basic_webserver_http_requests_active 0"));
+        drop(request);
+        drop(handle);
+        telemetry.shutdown();
+    }
+
+    #[tokio::test]
+    async fn body_failure_and_drop_are_distinct_terminal_states() {
+        let telemetry = telemetry(None, None);
+        let handle = telemetry.handle();
+        let failed = handle.start_request(&Method::GET, "/failed");
+        failed.set_destination(Destination::NativeFile);
+        let error_body = StreamBody::new(stream::iter([Err::<Frame<Bytes>, _>(io::Error::other(
+            "read failed",
+        ))]))
+        .boxed_unsync();
+        let response = failed.instrument(hyper::Response::new(error_body));
+        assert!(response.into_body().frame().await.unwrap().is_err());
+
+        let dropped = handle.start_request(&Method::GET, "/dropped");
+        dropped.set_destination(Destination::Roc);
+        let response = dropped.instrument(hyper::Response::new(full_body(Bytes::from_static(
+            b"not polled",
+        ))));
+        drop(response);
+
+        let rendered = handle.shared.metrics.render_openmetrics();
+        assert!(rendered.contains(
+            "basic_webserver_http_requests_total{method=\"GET\",destination=\"native_file\",completion=\"body_failure\"} 1"
+        ));
+        assert!(rendered.contains(
+            "basic_webserver_http_requests_total{method=\"GET\",destination=\"roc\",completion=\"body_dropped\"} 1"
+        ));
+        assert!(rendered.contains("basic_webserver_http_requests_active 0"));
+        drop(handle);
+        telemetry.shutdown();
+    }
+
+    #[test]
+    fn method_and_target_cardinality_are_bounded() {
+        let telemetry = telemetry(None, None);
+        let handle = telemetry.handle();
+        for index in 0..1_000 {
+            let method = Method::from_bytes(format!("X-{index}").as_bytes()).unwrap();
+            let request = handle.start_request(&method, &format!("/unique/{index}"));
+            request.set_destination(Destination::Roc);
+            request.finish_for_test(Completion::EndOfStream, 0);
+        }
+        let rendered = handle.shared.metrics.render_openmetrics();
+        assert!(rendered.contains(
+            "basic_webserver_http_requests_total{method=\"_OTHER\",destination=\"roc\",completion=\"end_of_stream\"} 1000"
+        ));
+        assert!(!rendered.contains("/unique/"));
+        drop(handle);
+        telemetry.shutdown();
+    }
+
+    #[test]
+    fn every_rejection_reason_has_one_fixed_metric_series() {
+        let telemetry = telemetry(None, None);
+        let handle = telemetry.handle();
+        for reason in RejectionReason::ALL {
+            let request = handle.start_request(&Method::GET, "/untrusted");
+            request.reject(reason);
+            request.finish_for_test(Completion::EndOfStream, 0);
+        }
+        let rendered = handle.shared.metrics.render_openmetrics();
+        for reason in RejectionReason::ALL {
+            assert!(rendered.contains(&format!(
+                "basic_webserver_rejections_total{{reason=\"{}\"}} 1",
+                reason.label()
+            )));
+        }
+        assert!(rendered.contains("basic_webserver_http_requests_active 0"));
+        drop(handle);
+        telemetry.shutdown();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_terminal_events_return_active_requests_to_zero() {
+        let telemetry = telemetry(None, None);
+        let handle = telemetry.handle();
+        let mut tasks = Vec::new();
+        let barrier = Arc::new(tokio::sync::Barrier::new(129));
+        for _ in 0..128 {
+            let request = handle.start_request(&Method::POST, "/same");
+            request.set_destination(Destination::Roc);
+            let barrier = Arc::clone(&barrier);
+            tasks.push(tokio::spawn(async move {
+                barrier.wait().await;
+                request.finish_for_test(Completion::EndOfStream, 1);
+            }));
+        }
+        barrier.wait().await;
+        for task in tasks {
+            task.await.unwrap();
+        }
+        let rendered = handle.shared.metrics.render_openmetrics();
+        assert!(rendered.contains("basic_webserver_http_requests_active 0"));
+        assert!(rendered.contains("basic_webserver_http_requests_active_high_water 128"));
+        assert!(rendered.contains(
+            "basic_webserver_http_requests_total{method=\"POST\",destination=\"roc\",completion=\"end_of_stream\"} 128"
+        ));
+        drop(handle);
+        telemetry.shutdown();
+    }
+
+    #[test]
+    fn structured_encoding_prevents_log_injection_and_bounds_paths() {
+        let event = AccessLogEvent {
+            timestamp_unix_ms: 1,
+            duration_us: 2,
+            request_id: "id".to_owned(),
+            method: "GET",
+            status: Some(200),
+            destination: "roc",
+            completion: "end_of_stream",
+            rejection: None,
+            handler_queue_wait_us: None,
+            roc_handler_duration_us: None,
+            response_body_bytes: 3,
+            target_path: Some("/bad\n{\"forged\":true}"),
+        };
+        let encoded = serde_json::to_string(&event).unwrap();
+        assert!(!encoded.contains('\n'));
+        assert!(encoded.contains("\\n"));
+        assert_eq!(
+            bounded_path(&"é".repeat(2_000)).len(),
+            MAX_LOGGED_PATH_BYTES
+        );
+    }
+
+    #[test]
+    fn request_ids_are_host_generated_and_unique_within_a_process() {
+        let telemetry = telemetry(None, None);
+        let handle = telemetry.handle();
+        let mut ids = BTreeSet::new();
+        for _ in 0..100 {
+            let request = handle.start_request(&Method::GET, "/");
+            ids.insert((
+                request.inner.request_id_prefix,
+                request.inner.request_id_sequence,
+            ));
+            request.finish_for_test(Completion::EndOfStream, 0);
+        }
+        assert_eq!(ids.len(), 100);
+        drop(handle);
+        telemetry.shutdown();
+    }
+
+    #[tokio::test]
+    async fn metrics_endpoint_has_openmetrics_headers_and_no_store() {
+        let telemetry = telemetry(None, Some("/metrics"));
+        let handle = telemetry.handle();
+        let response = handle.metrics_response(&Method::GET);
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()[CONTENT_TYPE], OPENMETRICS_CONTENT_TYPE);
+        assert_eq!(response.headers()[CACHE_CONTROL], "no-store");
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert!(body.ends_with(b"# EOF\n"));
+
+        let head = handle.metrics_response(&Method::HEAD);
+        assert_eq!(head.status(), StatusCode::OK);
+        assert_eq!(head.headers()[CONTENT_LENGTH], body.len().to_string());
+        assert!(head
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes()
+            .is_empty());
+        drop(handle);
+        telemetry.shutdown();
+    }
+
+    #[test]
+    fn log_queue_overflow_is_non_blocking_and_counted() {
+        let metrics = Metrics::new();
+        let (sender, _receiver) = mpsc::sync_channel(1);
+        let logger = LogSender {
+            sender,
+            metrics: Arc::clone(&metrics),
+        };
+        let event = AccessLogEvent {
+            timestamp_unix_ms: 1,
+            duration_us: 1,
+            request_id: "1".to_owned(),
+            method: "GET",
+            status: Some(200),
+            destination: "roc",
+            completion: "end_of_stream",
+            rejection: None,
+            handler_queue_wait_us: None,
+            roc_handler_duration_us: None,
+            response_body_bytes: 0,
+            target_path: None,
+        };
+        logger.send(&event);
+        logger.send(&event);
+        assert_eq!(metrics.access_log_dropped.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn empty_body_is_complete_without_transport_polling() {
+        let telemetry = telemetry(None, None);
+        let handle = telemetry.handle();
+        let request = handle.start_request(&Method::HEAD, "/");
+        request.set_destination(Destination::Roc);
+        let body = crate::file_server::empty_body();
+        let response = request.instrument(hyper::Response::new(body));
+        drop(response);
+        assert!(handle
+            .shared
+            .metrics
+            .render_openmetrics()
+            .contains("basic_webserver_http_requests_active 0"));
+        drop(handle);
+        telemetry.shutdown();
+    }
+
+    #[test]
+    fn infallible_marker_is_used_by_test_bodies() {
+        let _: Option<Infallible> = None;
+    }
+}


### PR DESCRIPTION
## Summary

- add one host-owned terminal request event at the response-body boundary for Roc responses, native files, metrics, overload, rejection, panic, disconnect/drop, and shutdown
- add opt-in bounded JSON Lines access logging to stderr with host-generated request IDs and an explicit no-target/path-without-query privacy policy
- add a native exact OpenMetrics endpoint backed by fixed-cardinality counters, gauges, high-water marks, and duration histograms
- integrate handler queue/active accounting, native file transfer accounting, connection accounting, response compression, and graceful shutdown into the same telemetry subsystem
- migrate `hello-web` from incomplete handler-local logging to the host facility and exercise the metrics/log contract in the runtime spec

The completion contract is deliberately limited to response-body end-of-stream, failure, or drop. Representation bytes are frames handed to Hyper, not bytes acknowledged on the physical network.

The access-log queue is finite and transport uses only `try_send`. A dedicated writer flushes complete JSON records promptly; queue overflow is counted, and shutdown will not wait indefinitely for a blocked stderr sink. Targets, request bodies, credentials, cookies, arbitrary headers, peer identity, user agents, and client-supplied request/trace IDs are excluded by default.

Metrics use only finite host enums. Unknown methods collapse to `_OTHER`, raw targets are never labels, and the exporter has the OpenMetrics content type plus `Cache-Control: no-store`.

## Validation

- `cargo test --locked --lib` (128 passed)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `roc fmt --check platform examples/hello-web.roc`
- `roc test platform/main.roc` (215 passed)
- `python3 scripts/test.py --operation validate --roc <pinned nightly 306abd6>` (23 applications validated)
- pinned generated Rust glue freshness check
- `python3 scripts/build.py --all` (x64musl and arm64musl)
- rebuilt and ran `examples/hello-web.roc` through the real listener; verified JSON completion records, query exclusion, terminal byte counts, and the OpenMetrics response

The full `python3 scripts/test.py` run with the current PATH compiler reaches the existing SQLite derived-parser failure (`parse_record_start` / `parser_for`) after the platform and earlier example validation passes. The pinned known-good compiler completes source validation.

Closes #182
