### PR TITLE
Add native liveness and readiness routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,16 @@ jobs:
       - name: Install the Zig-based Roc compiler
         uses: ./.github/actions/setup-roc
 
+      - name: Install Zig
+        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f
+        with:
+          version: 0.16.0
+
       - name: Install Rust toolchain
         run: |
           rustup toolchain install "${{ needs.rust-version.outputs.version }}" --profile minimal
           rustup default "${{ needs.rust-version.outputs.version }}"
-          rustup component add rustfmt
+          rustup component add rustfmt llvm-tools-preview
 
       - name: Check Rust formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -417,7 +417,10 @@ jobs:
           examples
 
       - name: Validate updated examples
-        run: python scripts/test.py --operation validate
+        run: >-
+          python scripts/test.py
+          --operation validate
+          --platform-dependency declared
 
       - name: Snapshot existing docs
         uses: roc-lang/release-package/actions/docs-snapshot@d2560ead9f724bfaabfbc8134b8895e120171064

--- a/examples/health.roc
+++ b/examples/health.roc
@@ -1,0 +1,96 @@
+## Native liveness and readiness routes backed by a typed host readiness gate.
+##
+## Probe requests never enter `respond!`, so they remain available while the
+## bounded Roc handler pool and queue are occupied.
+app [Context, program] {
+	pf: platform "https://github.com/roc-lang/basic-webserver/releases/download/0.14.0/9mrSfhWKEXsrPUW2oHdZZGov1oMRryvvACDT8p7E97PY.tar.zst",
+	http: "https://github.com/roc-lang/http/releases/download/1.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
+}
+
+import pf.Env
+import pf.Server
+import pf.Sleep
+import pf.Stdout
+import http.Response
+
+Context : { readiness : Server.Readiness }
+
+program = { init!, respond!, shutdown! }
+
+init! : () => Try({ config : Server.Config, context : Context }, [Exit(I64), ..])
+init! = || {
+	readiness = Server.Readiness.create!(NotReady)
+		? |_| Exit(1)
+	mode = 
+		match Env.var_str!("HEALTH_CONFIG") {
+			Ok(value) => value
+			_ => "valid"
+		}
+	native_routes = 
+		match mode {
+			"duplicate" => {
+				files: [],
+				liveness: [Server.liveness_route("/health")],
+				readiness: [Server.readiness_route({ at: "/health", readiness })],
+			}
+			"invalid" => {
+				files: [],
+				liveness: [Server.liveness_route("/live?details=true")],
+				readiness: [],
+			}
+			_ => {
+				files: [],
+				liveness: [Server.liveness_route("/live")],
+				readiness: [Server.readiness_route({ at: "/ready", readiness })],
+			}
+		}
+	config = 
+		Server.default_config
+			.with_limits({
+				max_connections: 16,
+				max_handlers: 1,
+				max_queued_handlers: 1,
+			})
+			.with_native_routes(native_routes)
+	Ok({
+		config,
+		context: {
+			readiness: readiness,
+		},
+	})
+}
+
+respond! : Server.Request, Context => Try(Server.Outcome, [ServerErr(Str), ..])
+respond! = |request, context|
+	match request.target() {
+		"/set-ready" => {
+			context.readiness.set!(Ready)
+				? |err| ServerErr("Failed to become ready: ${Str.inspect(err)}")
+			Ok(text_response(200, "ready"))
+		}
+		"/set-not-ready" => {
+			context.readiness.set!(NotReady)
+				? |err| ServerErr("Failed to become not ready: ${Str.inspect(err)}")
+			Ok(text_response(200, "not ready"))
+		}
+		"/slow" => {
+			Sleep.millis!(750)
+			Ok(text_response(200, "slow response"))
+		}
+		"/stop" => Ok(Server.stop_after(Response.from_status(200).with_body(Str.to_utf8("stopping"))))
+		_ => Ok(text_response(404, "not found"))
+	}
+
+shutdown! : Server.ShutdownReason, Context => Try({}, [Exit(I64), ..])
+shutdown! = |_reason, context| {
+	result = context.readiness.set!(Ready)
+	Stdout.line!("shutdown readiness update: ${Str.inspect(result)}") ?? {}
+	Ok({})
+}
+
+text_response = |status, body|
+	Server.respond(
+		Response.from_status(status)
+			.with_headers([{ name: "Content-Type", value: "text/plain; charset=utf-8" }])
+			.with_body(Str.to_utf8(body)),
+	)

--- a/examples/static-files.roc
+++ b/examples/static-files.roc
@@ -37,10 +37,14 @@ init! = || {
 	config = 
 		Server.default_config
 			.with_file_roots([assets, downloads])
-			.with_native_routes([
-				Server.static_mount({ at: "/assets", files: assets }),
-				Server.static_file({ at: "/favicon.ico", files: assets, relative: favicon }),
-			])
+			.with_native_routes({
+				files: [
+					Server.static_mount({ at: "/assets", files: assets }),
+					Server.static_file({ at: "/favicon.ico", files: assets, relative: favicon }),
+				],
+				liveness: [],
+				readiness: [],
+			})
 
 	Ok({
 		config,

--- a/platform/Host.roc
+++ b/platform/Host.roc
@@ -61,6 +61,8 @@ Host := [].{
 
 	RequestBody :: Box(U64)
 
+	Readiness :: Box(U64)
+
 	RequestBodyRead : [Chunk(List(U8)), End]
 
 	RequestBodyErr : [
@@ -71,6 +73,8 @@ Host := [].{
 		ConcurrentRead,
 		Cancelled,
 	]
+
+	ReadinessSetErr : [InvalidReadiness, StaleReadiness, ServerStopping]
 
 	CmdExecErr : [FailedToGetExitCode(IOErr), Timeout, Saturated]
 
@@ -123,6 +127,9 @@ Host := [].{
 
 	request_body_read! : RequestBody, U64 => Try(RequestBodyRead, RequestBodyErr)
 	request_body_read_all! : RequestBody, U64 => Try(List(U8), RequestBodyErr)
+
+	readiness_create! : Bool => Try(Readiness, [ReadinessCapacityExhausted])
+	readiness_set! : Readiness, Bool => Try({}, ReadinessSetErr)
 
 	path_type! : RawPath => Try(PathType, IOErr)
 

--- a/platform/InternalServer.roc
+++ b/platform/InternalServer.roc
@@ -58,7 +58,7 @@ InternalServer :: [].{
 				cache_max_age_seconds : U32,
 			},
 		),
-		native_routes : List(
+		native_file_routes : List(
 			{
 				at : Str,
 				root_id : Str,
@@ -69,6 +69,8 @@ InternalServer :: [].{
 				cache_max_age_seconds : U32,
 			},
 		),
+		liveness_routes : List(Str),
+		readiness_routes : List({ at : Str, readiness : Host.Readiness }),
 		file_max_concurrent : U16,
 		file_chunk_bytes : U32,
 	}

--- a/platform/Server.roc
+++ b/platform/Server.roc
@@ -234,8 +234,8 @@ Server :: [].{
 
 	## One startup-declared host-native file route. Static mounts own an exact
 	## prefix on segment boundaries. Static files own one exact URI path.
-	NativeRoute := [
-		NativeRoute(
+	FileRoute := [
+		FileRoute(
 			{
 				at : Str,
 				files : FileRoot,
@@ -247,7 +247,7 @@ Server :: [].{
 	].{
 
 		## Platform ABI conversion hook; not an application API.
-		to_host : NativeRoute -> {
+		to_host : FileRoute -> {
 			at : Str,
 			root_id : Str,
 			kind : U8,
@@ -256,7 +256,7 @@ Server :: [].{
 			cache_tag : U8,
 			cache_max_age_seconds : U32,
 		}
-		to_host = |NativeRoute(route)| {
+		to_host = |FileRoute(route)| {
 			FileRoot(root) = route.files
 			cache = CacheChoice.to_host(route.cache)
 			{
@@ -274,19 +274,19 @@ Server :: [].{
 	## Declare a public static mount that inherits its root cache policy. Route
 	## paths are ASCII absolute URI paths of at most 4 KiB and are validated at
 	## startup.
-	static_mount : { at : Str, files : FileRoot } -> NativeRoute
+	static_mount : { at : Str, files : FileRoot } -> FileRoute
 	static_mount = |{ at, files }|
-		NativeRoute({ at, files, kind: 0, relative: "", cache: Inherit })
+		FileRoute({ at, files, kind: 0, relative: "", cache: Inherit })
 
 	## Declare a public static mount with an explicit cache policy.
-	static_mount_with_cache : { at : Str, files : FileRoot, cache : CachePolicy } -> NativeRoute
+	static_mount_with_cache : { at : Str, files : FileRoot, cache : CachePolicy } -> FileRoute
 	static_mount_with_cache = |{ at, files, cache }|
-		NativeRoute({ at, files, kind: 0, relative: "", cache: Override(cache) })
+		FileRoute({ at, files, kind: 0, relative: "", cache: Override(cache) })
 
 	## Declare one exact public file route that inherits its root cache policy.
-	static_file : { at : Str, files : FileRoot, relative : RelativeFile } -> NativeRoute
+	static_file : { at : Str, files : FileRoot, relative : RelativeFile } -> FileRoute
 	static_file = |{ at, files, relative }|
-		NativeRoute({
+		FileRoute({
 			at,
 			files,
 			kind: 1,
@@ -295,15 +295,92 @@ Server :: [].{
 		})
 
 	## Declare one exact public file route with an explicit cache policy.
-	static_file_with_cache : { at : Str, files : FileRoot, relative : RelativeFile, cache : CachePolicy } -> NativeRoute
+	static_file_with_cache : { at : Str, files : FileRoot, relative : RelativeFile, cache : CachePolicy } -> FileRoute
 	static_file_with_cache = |{ at, files, relative, cache }|
-		NativeRoute({
+		FileRoute({
 			at,
 			files,
 			kind: 1,
 			relative: RelativeFile.to_host(relative),
 			cache: Override(cache),
 		})
+
+	## The complete readiness state. There are deliberately no names, reasons,
+	## dependency callbacks, or intermediate states.
+	ReadinessState : [NotReady, Ready]
+
+	## A bounded host-owned readiness gate. It is safe to retain in immutable
+	## context and update from concurrent handlers. Final Roc ARC release closes
+	## the capability; graceful drain permanently changes it to NotReady before
+	## `shutdown!` runs.
+	Readiness := { host : Host.Readiness }.{
+
+		## Create one readiness gate with an explicit initial state. The host has
+		## finite capacity and reports exhaustion instead of growing a registry.
+		create! : ReadinessState => Try(Readiness, [ReadinessCapacityExhausted])
+		create! = |state| {
+			host = Host.readiness_create!(state == Ready)?
+			Ok(Readiness.{ host })
+		}
+
+		## Atomically replace the readiness state. Once graceful drain begins,
+		## every update returns ServerStopping and the state remains NotReady.
+		set! : Readiness, ReadinessState => Try({}, [InvalidReadiness, StaleReadiness, ServerStopping])
+		set! = |readiness, state|
+			Host.readiness_set!(to_host(readiness), state == Ready)
+
+		## Render without exposing the host lifecycle token.
+		to_inspect : Readiness -> Str
+		to_inspect = |_| "Server.Readiness(<opaque>)"
+
+		## Platform ABI conversion hook; not an application API.
+		to_host : Readiness -> Host.Readiness
+		to_host = |Readiness.{ host }| host
+	}
+
+	## One native exact route whose response proves only that the listener and
+	## HTTP machinery can serve it. `init!` and complete route validation finish
+	## before the listener is bound, so this route also serves as a deployment
+	## startup probe once it becomes reachable; there is no separate mutable
+	## startup state.
+	LivenessRoute := [LivenessRoute(Str)].{
+
+		## Platform ABI conversion hook; not an application API.
+		to_host : LivenessRoute -> Str
+		to_host = |LivenessRoute(at)| at
+	}
+
+	## One native exact route backed by a typed readiness gate.
+	ReadinessRoute := [ReadinessRoute({ at : Str, readiness : Readiness })].{
+
+		## Platform ABI conversion hook; not an application API.
+		to_host : ReadinessRoute -> { at : Str, readiness : Host.Readiness }
+		to_host = |ReadinessRoute({ at, readiness })| {
+			at,
+			readiness: Readiness.to_host(readiness),
+		}
+	}
+
+	## Declare a native liveness route. Paths are validated with all other native
+	## routes atomically before the listener is bound.
+	liveness_route : Str -> LivenessRoute
+	liveness_route = |at| LivenessRoute(at)
+
+	## Declare a native readiness route backed by the supplied gate.
+	readiness_route : { at : Str, readiness : Readiness } -> ReadinessRoute
+	readiness_route = |route| ReadinessRoute(route)
+
+	## The immutable startup route topology. Exact route duplicates are rejected;
+	## exact routes take precedence over more general file prefixes.
+	NativeRoutes : {
+		files : List(FileRoute),
+		liveness : List(LivenessRoute),
+		readiness : List(ReadinessRoute),
+	}
+
+	## No host-native routes.
+	no_native_routes : NativeRoutes
+	no_native_routes = { files: [], liveness: [], readiness: [] }
 
 	## Opaque runtime configuration returned from the application's `init!`
 	## function. Use the builders below so future server settings can be added
@@ -336,7 +413,7 @@ Server :: [].{
 					hook_timeout_ms : U64,
 				},
 				file_roots : List(FileRoot),
-				native_routes : List(NativeRoute),
+				native_routes : NativeRoutes,
 				file_transfers : {
 					max_concurrent : U16,
 					chunk_bytes : U32,
@@ -370,7 +447,7 @@ Server :: [].{
 					cache_max_age_seconds : U32,
 				},
 			),
-			native_routes : List(
+			native_file_routes : List(
 				{
 					at : Str,
 					root_id : Str,
@@ -381,6 +458,8 @@ Server :: [].{
 					cache_max_age_seconds : U32,
 				},
 			),
+			liveness_routes : List(Str),
+			readiness_routes : List({ at : Str, readiness : Host.Readiness }),
 			file_max_concurrent : U16,
 			file_chunk_bytes : U32,
 		}
@@ -396,7 +475,9 @@ Server :: [].{
 			max_handlers: config.limits.max_handlers,
 			max_queued_handlers: config.limits.max_queued_handlers,
 			file_roots: config.file_roots.map(FileRoot.to_host),
-			native_routes: config.native_routes.map(NativeRoute.to_host),
+			native_file_routes: config.native_routes.files.map(FileRoute.to_host),
+			liveness_routes: config.native_routes.liveness.map(LivenessRoute.to_host),
+			readiness_routes: config.native_routes.readiness.map(ReadinessRoute.to_host),
 			file_max_concurrent: config.file_transfers.max_concurrent,
 			file_chunk_bytes: config.file_transfers.chunk_bytes,
 		}
@@ -425,7 +506,7 @@ Server :: [].{
 			hook_timeout_ms: 10_000,
 		},
 		file_roots: [],
-		native_routes: [],
+		native_routes: no_native_routes,
 		file_transfers: {
 			max_concurrent: default_max_file_transfers,
 			chunk_bytes: default_file_chunk_bytes,
@@ -458,8 +539,8 @@ Server :: [].{
 	with_file_roots : Config, List(FileRoot) -> Config
 	with_file_roots = |Config(config), file_roots| Config({ ..config, file_roots })
 
-	## Replace the immutable host-native route table.
-	with_native_routes : Config, List(NativeRoute) -> Config
+	## Replace the complete immutable host-native route table.
+	with_native_routes : Config, NativeRoutes -> Config
 	with_native_routes = |Config(config), native_routes| Config({ ..config, native_routes })
 
 	## Set the active-transfer bound and streaming chunk size for host-managed

--- a/platform/Sqlite.roc
+++ b/platform/Sqlite.roc
@@ -249,6 +249,9 @@ Sqlite :: [].{
 		rename_field : RowEncoding, Str -> Str
 		rename_field = |_, name| name
 
+		parse_record_start : RowEncoding, RowState -> Try([Counted({ len : U64, rest : RowState }), Uncounted(RowState)], QueryError)
+		parse_record_start = |_, state| Ok(Uncounted(state))
+
 		parse_str : RowEncoding, RowState -> Try({ value : Str, rest : RowState }, QueryError)
 		parse_str = |_, state| {
 			taken = take_row_value(state)?
@@ -326,14 +329,14 @@ Sqlite :: [].{
 				Field({ field : Encoding.FieldName(_shape), rest : RowState }),
 				TryField({ name : Str, rest : RowState }),
 				TryFieldCaseless({ name : Str, rest : RowState }),
-				Continue({ rest : RowState }),
-				Done({ rest : RowState }),
+				Continue(RowState),
+				Done(RowState),
 			],
 			QueryError,
 		)
 		parse_record_field = |_, fields, state|
 			if state.next >= state.columns.len() {
-				Ok(Done({ rest: state }))
+				Ok(Done(state))
 			} else {
 				name = state.columns.get(state.next) ? |_| MalformedRow
 				value = state.values.get(state.next) ? |_| MalformedRow
@@ -349,15 +352,21 @@ Sqlite :: [].{
 					Err(NotFound) =>
 						Ok(
 							Continue({
-								rest: {
-									columns: rest.columns,
-									current: NoCurrent,
-									next: rest.next,
-									values: rest.values,
-								},
+								columns: rest.columns,
+								current: NoCurrent,
+								next: rest.next,
+								values: rest.values,
 							}),
 						)
 					}
+			}
+
+		parse_record_after_field : RowEncoding, RowState -> Try([Continue(RowState), Done(RowState)], QueryError)
+		parse_record_after_field = |_, state|
+			if state.next >= state.columns.len() {
+				Ok(Done(state))
+			} else {
+				Ok(Continue(state))
 			}
 
 		skip_record_field : RowEncoding, RowState -> Try(RowState, QueryError)

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -103,6 +103,8 @@ platform "webserver"
 		"hosted_sleep_millis": Host.sleep_millis!,
 		"hosted_request_body_read": Host.request_body_read!,
 		"hosted_request_body_read_all": Host.request_body_read_all!,
+		"hosted_readiness_create": Host.readiness_create!,
+		"hosted_readiness_set": Host.readiness_set!,
 	}
 	targets: {
 		inputs_dir: "targets/",

--- a/scripts/bundle.py
+++ b/scripts/bundle.py
@@ -20,6 +20,13 @@ TARGET_INPUTS = {
     "arm64musl": ("crt1.o", "libhost.a", "libunwind.a", "libc.a"),
     "x64win": ("host.lib", "ws2_32.lib", "bcrypt.lib", "advapi32.lib"),
 }
+RUST_TARGETS = {
+    "x64mac": "x86_64-apple-darwin",
+    "arm64mac": "aarch64-apple-darwin",
+    "x64musl": "x86_64-unknown-linux-musl",
+    "arm64musl": "aarch64-unknown-linux-musl",
+    "x64win": "x86_64-pc-windows-msvc",
+}
 PLATFORM_LINK_SUPPORT = (
     PLATFORM_DIR / "targets" / "macos-sysroot" / "usr" / "lib" / "libSystem.tbd",
 )
@@ -46,29 +53,39 @@ def validate_target_manifest() -> None:
         )
 
 
-def generate_rust_dependency_licenses(output: Path) -> None:
-    metadata = json.loads(
-        subprocess.check_output(
-            ["cargo", "metadata", "--locked", "--format-version", "1"],
-            cwd=ROOT,
-            text=True,
+def generate_rust_dependency_licenses(
+    output: Path, selected_targets: tuple[str, ...]
+) -> None:
+    packages_by_id: dict[str, dict[str, object]] = {}
+    for target in selected_targets:
+        metadata = json.loads(
+            subprocess.check_output(
+                [
+                    "cargo",
+                    "metadata",
+                    "--locked",
+                    "--format-version",
+                    "1",
+                    "--filter-platform",
+                    RUST_TARGETS[target],
+                ],
+                cwd=ROOT,
+                text=True,
+            )
         )
-    )
-    packages = sorted(
-        (
-            package
+        reachable = {node["id"] for node in metadata["resolve"]["nodes"]}
+        packages_by_id.update(
+            (package["id"], package)
             for package in metadata["packages"]
-            if str(package.get("source", "")).startswith("registry+")
-        ),
+            if package["id"] in reachable
+            and str(package.get("source", "")).startswith("registry+")
+        )
+    packages = sorted(
+        packages_by_id.values(),
         key=lambda package: (package["name"], package["version"]),
     )
 
-    lines = [
-        "# Rust Dependency Licenses",
-        "",
-        "This file is generated from the exact dependencies in `Cargo.lock`.",
-        "",
-    ]
+    license_paths_by_id: dict[str, list[Path]] = {}
     for package in packages:
         package_root = Path(package["manifest_path"]).parent
         candidates: list[Path] = []
@@ -84,14 +101,42 @@ def generate_rust_dependency_licenses(output: Path) -> None:
                 )
             )
         )
-
-        license_paths: list[Path] = []
         seen: set[Path] = set()
+        license_paths_by_id[package["id"]] = []
         for candidate in candidates:
             candidate = candidate.resolve()
             if candidate.is_file() and candidate not in seen:
                 seen.add(candidate)
-                license_paths.append(candidate)
+                license_paths_by_id[package["id"]].append(candidate)
+
+    lines = [
+        "# Rust Dependency Licenses",
+        "",
+        "This file is generated from the exact dependencies in `Cargo.lock`.",
+        "",
+    ]
+    for package in packages:
+        license_paths = license_paths_by_id[package["id"]]
+        license_source = package
+        if not license_paths:
+            repository = package.get("repository")
+            license_expression = package.get("license")
+            matching_upstream = next(
+                (
+                    candidate
+                    for candidate in packages
+                    if candidate["id"] != package["id"]
+                    and repository
+                    and candidate.get("repository") == repository
+                    and license_expression
+                    and candidate.get("license") == license_expression
+                    and license_paths_by_id[candidate["id"]]
+                ),
+                None,
+            )
+            if matching_upstream is not None:
+                license_source = matching_upstream
+                license_paths = license_paths_by_id[matching_upstream["id"]]
         if not license_paths:
             raise SystemExit(
                 f"No license text found for Rust dependency "
@@ -109,6 +154,15 @@ def generate_rust_dependency_licenses(output: Path) -> None:
         repository = package.get("repository")
         if repository:
             lines.extend([f"Source: {repository}", ""])
+        if license_source["id"] != package["id"]:
+            lines.extend(
+                [
+                    "License text supplied by "
+                    f"`{license_source['name']} {license_source['version']}` "
+                    "from the same upstream repository and SPDX license.",
+                    "",
+                ]
+            )
         for license_path in license_paths:
             lines.extend(
                 [
@@ -127,6 +181,20 @@ def generate_rust_dependency_licenses(output: Path) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Bundle the basic-webserver platform")
     parser.add_argument("--output-dir", type=Path, default=ROOT)
+    parser.add_argument(
+        "--target",
+        action="append",
+        choices=TARGET_INPUTS,
+        dest="targets",
+        help=(
+            "include only this target (repeatable); defaults to every release target"
+        ),
+    )
+    parser.add_argument(
+        "--roc",
+        default="roc",
+        help="Roc compiler used to create the bundle",
+    )
     args, roc_args = parser.parse_known_args()
 
     output_dir = args.output_dir
@@ -136,13 +204,16 @@ def main() -> None:
     output_dir = output_dir.resolve()
 
     validate_target_manifest()
+    selected_targets = tuple(args.targets or TARGET_INPUTS)
     roc_files = sorted(PLATFORM_DIR.glob("*.roc"))
     library_files = [
         PLATFORM_DIR / "targets" / target / filename
-        for target, filenames in TARGET_INPUTS.items()
-        for filename in filenames
+        for target in selected_targets
+        for filename in TARGET_INPUTS[target]
     ]
-    link_input_files = [*library_files, *PLATFORM_LINK_SUPPORT]
+    link_input_files = [*library_files]
+    if any(target.endswith("mac") for target in selected_targets):
+        link_input_files.extend(PLATFORM_LINK_SUPPORT)
     missing = [path for path in link_input_files if not path.is_file()]
     if missing:
         formatted = "\n".join(
@@ -162,7 +233,7 @@ def main() -> None:
     ]
     license_source = ROOT / "THIRD_PARTY_LICENSES.md"
     rust_licenses_target = PLATFORM_DIR / "RUST_DEPENDENCY_LICENSES.md"
-    generate_rust_dependency_licenses(rust_licenses_target)
+    generate_rust_dependency_licenses(rust_licenses_target, selected_targets)
     unpacked_size = sum(path.stat().st_size for path in (*roc_files, *link_input_files))
     unpacked_size += license_source.stat().st_size + rust_licenses_target.stat().st_size
     if unpacked_size > MAX_PLATFORM_BYTES:
@@ -190,7 +261,7 @@ def main() -> None:
     try:
         subprocess.run(
             [
-                "roc",
+                args.roc,
                 "bundle",
                 *bundle_files,
                 "THIRD_PARTY_LICENSES.md",

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import gzip
+import functools
 import hashlib
 import http.client
 import json
@@ -24,7 +25,12 @@ import sys
 import tempfile
 import threading
 import time
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import urllib.request
+from http.server import (
+    BaseHTTPRequestHandler,
+    SimpleHTTPRequestHandler,
+    ThreadingHTTPServer,
+)
 from pathlib import Path
 from typing import Iterator
 
@@ -47,6 +53,7 @@ TARGET_PLATFORMS = {
     "x64win": "windows",
 }
 ISSUE_URL = re.compile(r"^https://github\.com/[^/]+/[^/]+/issues/[1-9][0-9]*$")
+PLATFORM_DEPENDENCY = re.compile(r'(?m)(\bplatform\s+)"[^"]+"')
 LISTENING = re.compile(r"Listening on <http://(?:\[.*\]|[^:]+):([0-9]+)>")
 HTTP2_CLIENT_PREFACE = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
 HTTP2_FRAME_DATA = 0x0
@@ -71,6 +78,34 @@ if hasattr(sys.stderr, "reconfigure"):
 
 class TestFailure(RuntimeError):
     pass
+
+
+class QuietFileHandler(SimpleHTTPRequestHandler):
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+class BundleServer:
+    """Serve one immutable bundle on loopback for Roc dependency resolution."""
+
+    def __init__(self, bundle: Path) -> None:
+        handler = functools.partial(QuietFileHandler, directory=str(bundle.parent))
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.url = f"http://127.0.0.1:{self.server.server_port}/{bundle.name}"
+
+    def __enter__(self) -> str:
+        self.thread.start()
+        with urllib.request.urlopen(
+            urllib.request.Request(self.url, method="HEAD"), timeout=5
+        ):
+            pass
+        return self.url
+
+    def __exit__(self, *_: object) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join()
 
 
 def fail(message: str) -> None:
@@ -141,6 +176,43 @@ def detect_native_target() -> str:
     raise AssertionError
 
 
+@contextlib.contextmanager
+def locally_built_platform(roc: str, target: str) -> Iterator[str]:
+    """Build, bundle, and host the checkout's platform for one Roc target."""
+
+    bundle_dir = ROOT / "target" / "local-platform-bundle" / target
+    if bundle_dir.exists():
+        shutil.rmtree(bundle_dir)
+    bundle_dir.mkdir(parents=True)
+
+    command(
+        sys.executable,
+        ROOT / "scripts" / "build.py",
+        "--target",
+        target,
+    )
+    command(
+        sys.executable,
+        ROOT / "scripts" / "bundle.py",
+        "--output-dir",
+        bundle_dir,
+        "--target",
+        target,
+        "--roc",
+        roc,
+    )
+    bundles = sorted(bundle_dir.glob("*.tar.zst"))
+    if len(bundles) != 1:
+        fail(
+            f"Expected one locally built platform bundle in {bundle_dir}, "
+            f"found {len(bundles)}"
+        )
+
+    with BundleServer(bundles[0]) as platform_url:
+        print(f"Using local platform bundle: {platform_url}", flush=True)
+        yield platform_url
+
+
 def validate_skip(owner: str, value: object) -> None:
     if not isinstance(value, dict):
         fail(f"{owner}: skip must be an object")
@@ -198,6 +270,15 @@ def validate_case(app_path: str, case: object, names: set[str]) -> None:
         fail(f"{app_path}: duplicate case name {name!r}")
     names.add(name)
     owner = f"{app_path} [{name}]"
+    if case.get("expect_startup_failure", False):
+        for incompatible in (
+            "requests",
+            "concurrent_requests",
+            "http2_requests",
+            "expect_exit",
+        ):
+            if case.get(incompatible):
+                fail(f"{owner}: expect_startup_failure cannot be combined with {incompatible}")
     if "skip" in case:
         validate_skip(owner, case["skip"])
     for key, value in case.items():
@@ -338,8 +419,8 @@ def stage_enabled(defaults: dict[str, bool], app: dict[str, object], stage: str)
     return value
 
 
-# TODO: Investigate the Roc compiler bug that makes the LLVM speed backend use
-# several GiB for form-url-encoded. Remove its per-app dev override once fixed.
+# TODO: Investigate the Roc compiler bugs that make the LLVM speed backend use
+# several GiB for some applications. Remove per-app dev overrides once fixed.
 def build_optimization(app: dict[str, object]) -> str:
     value = app.get("build_opt", "speed")
     assert isinstance(value, str) and value in BUILD_OPTIMIZATIONS
@@ -497,7 +578,30 @@ def prepare_memcheck_binaries(
     return binaries
 
 
-def readme_example(*, use_local_platform: bool = True) -> Path:
+def rewritten_app_source(app_path: str, platform_url: str | None) -> Path:
+    source_path = ROOT / app_path
+    if platform_url is None:
+        return source_path
+
+    source = source_path.read_text(encoding="utf-8")
+    rewritten, count = PLATFORM_DEPENDENCY.subn(
+        lambda match: f'{match.group(1)}"{platform_url}"',
+        source,
+        count=1,
+    )
+    if count != 1:
+        fail(f"{app_path}: expected exactly one platform dependency")
+
+    destination = VALIDATION_ROOT / "sources" / app_path
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    for sibling in source_path.parent.iterdir():
+        if sibling.is_file() and sibling.suffix != ".roc":
+            shutil.copy2(sibling, destination.parent / sibling.name)
+    destination.write_text(rewritten, encoding="utf-8", newline="\n")
+    return destination
+
+
+def readme_example(*, platform_url: str | None = None) -> Path:
     source = (ROOT / "README.md").read_text(encoding="utf-8")
     match = re.search(r"(?ms)^```roc\n(.*?)^```$", source)
     if match is None:
@@ -505,16 +609,14 @@ def readme_example(*, use_local_platform: bool = True) -> Path:
     directory = VALIDATION_ROOT / "readme"
     directory.mkdir(parents=True, exist_ok=True)
     rewritten = match.group(1)
-    if use_local_platform:
-        local_platform = os.path.relpath(
-            ROOT / "platform" / "main.roc", directory
-        ).replace(os.sep, "/")
-        rewritten = re.sub(
-            r'(?m)^(\s*pf:\s*platform\s+)"[^"]+"',
-            lambda dependency: f'{dependency.group(1)}"{local_platform}"',
+    if platform_url is not None:
+        rewritten, count = PLATFORM_DEPENDENCY.subn(
+            lambda dependency: f'{dependency.group(1)}"{platform_url}"',
             rewritten,
             count=1,
         )
+        if count != 1:
+            fail("README example check failed: expected one platform dependency")
     path = directory / "readme.roc"
     path.write_text(rewritten, encoding="utf-8", newline="\n")
     return path
@@ -1322,6 +1424,48 @@ def run_server_case(
             stderr = Capture(process.stderr)
             stdout.start()
             stderr.start()
+            if case.get("expect_startup_failure", False):
+                startup_error: BaseException | None = None
+                try:
+                    try:
+                        process.wait(timeout=timeout)
+                    except subprocess.TimeoutExpired:
+                        fail(f"{owner}: invalid startup configuration did not exit")
+                    expected_exit = int(case.get("exit_code", 1))
+                    if process.returncode != expected_exit:
+                        fail(
+                            f"{owner}: expected startup failure exit {expected_exit}, "
+                            f"got {process.returncode}"
+                        )
+                except BaseException as error:
+                    startup_error = error
+                finally:
+                    stop_process(process)
+                    stdout.thread.join(timeout=2)
+                    stderr.thread.join(timeout=2)
+
+                stdout_text = stdout.text()
+                stderr_text = stderr.text()
+                if LISTENING.search(stdout_text) is not None and startup_error is None:
+                    startup_error = TestFailure(f"{owner}: startup failure exposed a listener")
+                try:
+                    validate_memcheck_log(memcheck_log, owner)
+                except TestFailure as error:
+                    startup_error = error if startup_error is None else TestFailure(
+                        f"{startup_error}\n{error}"
+                    )
+                if startup_error is not None:
+                    fail(
+                        f"{owner}: startup-failure interaction failed: {startup_error}\n"
+                        f"process exit: {process.returncode}\n"
+                        f"--- stdout ---\n{stdout_text}"
+                        f"--- stderr ---\n{stderr_text}"
+                    )
+                assertion_text(owner, "stdout", stdout_text, case, "stdout_")
+                assertion_text(owner, "stderr", stderr_text, case, "stderr_")
+                assertion_text(owner, "combined output", stdout_text + stderr_text, case)
+                return
+
             interaction_error: BaseException | None = None
             try:
                 match = stdout.wait_for(LISTENING, process, timeout)
@@ -1681,7 +1825,7 @@ def validate_sources(
     defaults: dict[str, bool],
     apps: list[dict[str, object]],
     *,
-    use_local_readme_platform: bool = True,
+    platform_url: str | None,
 ) -> None:
     if VALIDATION_ROOT.exists():
         shutil.rmtree(VALIDATION_ROOT)
@@ -1692,14 +1836,14 @@ def validate_sources(
         for app in apps:
             if not stage_enabled(defaults, app, stage):
                 continue
-            source = ROOT / str(app["path"])
+            source = rewritten_app_source(str(app["path"]), platform_url)
             print(f"==> {stage} {app['path']}", flush=True)
             if stage == "fmt":
                 command(roc, "fmt", "--check", source)
             else:
                 command(roc, stage, source)
 
-    readme = readme_example(use_local_platform=use_local_readme_platform)
+    readme = readme_example(platform_url=platform_url)
     command(roc, "check", readme)
     command(roc, "test", readme)
 
@@ -1712,7 +1856,7 @@ def build_artifacts(
     apps: list[dict[str, object]],
     *,
     build_id: str = "local",
-    use_local_readme_platform: bool = True,
+    platform_url: str | None,
     examples_sha256: str | None = None,
 ) -> dict[str, Path]:
     prepare_artifact_output(target, artifact_dir)
@@ -1720,8 +1864,9 @@ def build_artifacts(
     for app in apps:
         if not stage_enabled(defaults, app, "build"):
             continue
-        source = ROOT / str(app["path"])
-        binary = output_path(source, target, artifact_dir)
+        app_path = str(app["path"])
+        source = rewritten_app_source(app_path, platform_url)
+        binary = output_path(ROOT / app_path, target, artifact_dir)
         print(f"==> build {app['path']} ({target})", flush=True)
         command(
             roc,
@@ -1733,7 +1878,7 @@ def build_artifacts(
         )
         binaries[str(app["path"])] = binary
 
-    readme = readme_example(use_local_platform=use_local_readme_platform)
+    readme = readme_example(platform_url=platform_url)
     command(
         roc,
         "build",
@@ -1772,10 +1917,13 @@ def main() -> None:
         help="stable identity of the machine that produced a binary artifact",
     )
     parser.add_argument(
-        "--readme-platform",
-        choices=("local", "declared"),
-        default="local",
-        help="use the checkout platform or preserve the README platform URL",
+        "--platform-dependency",
+        choices=("local-bundle", "declared"),
+        default="local-bundle",
+        help=(
+            "build and host this checkout's platform bundle, or use the URLs "
+            "already declared by the application sources"
+        ),
     )
     parser.add_argument(
         "--examples-sha256",
@@ -1798,7 +1946,7 @@ def main() -> None:
 
     defaults, apps = load_spec()
     artifact_dir = args.artifact_dir.resolve()
-    use_local_readme_platform = args.readme_platform == "local"
+    use_local_bundle = args.platform_dependency == "local-bundle"
 
     if args.operation == "memcheck":
         if args.target is not None or args.all_targets:
@@ -1817,16 +1965,22 @@ def main() -> None:
             parser.error("--all-targets requires --operation build")
         total = 0
         for build_target in declared_targets():
-            binaries = build_artifacts(
-                args.roc,
-                build_target,
-                artifact_dir,
-                defaults,
-                apps,
-                build_id=args.build_id,
-                use_local_readme_platform=use_local_readme_platform,
-                examples_sha256=args.examples_sha256,
+            dependency = (
+                locally_built_platform(args.roc, build_target)
+                if use_local_bundle
+                else contextlib.nullcontext(None)
             )
+            with dependency as platform_url:
+                binaries = build_artifacts(
+                    args.roc,
+                    build_target,
+                    artifact_dir,
+                    defaults,
+                    apps,
+                    build_id=args.build_id,
+                    platform_url=platform_url,
+                    examples_sha256=args.examples_sha256,
+                )
             total += len(binaries)
         print(
             f"\nBuilt {total} applications across "
@@ -1842,35 +1996,42 @@ def main() -> None:
             f"{detect_native_target()}"
         )
 
-    if args.operation in ("all", "validate"):
-        command(sys.executable, "-m", "unittest", "scripts.test_harness_test")
-        validate_sources(
-            args.roc,
-            defaults,
-            apps,
-            use_local_readme_platform=use_local_readme_platform,
-        )
-        if args.operation == "validate":
-            print(f"\nValidated {len(apps)} applications.")
-            return
+    compiles_sources = args.operation in ("all", "validate", "build")
+    dependency = (
+        locally_built_platform(args.roc, target)
+        if use_local_bundle and compiles_sources
+        else contextlib.nullcontext(None)
+    )
+    with dependency as platform_url:
+        if args.operation in ("all", "validate"):
+            command(sys.executable, "-m", "unittest", "scripts.test_harness_test")
+            validate_sources(
+                args.roc,
+                defaults,
+                apps,
+                platform_url=platform_url,
+            )
+            if args.operation == "validate":
+                print(f"\nValidated {len(apps)} applications.")
+                return
 
-    if args.operation in ("all", "build"):
-        binaries = build_artifacts(
-            args.roc,
-            target,
-            artifact_dir,
-            defaults,
-            apps,
-            build_id=args.build_id,
-            use_local_readme_platform=use_local_readme_platform,
-            examples_sha256=args.examples_sha256,
-        )
-        if args.operation == "build":
-            print(f"\nBuilt {len(binaries)} applications for {target}.")
-            return
-        builds = load_artifact_builds(target, artifact_dir, defaults, apps)
-    else:
-        builds = load_artifact_builds(target, artifact_dir, defaults, apps)
+        if args.operation in ("all", "build"):
+            binaries = build_artifacts(
+                args.roc,
+                target,
+                artifact_dir,
+                defaults,
+                apps,
+                build_id=args.build_id,
+                platform_url=platform_url,
+                examples_sha256=args.examples_sha256,
+            )
+            if args.operation == "build":
+                print(f"\nBuilt {len(binaries)} applications for {target}.")
+                return
+            builds = load_artifact_builds(target, artifact_dir, defaults, apps)
+        else:
+            builds = load_artifact_builds(target, artifact_dir, defaults, apps)
 
     total = 0
     failed_builds: list[tuple[str, str]] = []

--- a/scripts/test_bundle.py
+++ b/scripts/test_bundle.py
@@ -2,47 +2,17 @@
 from __future__ import annotations
 
 import argparse
-import functools
 import os
 import re
 import subprocess
 import sys
-import threading
-import urllib.request
-from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 from update_app_platform_urls import update_apps
-from test import declared_targets, examples_hash
+from test import BundleServer, declared_targets, examples_hash
 
 
 ROOT = Path(__file__).resolve().parents[1]
-
-
-class QuietHandler(SimpleHTTPRequestHandler):
-    def log_message(self, format: str, *args: object) -> None:
-        pass
-
-
-class BundleServer:
-    def __init__(self, bundle: Path) -> None:
-        handler = functools.partial(QuietHandler, directory=str(bundle.parent))
-        self.server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
-        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
-        self.url = f"http://127.0.0.1:{self.server.server_port}/{bundle.name}"
-
-    def __enter__(self) -> str:
-        self.thread.start()
-        with urllib.request.urlopen(
-            urllib.request.Request(self.url, method="HEAD"), timeout=5
-        ):
-            pass
-        return self.url
-
-    def __exit__(self, *_: object) -> None:
-        self.server.shutdown()
-        self.server.server_close()
-        self.thread.join()
 
 
 def update_readme(platform_url: str) -> None:
@@ -122,7 +92,7 @@ def main() -> None:
             command = [
                 sys.executable,
                 str(ROOT / "scripts" / "test.py"),
-                "--readme-platform",
+                "--platform-dependency",
                 "declared",
             ]
             if args.operation == "build-all":

--- a/scripts/test_harness_test.py
+++ b/scripts/test_harness_test.py
@@ -12,6 +12,43 @@ from scripts import test, update_app_platform_urls
 
 
 class SpecValidationTests(unittest.TestCase):
+    def test_local_bundle_rewrite_uses_a_copy(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory)
+            source = root / "examples" / "example.roc"
+            source.parent.mkdir()
+            original = 'app [main] { pf: platform "https://example.invalid/old" }\n'
+            source.write_text(original, encoding="utf-8")
+
+            with (
+                mock.patch.object(test, "ROOT", root),
+                mock.patch.object(test, "VALIDATION_ROOT", root / "target" / "spec"),
+            ):
+                rewritten = test.rewritten_app_source(
+                    "examples/example.roc",
+                    "http://127.0.0.1:1234/platform.tar.zst",
+                )
+
+            self.assertNotEqual(rewritten, source)
+            self.assertEqual(source.read_text(encoding="utf-8"), original)
+            self.assertIn(
+                'platform "http://127.0.0.1:1234/platform.tar.zst"',
+                rewritten.read_text(encoding="utf-8"),
+            )
+
+    def test_startup_failure_case_cannot_send_requests(self) -> None:
+        case = {
+            "name": "invalid-startup",
+            "expect_startup_failure": True,
+            "requests": [{"method": "GET", "target": "/"}],
+        }
+
+        with self.assertRaisesRegex(
+            test.TestFailure,
+            "expect_startup_failure cannot be combined with requests",
+        ):
+            test.validate_case("examples/health.roc", case, set())
+
     def test_http2_request_headers_use_prior_knowledge_hpack(self) -> None:
         block = test.hpack_request_headers(
             8000,

--- a/scripts/test_spec.json
+++ b/scripts/test_spec.json
@@ -195,6 +195,7 @@
     {
       "path": "examples/error-handling.roc",
       "mode": "server",
+      "build_opt": "dev",
       "cases": [
         {
           "name": "outbound-http",
@@ -443,8 +444,168 @@
       ]
     },
     {
+      "path": "examples/health.roc",
+      "mode": "server",
+      "cases": [
+        {
+          "name": "native-probes-and-readiness-transitions",
+          "requests": [
+            {
+              "target": "/live",
+              "response_headers": {
+                "Cache-Control": "no-store",
+                "Content-Type": "text/plain; charset=utf-8",
+                "Content-Length": "3"
+              },
+              "expect_body": "OK\n"
+            },
+            {
+              "method": "HEAD",
+              "target": "/live",
+              "response_headers": {
+                "Cache-Control": "no-store",
+                "Content-Type": "text/plain; charset=utf-8",
+                "Content-Length": "3"
+              },
+              "expect_body": ""
+            },
+            {
+              "target": "/ready",
+              "status": 503,
+              "response_headers": {
+                "Cache-Control": "no-store",
+                "Content-Length": "10"
+              },
+              "expect_body": "NOT READY\n"
+            },
+            {
+              "method": "HEAD",
+              "target": "/ready",
+              "status": 503,
+              "response_headers": {
+                "Content-Length": "10"
+              },
+              "expect_body": ""
+            },
+            {
+              "method": "POST",
+              "target": "/ready",
+              "status": 405,
+              "response_headers": {
+                "Allow": "GET, HEAD",
+                "Cache-Control": "no-store"
+              },
+              "expect_body": "Method Not Allowed\n"
+            },
+            {
+              "target": "/set-ready",
+              "expect_body": "ready"
+            },
+            {
+              "target": "/ready",
+              "expect_body": "OK\n"
+            },
+            {
+              "method": "HEAD",
+              "target": "/ready",
+              "response_headers": {
+                "Content-Length": "3"
+              },
+              "expect_body": ""
+            },
+            {
+              "target": "/set-not-ready",
+              "expect_body": "not ready"
+            },
+            {
+              "target": "/ready",
+              "status": 503,
+              "expect_body": "NOT READY\n"
+            }
+          ]
+        },
+        {
+          "name": "probes-bypass-saturated-handlers",
+          "timeout": 5,
+          "requests": [
+            {
+              "target": "/set-ready",
+              "expect_body": "ready"
+            }
+          ],
+          "concurrent_requests": [
+            {
+              "target": "/slow",
+              "expect_body": "slow response"
+            },
+            {
+              "target": "/slow",
+              "launch_after_ms": 100,
+              "expect_body": "slow response"
+            },
+            {
+              "target": "/slow",
+              "launch_after_ms": 100,
+              "status": 503,
+              "expect_body": "Server is overloaded"
+            },
+            {
+              "target": "/live",
+              "launch_after_ms": 100,
+              "expect_body": "OK\n"
+            },
+            {
+              "target": "/ready",
+              "expect_body": "OK\n"
+            }
+          ]
+        },
+        {
+          "name": "drain-forces-not-ready-before-shutdown-hook",
+          "requests": [
+            {
+              "target": "/set-ready",
+              "expect_body": "ready"
+            },
+            {
+              "target": "/stop",
+              "expect_body": "stopping"
+            }
+          ],
+          "expect_exit": true,
+          "exit_code": 0,
+          "stdout_contains": [
+            "shutdown readiness update: Err(ServerStopping)"
+          ]
+        },
+        {
+          "name": "duplicate-native-route-rejected-before-listen",
+          "env": {
+            "HEALTH_CONFIG": "duplicate"
+          },
+          "expect_startup_failure": true,
+          "exit_code": 1,
+          "stderr_contains": [
+            "Server startup configuration is invalid: duplicate exact native route \"/health\""
+          ]
+        },
+        {
+          "name": "invalid-native-route-rejected-before-listen",
+          "env": {
+            "HEALTH_CONFIG": "invalid"
+          },
+          "expect_startup_failure": true,
+          "exit_code": 1,
+          "stderr_contains": [
+            "Server startup configuration is invalid: invalid native route path \"/live?details=true\""
+          ]
+        }
+      ]
+    },
+    {
       "path": "examples/http.roc",
       "mode": "server",
+      "build_opt": "dev",
       "cases": [
         {
           "name": "outbound-http-effects",
@@ -596,6 +757,7 @@
     {
       "path": "examples/todos.roc",
       "mode": "server",
+      "build_opt": "dev",
       "cases": [
         {
           "name": "routes-and-database",

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -118,11 +118,20 @@ pub(crate) type HostIOErrTagType = IOErrTag;
 
 pub(crate) type ServerConfig = InitForHostOkConfig;
 pub(crate) type ServerFileRoot = InitForHostOkConfigFileRoots;
-pub(crate) type ServerNativeRoute = InitForHostOkConfigNativeRoutes;
+pub(crate) type ServerNativeFileRoute = InitForHostOkConfigNativeFileRoutes;
+pub(crate) type ServerReadinessRoute = InitForHostOkConfigReadinessRoutes;
 pub(crate) type ServerRequest = RespondForHostArg0;
 pub(crate) type ServerResponse = RespondForHost;
 pub(crate) type ServerHeader = RespondForHostArg0Headers;
 pub(crate) type ServerShutdownReason = ShutdownForHostArg0;
+
+pub(crate) type ReadinessCreateResult = HostReadinessCreateResult;
+pub(crate) type ReadinessCreateResultPayload = HostReadinessCreateResultPayload;
+pub(crate) type ReadinessCreateResultTag = HostReadinessCreateResultTag;
+pub(crate) type ReadinessSetResult = HostReadinessSetResult;
+pub(crate) type ReadinessSetResultPayload = HostReadinessSetResultPayload;
+pub(crate) type ReadinessSetResultTag = HostReadinessSetResultTag;
+pub(crate) type ReadinessSetError = HostReadinessSetErr;
 
 pub(crate) type BodyReadResult = HostRequestBodyReadResult;
 pub(crate) type BodyReadResultPayload = HostRequestBodyReadResultPayload;
@@ -163,6 +172,12 @@ pub(crate) fn initialize_roc_host() {
         .unwrap_or_else(|_| panic!("RocHost initialized more than once"));
 }
 
+#[cfg(test)]
+pub(crate) fn initialize_test_roc_host() {
+    static INITIALIZE: std::sync::Once = std::sync::Once::new();
+    INITIALIZE.call_once(initialize_roc_host);
+}
+
 fn roc_host_ptr() -> *mut RocHost {
     match ROC_HOST.get() {
         Some(host) => &host.0 as *const RocHost as *mut RocHost,
@@ -197,6 +212,7 @@ pub(crate) extern "C" fn routed_roc_dealloc(
         ("SQLite", crate::sqlite::route_resource_dealloc),
         ("file reader", crate::file::route_resource_dealloc),
         ("TCP stream", crate::tcp::route_resource_dealloc),
+        ("readiness", crate::readiness::route_resource_dealloc),
     ] {
         let route = route_resource(ptr);
         match route {
@@ -223,6 +239,7 @@ fn is_host_resource_address(ptr: *const c_void) -> bool {
         || crate::sqlite::contains_resource_address(ptr)
         || crate::file::contains_resource_address(ptr)
         || crate::tcp::contains_resource_address(ptr)
+        || crate::readiness::contains_resource_address(ptr)
 }
 
 pub(crate) extern "C" fn routed_roc_realloc(

--- a/src/file_server.rs
+++ b/src/file_server.rs
@@ -1,4 +1,4 @@
-//! Immutable native file routes and host-owned, bounded file responses.
+//! Host-owned, bounded file roots and responses.
 
 use crate::compression::{
     apply_content_coding, encoded_etag, response_is_compressible, vary_on_accept_encoding,
@@ -15,7 +15,7 @@ use hyper::header::{
     IF_UNMODIFIED_SINCE, LAST_MODIFIED, RANGE,
 };
 use hyper::{HeaderMap, Method, StatusCode};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -30,8 +30,6 @@ pub(crate) type ServerBody = UnsyncBoxBody<Bytes, io::Error>;
 pub(crate) type ServerResponse = hyper::Response<ServerBody>;
 
 const MAX_FILE_ROOTS: usize = 64;
-const MAX_NATIVE_ROUTES: usize = 128;
-const MAX_ROUTE_PATH_BYTES: usize = 4 * 1024;
 const MAX_RELATIVE_PATH_BYTES: usize = 4 * 1024;
 const MAX_DOWNLOAD_NAME_CHARS: usize = 150;
 
@@ -83,21 +81,6 @@ pub(crate) struct FileRootSpec {
     pub(crate) cache: CachePolicy,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum NativeRouteKind {
-    Prefix,
-    Exact,
-}
-
-#[derive(Debug)]
-pub(crate) struct NativeRouteSpec {
-    pub(crate) at: String,
-    pub(crate) root_id: String,
-    pub(crate) kind: NativeRouteKind,
-    pub(crate) relative: String,
-    pub(crate) cache: Option<CachePolicy>,
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum Disposition {
     Inline,
@@ -137,19 +120,8 @@ struct FileRoot {
 }
 
 #[derive(Clone, Debug)]
-struct NativeRoute {
-    at: String,
-    root_id: String,
-    kind: NativeRouteKind,
-    relative: String,
-    cache: Option<CachePolicy>,
-}
-
-#[derive(Clone, Debug)]
 pub(crate) struct FileService {
     roots: Arc<BTreeMap<String, Arc<FileRoot>>>,
-    exact_routes: Arc<BTreeMap<String, NativeRoute>>,
-    prefix_routes: Arc<Vec<NativeRoute>>,
     transfers: Arc<Semaphore>,
     chunk_bytes: usize,
     diagnostics: Arc<TransferDiagnostics>,
@@ -158,18 +130,12 @@ pub(crate) struct FileService {
 impl FileService {
     pub(crate) fn activate(
         root_specs: Vec<FileRootSpec>,
-        route_specs: Vec<NativeRouteSpec>,
         max_concurrent: usize,
         chunk_bytes: usize,
     ) -> Result<Self, String> {
         if root_specs.len() > MAX_FILE_ROOTS {
             return Err(format!(
                 "at most {MAX_FILE_ROOTS} file roots may be declared"
-            ));
-        }
-        if route_specs.len() > MAX_NATIVE_ROUTES {
-            return Err(format!(
-                "at most {MAX_NATIVE_ROUTES} native routes may be declared"
             ));
         }
         if max_concurrent == 0 {
@@ -207,88 +173,28 @@ impl FileService {
             );
         }
 
-        let mut exact_routes = BTreeMap::new();
-        let mut prefix_routes = Vec::new();
-        let mut prefix_paths = BTreeSet::new();
-        for spec in route_specs {
-            validate_route_path(&spec.at)?;
-            if !roots.contains_key(&spec.root_id) {
-                return Err(format!(
-                    "native route {:?} references undeclared file root {:?}",
-                    spec.at, spec.root_id
-                ));
-            }
-            if spec.kind == NativeRouteKind::Exact {
-                validate_relative_path(&spec.relative)?;
-            } else if !spec.relative.is_empty() {
-                return Err(format!(
-                    "static mount {:?} supplied an unexpected relative file",
-                    spec.at
-                ));
-            }
-            let route = NativeRoute {
-                at: spec.at.clone(),
-                root_id: spec.root_id,
-                kind: spec.kind,
-                relative: spec.relative,
-                cache: spec.cache,
-            };
-            match spec.kind {
-                NativeRouteKind::Exact => {
-                    if exact_routes.insert(spec.at.clone(), route).is_some() {
-                        return Err(format!("duplicate exact native route {:?}", spec.at));
-                    }
-                }
-                NativeRouteKind::Prefix => {
-                    if !prefix_paths.insert(spec.at.clone()) {
-                        return Err(format!("duplicate native route prefix {:?}", spec.at));
-                    }
-                    prefix_routes.push(route);
-                }
-            }
-        }
-        prefix_routes.sort_by(|left, right| {
-            right
-                .at
-                .len()
-                .cmp(&left.at.len())
-                .then_with(|| left.at.cmp(&right.at))
-        });
-
         Ok(Self {
             roots: Arc::new(roots),
-            exact_routes: Arc::new(exact_routes),
-            prefix_routes: Arc::new(prefix_routes),
             transfers: Arc::new(Semaphore::new(max_concurrent)),
             chunk_bytes,
             diagnostics: Arc::new(TransferDiagnostics::default()),
         })
     }
 
-    pub(crate) fn route(&self, uri_path: &str) -> Option<FilePlan> {
-        if let Some(route) = self.exact_routes.get(uri_path) {
-            return Some(route.plan(route.relative.clone(), false));
+    pub(crate) fn validate_native_route(
+        &self,
+        root_id: &str,
+        relative: Option<&str>,
+    ) -> Result<(), String> {
+        if !self.roots.contains_key(root_id) {
+            return Err(format!(
+                "native route references undeclared file root {root_id:?}"
+            ));
         }
-        for route in self.prefix_routes.iter() {
-            let relative = if route.at == "/" {
-                match uri_path.strip_prefix('/') {
-                    Some(relative) => relative,
-                    None => continue,
-                }
-            } else if uri_path == route.at {
-                ""
-            } else {
-                match uri_path
-                    .strip_prefix(&route.at)
-                    .and_then(|suffix| suffix.strip_prefix('/'))
-                {
-                    Some(relative) => relative,
-                    None => continue,
-                }
-            };
-            return Some(route.plan(relative.to_owned(), true));
+        if let Some(relative) = relative {
+            validate_relative_path(relative)?;
         }
-        None
+        Ok(())
     }
 
     pub(crate) async fn serve(
@@ -372,18 +278,19 @@ impl FileService {
     }
 }
 
-impl NativeRoute {
-    fn plan(&self, relative: String, encoded_uri_path: bool) -> FilePlan {
-        debug_assert!(
-            self.kind == NativeRouteKind::Prefix || !encoded_uri_path,
-            "only prefix routes derive paths from request URIs"
-        );
-        FilePlan {
-            root_id: self.root_id.clone(),
+impl FilePlan {
+    pub(crate) fn native(
+        root_id: String,
+        relative: String,
+        encoded_uri_path: bool,
+        cache: Option<CachePolicy>,
+    ) -> Self {
+        Self {
+            root_id,
             relative,
             encoded_uri_path,
             disposition: Disposition::Inline,
-            cache: self.cache,
+            cache,
         }
     }
 }
@@ -782,26 +689,6 @@ fn validate_root_id(id: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn validate_route_path(path: &str) -> Result<(), String> {
-    if !path.starts_with('/')
-        || path.len() > MAX_ROUTE_PATH_BYTES
-        || (path.len() > 1 && path.ends_with('/'))
-        || path.contains("//")
-        || !path.is_ascii()
-        || path
-            .bytes()
-            .any(|byte| byte == b'%' || byte == b'\\' || byte == 0 || byte == b'?')
-    {
-        return Err(format!("invalid native route path {path:?}"));
-    }
-    for segment in path.split('/').skip(1) {
-        if segment == "." || segment == ".." || segment.starts_with('.') {
-            return Err(format!("invalid native route path {path:?}"));
-        }
-    }
-    Ok(())
-}
-
 pub(crate) fn validate_relative_path(relative: &str) -> Result<Vec<String>, String> {
     if relative.is_empty() || relative.len() > MAX_RELATIVE_PATH_BYTES {
         return Err("relative file path is empty or too long".to_owned());
@@ -1176,60 +1063,7 @@ mod tests {
     use std::io::Read;
 
     #[test]
-    fn route_matching_has_segment_boundaries_and_precedence() {
-        let temp = tempfile_dir();
-        let service = FileService::activate(
-            vec![FileRootSpec {
-                id: "root".to_owned(),
-                path: temp.clone(),
-                cache: CachePolicy::Revalidate,
-            }],
-            vec![
-                NativeRouteSpec {
-                    at: "/assets".to_owned(),
-                    root_id: "root".to_owned(),
-                    kind: NativeRouteKind::Prefix,
-                    relative: String::new(),
-                    cache: None,
-                },
-                NativeRouteSpec {
-                    at: "/assets/special".to_owned(),
-                    root_id: "root".to_owned(),
-                    kind: NativeRouteKind::Exact,
-                    relative: "special.txt".to_owned(),
-                    cache: None,
-                },
-                NativeRouteSpec {
-                    at: "/assets/deep".to_owned(),
-                    root_id: "root".to_owned(),
-                    kind: NativeRouteKind::Prefix,
-                    relative: String::new(),
-                    cache: None,
-                },
-            ],
-            2,
-            1024,
-        )
-        .unwrap();
-
-        assert_eq!(
-            service.route("/assets/special").unwrap().relative,
-            "special.txt"
-        );
-        assert_eq!(
-            service.route("/assets/deep/file.txt").unwrap().relative,
-            "file.txt"
-        );
-        assert_eq!(
-            service.route("/assets/file.txt").unwrap().relative,
-            "file.txt"
-        );
-        assert!(service.route("/assets2/file.txt").is_none());
-        fs::remove_dir(temp).unwrap();
-    }
-
-    #[test]
-    fn route_activation_rejects_duplicates_and_missing_roots() {
+    fn root_activation_rejects_duplicates_and_missing_directories() {
         let temp = tempfile_dir();
         let duplicate_root = FileService::activate(
             vec![
@@ -1244,7 +1078,6 @@ mod tests {
                     cache: CachePolicy::NoStore,
                 },
             ],
-            Vec::new(),
             1,
             1,
         );
@@ -1258,54 +1091,10 @@ mod tests {
                 path: temp.join("does-not-exist"),
                 cache: CachePolicy::Revalidate,
             }],
-            Vec::new(),
             1,
             1,
         );
         assert!(absent.unwrap_err().contains("missing, inaccessible"));
-
-        let duplicate = FileService::activate(
-            vec![FileRootSpec {
-                id: "root".to_owned(),
-                path: temp.clone(),
-                cache: CachePolicy::Revalidate,
-            }],
-            vec![
-                NativeRouteSpec {
-                    at: "/assets".to_owned(),
-                    root_id: "root".to_owned(),
-                    kind: NativeRouteKind::Prefix,
-                    relative: String::new(),
-                    cache: None,
-                },
-                NativeRouteSpec {
-                    at: "/assets".to_owned(),
-                    root_id: "root".to_owned(),
-                    kind: NativeRouteKind::Prefix,
-                    relative: String::new(),
-                    cache: None,
-                },
-            ],
-            1,
-            1,
-        );
-        assert!(duplicate
-            .unwrap_err()
-            .contains("duplicate native route prefix"));
-
-        let missing = FileService::activate(
-            Vec::new(),
-            vec![NativeRouteSpec {
-                at: "/assets".to_owned(),
-                root_id: "missing".to_owned(),
-                kind: NativeRouteKind::Prefix,
-                relative: String::new(),
-                cache: None,
-            }],
-            1,
-            1,
-        );
-        assert!(missing.unwrap_err().contains("undeclared file root"));
         fs::remove_dir(temp).unwrap();
     }
 
@@ -1431,7 +1220,6 @@ mod tests {
                 path: root.clone(),
                 cache: CachePolicy::Revalidate,
             }],
-            Vec::new(),
             1,
             1024,
         )
@@ -1494,7 +1282,6 @@ mod tests {
                 path: root.clone(),
                 cache: CachePolicy::Revalidate,
             }],
-            Vec::new(),
             1,
             1024,
         )

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -1,17 +1,20 @@
 //! Tokio/Hyper server lifecycle and the provided Roc application entrypoints.
 
 use crate::abi::{
-    roc_host, ServerConfig, ServerFileRoot, ServerHeader, ServerNativeRoute, ServerRequest,
-    ServerResponse as RocServerResponse, ServerShutdownReason,
+    roc_host, ServerConfig, ServerFileRoot, ServerHeader, ServerNativeFileRoute,
+    ServerReadinessRoute, ServerRequest, ServerResponse as RocServerResponse, ServerShutdownReason,
 };
 use crate::compression::{
     apply_content_coding, encode_bytes, response_is_compressible, vary_on_accept_encoding,
     AcceptedEncodings, MAX_BUFFERED_COMPRESSION_BYTES,
 };
 use crate::file_server::{
-    full_body, CachePolicy, Disposition, FilePlan, FileRootSpec, FileService, NativeRouteKind,
-    NativeRouteSpec, ServerResponse,
+    full_body, CachePolicy, Disposition, FilePlan, FileRootSpec, FileService, ServerResponse,
 };
+use crate::native_router::{
+    FileRouteKind, FileRouteSpec, NativeMatch, NativeRouter, ReadinessRouteSpec,
+};
+use crate::readiness::ReadinessLease;
 use crate::request_body::{register as register_body, PumpError};
 use crate::request_parts::{request_target, RequestPartsBacking};
 use crate::roc_platform_abi::*;
@@ -46,6 +49,7 @@ struct RuntimeConfig {
     drain_timeout: Duration,
     hook_timeout: Duration,
     files: FileService,
+    routes: NativeRouter,
 }
 
 impl RuntimeConfig {
@@ -68,18 +72,31 @@ impl RuntimeConfig {
                 .iter()
                 .map(file_root_from_roc)
                 .collect::<Result<Vec<_>, _>>()?;
-            let routes = config
-                .native_routes
+            let file_routes = config
+                .native_file_routes
                 .as_slice()
                 .iter()
-                .map(native_route_from_roc)
+                .map(native_file_route_from_roc)
+                .collect::<Result<Vec<_>, _>>()?;
+            let liveness_routes = config
+                .liveness_routes
+                .as_slice()
+                .iter()
+                .map(|path| path.as_str().to_owned())
+                .collect();
+            let readiness_routes = config
+                .readiness_routes
+                .as_slice()
+                .iter()
+                .map(readiness_route_from_roc)
                 .collect::<Result<Vec<_>, _>>()?;
             let files = FileService::activate(
                 roots,
-                routes,
                 config.file_max_concurrent as usize,
                 config.file_chunk_bytes as usize,
             )?;
+            let routes =
+                NativeRouter::activate(&files, file_routes, liveness_routes, readiness_routes)?;
             Ok(Self {
                 host: config.host.as_str().to_owned(),
                 port: config.port,
@@ -92,6 +109,7 @@ impl RuntimeConfig {
                 drain_timeout: Duration::from_millis(config.drain_timeout_ms),
                 hook_timeout: Duration::from_millis(config.hook_timeout_ms),
                 files,
+                routes,
             })
         })();
         // SAFETY: every Roc-owned field in the ABI config is borrowed only
@@ -104,9 +122,11 @@ impl RuntimeConfig {
     fn max_http2_streams_per_connection(&self) -> u32 {
         // The Roc configuration fields are u16, so their sum always fits u32.
         // A stream still passes through the global handler admission gate; the
-        // HTTP/2 setting prevents one connection from creating more service
-        // futures than the complete active-plus-queued handler budget.
-        (self.max_handlers + self.max_queued_handlers)
+        // HTTP/2 setting prevents one connection from creating substantially
+        // more service futures than the complete active-plus-queued handler
+        // budget. Two bounded extra streams let liveness and readiness enter
+        // native routing while that handler budget is occupied.
+        (self.max_handlers + self.max_queued_handlers + 2)
             .max(1)
             .try_into()
             .expect("validated handler capacity fits in u32")
@@ -157,10 +177,10 @@ fn path_buf_from_file_root(root: &ServerFileRoot) -> Result<PathBuf, String> {
     }
 }
 
-fn native_route_from_roc(route: &ServerNativeRoute) -> Result<NativeRouteSpec, String> {
+fn native_file_route_from_roc(route: &ServerNativeFileRoute) -> Result<FileRouteSpec, String> {
     let kind = match route.kind {
-        0 => NativeRouteKind::Prefix,
-        1 => NativeRouteKind::Exact,
+        0 => FileRouteKind::Prefix,
+        1 => FileRouteKind::Exact,
         _ => return Err("invalid native route kind".to_owned()),
     };
     let cache = if route.cache_override {
@@ -173,12 +193,19 @@ fn native_route_from_roc(route: &ServerNativeRoute) -> Result<NativeRouteSpec, S
     } else {
         return Err("malformed native route cache override".to_owned());
     };
-    Ok(NativeRouteSpec {
+    Ok(FileRouteSpec {
         at: route.at.as_str().to_owned(),
         root_id: route.root_id.as_str().to_owned(),
         kind,
         relative: route.relative.as_str().to_owned(),
         cache,
+    })
+}
+
+fn readiness_route_from_roc(route: &ServerReadinessRoute) -> Result<ReadinessRouteSpec, String> {
+    Ok(ReadinessRouteSpec {
+        at: route.at.as_str().to_owned(),
+        readiness: ReadinessLease::retain(route.readiness)?,
     })
 }
 
@@ -299,6 +326,7 @@ fn start_inner() -> i32 {
     let config = match RuntimeConfig::from_roc(initialized.config) {
         Ok(config) => config,
         Err(detail) => {
+            eprintln!("Server startup configuration is invalid: {detail}");
             return finish_shutdown(
                 ShutdownReason::StartupFailed(detail),
                 raw_context,
@@ -704,14 +732,23 @@ async fn handle_req(
         None => return service_unavailable(),
     };
 
-    if let Some(plan) = context.config.files.route(request.uri().path()) {
+    if let Some(native) = context
+        .config
+        .routes
+        .route(request.uri().path(), request.method())
+    {
         let (parts, body) = request.into_parts();
         drop(body);
-        return context
-            .config
-            .files
-            .serve(plan, parts.method, parts.headers, active_request)
-            .await;
+        return match native {
+            NativeMatch::File(plan) => {
+                context
+                    .config
+                    .files
+                    .serve(plan, parts.method, parts.headers, active_request)
+                    .await
+            }
+            NativeMatch::Probe(response) => response,
+        };
     }
 
     if !request_headers_are_utf8(request.headers()) {
@@ -896,6 +933,7 @@ async fn run_server(context: ServerContext) -> ShutdownReason {
         }
     };
 
+    context.config.routes.begin_draining();
     context.requests.begin_draining();
     let drained = tokio::time::timeout(context.config.drain_timeout, async {
         context.requests.wait_for_idle().await;
@@ -989,8 +1027,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn initialize_test_host() {
-        static INITIALIZE: std::sync::Once = std::sync::Once::new();
-        INITIALIZE.call_once(crate::abi::initialize_roc_host);
+        crate::abi::initialize_test_roc_host();
     }
 
     fn no_compression() -> AcceptedEncodings {
@@ -1347,7 +1384,9 @@ mod tests {
     }
 
     #[test]
-    fn http2_stream_limit_matches_the_complete_handler_budget() {
+    fn http2_stream_limit_reserves_bounded_native_probe_headroom() {
+        let files = FileService::activate(Vec::new(), 1, 1024).unwrap();
+        let routes = NativeRouter::activate(&files, Vec::new(), Vec::new(), Vec::new()).unwrap();
         let config = RuntimeConfig {
             host: "127.0.0.1".to_owned(),
             port: 8000,
@@ -1359,9 +1398,10 @@ mod tests {
             body_buffered_chunks: 1,
             drain_timeout: Duration::from_secs(30),
             hook_timeout: Duration::from_secs(10),
-            files: FileService::activate(Vec::new(), Vec::new(), 1, 1024).unwrap(),
+            files,
+            routes,
         };
-        assert_eq!(config.max_http2_streams_per_connection(), 96);
+        assert_eq!(config.max_http2_streams_per_connection(), 98);
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,10 @@ mod host_resource;
 mod http;
 mod http_error;
 mod http_server;
+mod native_router;
 mod os_str;
 mod path;
+mod readiness;
 mod request_body;
 mod request_parts;
 mod roc_alloc;
@@ -47,18 +49,20 @@ pub fn rust_main() -> i32 {
         + tcp::active_resources()
         + request_parts::active_backings()
         + request_body::metrics().active_bodies
-        + request_body::metrics().active_backings;
+        + request_body::metrics().active_backings
+        + readiness::active_resources();
     if live_resources != 0 {
         eprintln!(
             "host resource lifecycle error: {live_resources} native resources remained after \
              shutdown (high-water marks: sqlite={}, file_readers={}, tcp_streams={}, \
-             request_backings={}, request_bodies={}, body_backings={})",
+             request_backings={}, request_bodies={}, body_backings={}, readiness={})",
             sqlite::resource_high_water(),
             file::resource_high_water(),
             tcp::resource_high_water(),
             request_parts::high_water(),
             request_body::metrics().body_high_water,
             request_body::metrics().backing_high_water,
+            readiness::resource_high_water(),
         );
         1
     } else {

--- a/src/native_router.rs
+++ b/src/native_router.rs
@@ -1,0 +1,499 @@
+//! One immutable, startup-validated route table for every host-native route.
+
+use crate::file_server::{
+    empty_body, full_body, CachePolicy, FilePlan, FileService, ServerResponse,
+};
+use crate::readiness::ReadinessLease;
+use bytes::Bytes;
+use hyper::header::{ALLOW, CACHE_CONTROL, CONTENT_LENGTH, CONTENT_TYPE};
+use hyper::{Method, StatusCode};
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+const MAX_NATIVE_ROUTES: usize = 128;
+const MAX_ROUTE_PATH_BYTES: usize = 4 * 1024;
+const PROBE_ALLOW: &str = "GET, HEAD";
+const PROBE_CONTENT_TYPE: &str = "text/plain; charset=utf-8";
+const PROBE_CACHE_CONTROL: &str = "no-store";
+const LIVE_BODY: &[u8] = b"OK\n";
+const READY_BODY: &[u8] = b"OK\n";
+const NOT_READY_BODY: &[u8] = b"NOT READY\n";
+const METHOD_NOT_ALLOWED_BODY: &[u8] = b"Method Not Allowed\n";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum FileRouteKind {
+    Prefix,
+    Exact,
+}
+
+#[derive(Debug)]
+pub(crate) struct FileRouteSpec {
+    pub(crate) at: String,
+    pub(crate) root_id: String,
+    pub(crate) kind: FileRouteKind,
+    pub(crate) relative: String,
+    pub(crate) cache: Option<CachePolicy>,
+}
+
+pub(crate) struct ReadinessRouteSpec {
+    pub(crate) at: String,
+    pub(crate) readiness: ReadinessLease,
+}
+
+enum ExactRoute {
+    File {
+        root_id: String,
+        relative: String,
+        cache: Option<CachePolicy>,
+    },
+    Liveness,
+    Readiness(ReadinessLease),
+}
+
+struct PrefixRoute {
+    at: String,
+    root_id: String,
+    cache: Option<CachePolicy>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProbeKind {
+    Liveness,
+    Readiness,
+}
+
+impl ProbeKind {
+    fn telemetry_label(self) -> &'static str {
+        match self {
+            Self::Liveness => "liveness",
+            Self::Readiness => "readiness",
+        }
+    }
+
+    fn suppress_success_log(self) -> bool {
+        true
+    }
+}
+
+#[derive(Default)]
+struct ProbeCounters {
+    liveness_requests: AtomicU64,
+    readiness_requests: AtomicU64,
+    ready_responses: AtomicU64,
+    not_ready_responses: AtomicU64,
+    method_not_allowed_responses: AtomicU64,
+}
+
+impl ProbeCounters {
+    fn record_request(&self, kind: ProbeKind) {
+        let counter = match kind {
+            ProbeKind::Liveness => &self.liveness_requests,
+            ProbeKind::Readiness => &self.readiness_requests,
+        };
+        saturating_increment(counter);
+    }
+
+    fn record_status(&self, status: StatusCode) {
+        let counter = match status {
+            StatusCode::OK => &self.ready_responses,
+            StatusCode::SERVICE_UNAVAILABLE => &self.not_ready_responses,
+            StatusCode::METHOD_NOT_ALLOWED => &self.method_not_allowed_responses,
+            _ => return,
+        };
+        saturating_increment(counter);
+    }
+}
+
+fn saturating_increment(counter: &AtomicU64) {
+    let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+        value.checked_add(1)
+    });
+}
+
+struct NativeRouterInner {
+    exact: BTreeMap<String, ExactRoute>,
+    prefixes: Vec<PrefixRoute>,
+    probes: ProbeCounters,
+}
+
+#[derive(Clone)]
+pub(crate) struct NativeRouter {
+    inner: Arc<NativeRouterInner>,
+}
+
+pub(crate) enum NativeMatch {
+    File(FilePlan),
+    Probe(ServerResponse),
+}
+
+impl NativeRouter {
+    pub(crate) fn activate(
+        files: &FileService,
+        file_specs: Vec<FileRouteSpec>,
+        liveness_paths: Vec<String>,
+        readiness_specs: Vec<ReadinessRouteSpec>,
+    ) -> Result<Self, String> {
+        let route_count = file_specs
+            .len()
+            .checked_add(liveness_paths.len())
+            .and_then(|count| count.checked_add(readiness_specs.len()))
+            .ok_or_else(|| "native route count overflowed".to_owned())?;
+        if route_count > MAX_NATIVE_ROUTES {
+            return Err(format!(
+                "at most {MAX_NATIVE_ROUTES} native routes may be declared"
+            ));
+        }
+
+        let mut exact = BTreeMap::new();
+        let mut prefixes = Vec::new();
+        let mut prefix_paths = BTreeSet::new();
+
+        for spec in file_specs {
+            validate_route_path(&spec.at)?;
+            let relative = (spec.kind == FileRouteKind::Exact).then_some(spec.relative.as_str());
+            if spec.kind == FileRouteKind::Prefix && !spec.relative.is_empty() {
+                return Err(format!(
+                    "static mount {:?} supplied an unexpected relative file",
+                    spec.at
+                ));
+            }
+            files
+                .validate_native_route(&spec.root_id, relative)
+                .map_err(|detail| format!("native route {:?} {detail}", spec.at))?;
+            match spec.kind {
+                FileRouteKind::Exact => insert_exact(
+                    &mut exact,
+                    spec.at,
+                    ExactRoute::File {
+                        root_id: spec.root_id,
+                        relative: spec.relative,
+                        cache: spec.cache,
+                    },
+                )?,
+                FileRouteKind::Prefix => {
+                    if !prefix_paths.insert(spec.at.clone()) {
+                        return Err(format!("duplicate native route prefix {:?}", spec.at));
+                    }
+                    prefixes.push(PrefixRoute {
+                        at: spec.at,
+                        root_id: spec.root_id,
+                        cache: spec.cache,
+                    });
+                }
+            }
+        }
+
+        for at in liveness_paths {
+            validate_route_path(&at)?;
+            insert_exact(&mut exact, at, ExactRoute::Liveness)?;
+        }
+        for spec in readiness_specs {
+            validate_route_path(&spec.at)?;
+            insert_exact(&mut exact, spec.at, ExactRoute::Readiness(spec.readiness))?;
+        }
+
+        prefixes.sort_by(|left, right| {
+            right
+                .at
+                .len()
+                .cmp(&left.at.len())
+                .then_with(|| left.at.cmp(&right.at))
+        });
+        Ok(Self {
+            inner: Arc::new(NativeRouterInner {
+                exact,
+                prefixes,
+                probes: ProbeCounters::default(),
+            }),
+        })
+    }
+
+    pub(crate) fn route(&self, uri_path: &str, method: &Method) -> Option<NativeMatch> {
+        if let Some(route) = self.inner.exact.get(uri_path) {
+            return Some(match route {
+                ExactRoute::File {
+                    root_id,
+                    relative,
+                    cache,
+                } => NativeMatch::File(FilePlan::native(
+                    root_id.clone(),
+                    relative.clone(),
+                    false,
+                    *cache,
+                )),
+                ExactRoute::Liveness => {
+                    NativeMatch::Probe(self.probe_response(ProbeKind::Liveness, true, method))
+                }
+                ExactRoute::Readiness(readiness) => NativeMatch::Probe(self.probe_response(
+                    ProbeKind::Readiness,
+                    readiness.is_ready(),
+                    method,
+                )),
+            });
+        }
+        for route in &self.inner.prefixes {
+            let relative = if route.at == "/" {
+                uri_path.strip_prefix('/')?
+            } else if uri_path == route.at {
+                ""
+            } else {
+                match uri_path
+                    .strip_prefix(&route.at)
+                    .and_then(|suffix| suffix.strip_prefix('/'))
+                {
+                    Some(relative) => relative,
+                    None => continue,
+                }
+            };
+            return Some(NativeMatch::File(FilePlan::native(
+                route.root_id.clone(),
+                relative.to_owned(),
+                true,
+                route.cache,
+            )));
+        }
+        None
+    }
+
+    pub(crate) fn begin_draining(&self) {
+        for route in self.inner.exact.values() {
+            if let ExactRoute::Readiness(readiness) = route {
+                readiness.begin_stopping();
+            }
+        }
+    }
+
+    fn probe_response(&self, kind: ProbeKind, available: bool, method: &Method) -> ServerResponse {
+        self.inner.probes.record_request(kind);
+        debug_assert!(!kind.telemetry_label().is_empty());
+        debug_assert!(kind.suppress_success_log());
+        let (status, body) = if method != Method::GET && method != Method::HEAD {
+            (StatusCode::METHOD_NOT_ALLOWED, METHOD_NOT_ALLOWED_BODY)
+        } else if available {
+            (
+                StatusCode::OK,
+                if kind == ProbeKind::Liveness {
+                    LIVE_BODY
+                } else {
+                    READY_BODY
+                },
+            )
+        } else {
+            (StatusCode::SERVICE_UNAVAILABLE, NOT_READY_BODY)
+        };
+        self.inner.probes.record_status(status);
+
+        let mut response = hyper::Response::new(if method == Method::HEAD {
+            empty_body()
+        } else {
+            full_body(Bytes::from_static(body))
+        });
+        *response.status_mut() = status;
+        let headers = response.headers_mut();
+        headers.insert(
+            CACHE_CONTROL,
+            hyper::header::HeaderValue::from_static(PROBE_CACHE_CONTROL),
+        );
+        headers.insert(
+            CONTENT_TYPE,
+            hyper::header::HeaderValue::from_static(PROBE_CONTENT_TYPE),
+        );
+        headers.insert(
+            CONTENT_LENGTH,
+            hyper::header::HeaderValue::from_str(&body.len().to_string())
+                .expect("fixed probe body length is a valid header"),
+        );
+        if status == StatusCode::METHOD_NOT_ALLOWED {
+            headers.insert(ALLOW, hyper::header::HeaderValue::from_static(PROBE_ALLOW));
+        }
+        response
+    }
+
+    #[cfg(test)]
+    fn probe_metrics(&self) -> ProbeMetrics {
+        ProbeMetrics {
+            liveness_requests: self.inner.probes.liveness_requests.load(Ordering::Relaxed),
+            readiness_requests: self.inner.probes.readiness_requests.load(Ordering::Relaxed),
+            ready_responses: self.inner.probes.ready_responses.load(Ordering::Relaxed),
+            not_ready_responses: self
+                .inner
+                .probes
+                .not_ready_responses
+                .load(Ordering::Relaxed),
+            method_not_allowed_responses: self
+                .inner
+                .probes
+                .method_not_allowed_responses
+                .load(Ordering::Relaxed),
+        }
+    }
+}
+
+fn insert_exact(
+    routes: &mut BTreeMap<String, ExactRoute>,
+    at: String,
+    route: ExactRoute,
+) -> Result<(), String> {
+    if routes.insert(at.clone(), route).is_some() {
+        Err(format!("duplicate exact native route {at:?}"))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_route_path(path: &str) -> Result<(), String> {
+    if !path.starts_with('/')
+        || path.len() > MAX_ROUTE_PATH_BYTES
+        || (path.len() > 1 && path.ends_with('/'))
+        || path.contains("//")
+        || !path.is_ascii()
+        || path
+            .bytes()
+            .any(|byte| byte == b'%' || byte == b'\\' || byte == 0 || byte == b'?')
+    {
+        return Err(format!("invalid native route path {path:?}"));
+    }
+    for segment in path.split('/').skip(1) {
+        if segment == "." || segment == ".." || segment.starts_with('.') {
+            return Err(format!("invalid native route path {path:?}"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[derive(Debug, Eq, PartialEq)]
+struct ProbeMetrics {
+    liveness_requests: u64,
+    readiness_requests: u64,
+    ready_responses: u64,
+    not_ready_responses: u64,
+    method_not_allowed_responses: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_body_util::BodyExt;
+
+    fn empty_files() -> FileService {
+        FileService::activate(Vec::new(), 1, 1024).unwrap()
+    }
+
+    #[test]
+    fn route_paths_and_cross_type_duplicates_are_validated_together() {
+        let files = empty_files();
+        let duplicate = NativeRouter::activate(
+            &files,
+            Vec::new(),
+            vec!["/health".to_owned()],
+            vec![ReadinessRouteSpec {
+                at: "/health".to_owned(),
+                readiness: crate::readiness::test_lease(false),
+            }],
+        )
+        .err()
+        .unwrap();
+        assert!(duplicate.contains("duplicate exact native route"));
+
+        for invalid in [
+            "health",
+            "/health/",
+            "/health?detail=1",
+            "/.health",
+            "/h%65alth",
+        ] {
+            assert!(NativeRouter::activate(
+                &files,
+                Vec::new(),
+                vec![invalid.to_owned()],
+                Vec::new(),
+            )
+            .is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn probes_have_fixed_responses_methods_and_metrics() {
+        let files = empty_files();
+        let router = NativeRouter::activate(
+            &files,
+            Vec::new(),
+            vec!["/live".to_owned()],
+            vec![ReadinessRouteSpec {
+                at: "/ready".to_owned(),
+                readiness: crate::readiness::test_lease(false),
+            }],
+        )
+        .unwrap();
+
+        let NativeMatch::Probe(live) = router.route("/live", &Method::HEAD).unwrap() else {
+            panic!("liveness route was not a probe");
+        };
+        assert_eq!(live.status(), StatusCode::OK);
+        assert_eq!(live.headers()[CACHE_CONTROL], PROBE_CACHE_CONTROL);
+        assert_eq!(live.headers()[CONTENT_LENGTH], LIVE_BODY.len().to_string());
+        assert!(live
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes()
+            .is_empty());
+
+        let NativeMatch::Probe(not_ready) = router.route("/ready", &Method::GET).unwrap() else {
+            panic!("readiness route was not a probe");
+        };
+        assert_eq!(not_ready.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            not_ready.into_body().collect().await.unwrap().to_bytes(),
+            NOT_READY_BODY
+        );
+
+        let NativeMatch::Probe(disallowed) = router.route("/ready", &Method::POST).unwrap() else {
+            panic!("readiness route was not a probe");
+        };
+        assert_eq!(disallowed.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(disallowed.headers()[ALLOW], PROBE_ALLOW);
+        assert_eq!(
+            router.probe_metrics(),
+            ProbeMetrics {
+                liveness_requests: 1,
+                readiness_requests: 2,
+                ready_responses: 1,
+                not_ready_responses: 1,
+                method_not_allowed_responses: 1,
+            }
+        );
+        assert_eq!(ProbeKind::Liveness.telemetry_label(), "liveness");
+        assert_eq!(ProbeKind::Readiness.telemetry_label(), "readiness");
+        assert!(ProbeKind::Liveness.suppress_success_log());
+        assert!(ProbeKind::Readiness.suppress_success_log());
+    }
+
+    #[test]
+    fn draining_forces_every_readiness_route_not_ready() {
+        let files = empty_files();
+        let lease = crate::readiness::test_lease(true);
+        let router = NativeRouter::activate(
+            &files,
+            Vec::new(),
+            Vec::new(),
+            vec![ReadinessRouteSpec {
+                at: "/ready".to_owned(),
+                readiness: lease,
+            }],
+        )
+        .unwrap();
+        let NativeMatch::Probe(before) = router.route("/ready", &Method::GET).unwrap() else {
+            panic!("readiness route was not a probe");
+        };
+        assert_eq!(before.status(), StatusCode::OK);
+        router.begin_draining();
+        let NativeMatch::Probe(after) = router.route("/ready", &Method::GET).unwrap() else {
+            panic!("readiness route was not a probe");
+        };
+        assert_eq!(after.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+}

--- a/src/readiness.rs
+++ b/src/readiness.rs
@@ -1,0 +1,320 @@
+//! Bounded, ARC-owned host readiness gates.
+
+use core::ffi::c_void;
+use core::mem::ManuallyDrop;
+use core::sync::atomic::{AtomicU8, Ordering};
+use std::sync::OnceLock;
+
+use crate::abi::{
+    roc_host, ReadinessCreateResult, ReadinessCreateResultPayload, ReadinessCreateResultTag,
+    ReadinessSetError, ReadinessSetResult, ReadinessSetResultPayload, ReadinessSetResultTag,
+};
+use crate::host_resource::{DeallocRoute, HostResourceHeap, LookupError, ReserveError};
+use crate::roc_platform_abi::{decref_box, incref_box, RocBox};
+
+const MAX_READINESS_GATES: usize = 64;
+const NOT_READY: u8 = 0;
+const READY: u8 = 1;
+const STOPPING: u8 = 2;
+
+struct ReadinessGate {
+    state: AtomicU8,
+}
+
+impl ReadinessGate {
+    fn new(ready: bool) -> Self {
+        Self {
+            state: AtomicU8::new(if ready { READY } else { NOT_READY }),
+        }
+    }
+
+    fn is_ready(&self) -> bool {
+        self.state.load(Ordering::Acquire) == READY
+    }
+
+    fn set(&self, ready: bool) -> Result<(), ReadinessSetError> {
+        let desired = if ready { READY } else { NOT_READY };
+        self.state
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                (current != STOPPING).then_some(desired)
+            })
+            .map(|_| ())
+            .map_err(|_| ReadinessSetError::ServerStopping)
+    }
+
+    fn begin_stopping(&self) {
+        self.state.store(STOPPING, Ordering::Release);
+    }
+}
+
+static READINESS_GATES: OnceLock<HostResourceHeap<ReadinessGate>> = OnceLock::new();
+
+fn readiness_gates() -> &'static HostResourceHeap<ReadinessGate> {
+    READINESS_GATES.get_or_init(|| HostResourceHeap::new(MAX_READINESS_GATES))
+}
+
+unsafe fn gate_ref(handle: *mut u64) -> Result<&'static ReadinessGate, LookupError> {
+    unsafe { readiness_gates().get(handle) }
+}
+
+fn set_handle(handle: *mut u64, ready: bool) -> Result<(), ReadinessSetError> {
+    match unsafe { gate_ref(handle) } {
+        Ok(gate) => gate.set(ready),
+        Err(LookupError::Invalid) => Err(ReadinessSetError::InvalidReadiness),
+        Err(LookupError::Stale) => Err(ReadinessSetError::StaleReadiness),
+    }
+}
+
+/// An owned host reference retained by an activated readiness route.
+///
+/// The application's context normally owns another reference. Keeping this
+/// route reference makes the native route independent of context record shape
+/// and keeps the gate alive through the final shutdown hook.
+pub(crate) struct ReadinessLease {
+    handle: *mut u64,
+}
+
+impl ReadinessLease {
+    pub(crate) fn retain(handle: *mut u64) -> Result<Self, String> {
+        match unsafe { gate_ref(handle) } {
+            Ok(_) => {
+                unsafe { incref_box(handle as RocBox, 1) };
+                Ok(Self { handle })
+            }
+            Err(LookupError::Invalid) => {
+                Err("readiness route references an invalid capability".to_owned())
+            }
+            Err(LookupError::Stale) => {
+                Err("readiness route references a stale capability".to_owned())
+            }
+        }
+    }
+
+    pub(crate) fn is_ready(&self) -> bool {
+        unsafe { gate_ref(self.handle) }.is_ok_and(ReadinessGate::is_ready)
+    }
+
+    pub(crate) fn begin_stopping(&self) {
+        if let Ok(gate) = unsafe { gate_ref(self.handle) } {
+            gate.begin_stopping();
+        }
+    }
+}
+
+// SAFETY: the lease owns a stable host-resource slot, and all mutable gate
+// state is atomic.
+unsafe impl Send for ReadinessLease {}
+unsafe impl Sync for ReadinessLease {}
+
+impl Drop for ReadinessLease {
+    fn drop(&mut self) {
+        unsafe { decref_box(self.handle as RocBox, roc_host()) };
+    }
+}
+
+fn create_ok(handle: *mut u64) -> ReadinessCreateResult {
+    #[cfg(target_pointer_width = "32")]
+    unsafe {
+        let mut result: ReadinessCreateResult = core::mem::zeroed();
+        core::ptr::write(result.payload.as_mut_ptr().cast::<*mut u64>(), handle);
+        result.tag = ReadinessCreateResultTag::Ok;
+        result
+    }
+    #[cfg(not(target_pointer_width = "32"))]
+    {
+        ReadinessCreateResult {
+            payload: ReadinessCreateResultPayload {
+                ok: ManuallyDrop::new(handle),
+            },
+            tag: ReadinessCreateResultTag::Ok,
+        }
+    }
+}
+
+fn create_err() -> ReadinessCreateResult {
+    #[cfg(target_pointer_width = "32")]
+    {
+        ReadinessCreateResult {
+            _payload_alignment: [],
+            payload: [0; 4],
+            tag: ReadinessCreateResultTag::Err,
+        }
+    }
+    #[cfg(not(target_pointer_width = "32"))]
+    {
+        ReadinessCreateResult {
+            payload: ReadinessCreateResultPayload { err: [] },
+            tag: ReadinessCreateResultTag::Err,
+        }
+    }
+}
+
+fn set_ok() -> ReadinessSetResult {
+    #[cfg(target_pointer_width = "32")]
+    {
+        ReadinessSetResult {
+            _payload_alignment: [],
+            payload: [0],
+            tag: ReadinessSetResultTag::Ok,
+        }
+    }
+    #[cfg(not(target_pointer_width = "32"))]
+    {
+        ReadinessSetResult {
+            payload: ReadinessSetResultPayload { ok: [] },
+            tag: ReadinessSetResultTag::Ok,
+        }
+    }
+}
+
+fn set_err(error: ReadinessSetError) -> ReadinessSetResult {
+    #[cfg(target_pointer_width = "32")]
+    unsafe {
+        let mut result: ReadinessSetResult = core::mem::zeroed();
+        core::ptr::write(
+            result.payload.as_mut_ptr().cast::<ReadinessSetError>(),
+            error,
+        );
+        result.tag = ReadinessSetResultTag::Err;
+        result
+    }
+    #[cfg(not(target_pointer_width = "32"))]
+    {
+        ReadinessSetResult {
+            payload: ReadinessSetResultPayload {
+                err: ManuallyDrop::new(error),
+            },
+            tag: ReadinessSetResultTag::Err,
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn hosted_readiness_create(initially_ready: bool) -> ReadinessCreateResult {
+    match readiness_gates().reserve() {
+        Ok(reservation) => create_ok(reservation.insert(ReadinessGate::new(initially_ready))),
+        Err(ReserveError::Capacity) => create_err(),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn hosted_readiness_set(handle: *mut u64, ready: bool) -> ReadinessSetResult {
+    let result = set_handle(handle, ready);
+    // SAFETY: hosted arguments transfer one owned Roc reference.
+    unsafe { decref_box(handle as RocBox, roc_host()) };
+    match result {
+        Ok(()) => set_ok(),
+        Err(error) => set_err(error),
+    }
+}
+
+pub(crate) fn route_resource_dealloc(ptr: *mut c_void) -> DeallocRoute {
+    READINESS_GATES
+        .get()
+        .map_or(DeallocRoute::NotOwned, |heap| heap.route_dealloc(ptr))
+}
+
+pub(crate) fn contains_resource_address(ptr: *const c_void) -> bool {
+    READINESS_GATES
+        .get()
+        .is_some_and(|heap| heap.contains_address(ptr))
+}
+
+pub(crate) fn active_resources() -> usize {
+    READINESS_GATES.get().map_or(0, HostResourceHeap::active)
+}
+
+pub(crate) fn resource_high_water() -> usize {
+    READINESS_GATES
+        .get()
+        .map_or(0, HostResourceHeap::high_water)
+}
+
+#[cfg(test)]
+pub(crate) fn test_lease(ready: bool) -> ReadinessLease {
+    crate::abi::initialize_test_roc_host();
+    let handle = readiness_gates()
+        .reserve()
+        .unwrap()
+        .insert(ReadinessGate::new(ready));
+    let lease = ReadinessLease::retain(handle).unwrap();
+    unsafe { decref_box(handle as RocBox, roc_host()) };
+    lease
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn release(handle: *mut u64) {
+        unsafe { decref_box(handle as RocBox, roc_host()) };
+    }
+
+    #[test]
+    fn concurrent_reads_and_writes_are_atomic() {
+        crate::abi::initialize_test_roc_host();
+        let handle = readiness_gates()
+            .reserve()
+            .unwrap()
+            .insert(ReadinessGate::new(false));
+        let lease = ReadinessLease::retain(handle).unwrap();
+        let address = handle as usize;
+        let workers = (0..8)
+            .map(|worker| {
+                std::thread::spawn(move || {
+                    let handle = address as *mut u64;
+                    for iteration in 0..10_000 {
+                        set_handle(handle, (worker + iteration) % 2 == 0).unwrap();
+                        let state = unsafe { gate_ref(handle) }
+                            .unwrap()
+                            .state
+                            .load(Ordering::Acquire);
+                        assert!(state == READY || state == NOT_READY);
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        for worker in workers {
+            worker.join().unwrap();
+        }
+        drop(lease);
+        release(handle);
+    }
+
+    #[test]
+    fn drain_is_terminal_and_forces_not_ready() {
+        crate::abi::initialize_test_roc_host();
+        let handle = readiness_gates()
+            .reserve()
+            .unwrap()
+            .insert(ReadinessGate::new(true));
+        let lease = ReadinessLease::retain(handle).unwrap();
+        assert!(lease.is_ready());
+        lease.begin_stopping();
+        assert!(!lease.is_ready());
+        assert_eq!(
+            set_handle(handle, true),
+            Err(ReadinessSetError::ServerStopping)
+        );
+        drop(lease);
+        release(handle);
+    }
+
+    #[test]
+    fn invalid_and_stale_handles_are_distinct() {
+        crate::abi::initialize_test_roc_host();
+        assert_eq!(
+            set_handle(core::ptr::null_mut(), true),
+            Err(ReadinessSetError::InvalidReadiness)
+        );
+        let handle = readiness_gates()
+            .reserve()
+            .unwrap()
+            .insert(ReadinessGate::new(false));
+        release(handle);
+        assert_eq!(
+            set_handle(handle, true),
+            Err(ReadinessSetError::StaleReadiness)
+        );
+    }
+}

--- a/src/roc_platform_abi.rs
+++ b/src/roc_platform_abi.rs
@@ -1320,44 +1320,46 @@ const _: () = assert!(core::mem::size_of::<AnonStruct1f12a65955b54fe1>() == 12, 
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(core::mem::align_of::<AnonStruct1f12a65955b54fe1>() == 4, "AnonStruct1f12a65955b54fe1 alignment mismatch");
 
-/// Element type for __AnonStruct_9d4feaaa75529fdc
+/// Element type for __AnonStruct_c9d7cf274e6253
 #[cfg(target_pointer_width = "32")]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStruct9d4feaaa75529fdc {
-    pub config: AnonStructAeeb7f2cfe80f10,
+pub struct AnonStructC9d7cf274e6253 {
+    pub config: AnonStruct5544d9f4d7da9aed,
     pub context: RocBox,
 }
 
-/// Element type for __AnonStruct_9d4feaaa75529fdc
+/// Element type for __AnonStruct_c9d7cf274e6253
 #[cfg(not(target_pointer_width = "32"))]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStruct9d4feaaa75529fdc {
-    pub config: AnonStructAeeb7f2cfe80f10,
+pub struct AnonStructC9d7cf274e6253 {
+    pub config: AnonStruct5544d9f4d7da9aed,
     pub context: RocBox,
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<AnonStruct9d4feaaa75529fdc>() == 128, "AnonStruct9d4feaaa75529fdc size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStructC9d7cf274e6253>() == 176, "AnonStructC9d7cf274e6253 size mismatch");
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::align_of::<AnonStruct9d4feaaa75529fdc>() == 8, "AnonStruct9d4feaaa75529fdc alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStructC9d7cf274e6253>() == 8, "AnonStructC9d7cf274e6253 alignment mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::size_of::<AnonStruct9d4feaaa75529fdc>() == 96, "AnonStruct9d4feaaa75529fdc size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStructC9d7cf274e6253>() == 120, "AnonStructC9d7cf274e6253 size mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::align_of::<AnonStruct9d4feaaa75529fdc>() == 8, "AnonStruct9d4feaaa75529fdc alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStructC9d7cf274e6253>() == 8, "AnonStructC9d7cf274e6253 alignment mismatch");
 
-/// Element type for __AnonStruct_aeeb7f2cfe80f10
+/// Element type for __AnonStruct_5544d9f4d7da9aed
 #[cfg(target_pointer_width = "32")]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStructAeeb7f2cfe80f10 {
+pub struct AnonStruct5544d9f4d7da9aed {
     pub body_max_bytes: u64,
     pub drain_timeout_ms: u64,
     pub hook_timeout_ms: u64,
     pub file_roots: RocList<AnonStruct3b01e35488cb00dc>,
     pub host: RocStr,
-    pub native_routes: RocList<AnonStructFf6f93028827ced0>,
+    pub liveness_routes: RocList<RocStr>,
+    pub native_file_routes: RocList<AnonStructFf6f93028827ced0>,
+    pub readiness_routes: RocList<AnonStruct88f5430c7a4d7d9d>,
     pub body_chunk_bytes: u32,
     pub file_chunk_bytes: u32,
     pub max_connections: u32,
@@ -1368,17 +1370,19 @@ pub struct AnonStructAeeb7f2cfe80f10 {
     pub port: u16,
 }
 
-/// Element type for __AnonStruct_aeeb7f2cfe80f10
+/// Element type for __AnonStruct_5544d9f4d7da9aed
 #[cfg(not(target_pointer_width = "32"))]
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct AnonStructAeeb7f2cfe80f10 {
+pub struct AnonStruct5544d9f4d7da9aed {
     pub body_max_bytes: u64,
     pub drain_timeout_ms: u64,
     pub hook_timeout_ms: u64,
     pub file_roots: RocList<AnonStruct3b01e35488cb00dc>,
     pub host: RocStr,
-    pub native_routes: RocList<AnonStructFf6f93028827ced0>,
+    pub liveness_routes: RocList<RocStr>,
+    pub native_file_routes: RocList<AnonStructFf6f93028827ced0>,
+    pub readiness_routes: RocList<AnonStruct88f5430c7a4d7d9d>,
     pub body_chunk_bytes: u32,
     pub file_chunk_bytes: u32,
     pub max_connections: u32,
@@ -1390,13 +1394,13 @@ pub struct AnonStructAeeb7f2cfe80f10 {
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<AnonStructAeeb7f2cfe80f10>() == 120, "AnonStructAeeb7f2cfe80f10 size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStruct5544d9f4d7da9aed>() == 168, "AnonStruct5544d9f4d7da9aed size mismatch");
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::align_of::<AnonStructAeeb7f2cfe80f10>() == 8, "AnonStructAeeb7f2cfe80f10 alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStruct5544d9f4d7da9aed>() == 8, "AnonStruct5544d9f4d7da9aed alignment mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::size_of::<AnonStructAeeb7f2cfe80f10>() == 88, "AnonStructAeeb7f2cfe80f10 size mismatch");
+const _: () = assert!(core::mem::size_of::<AnonStruct5544d9f4d7da9aed>() == 112, "AnonStruct5544d9f4d7da9aed size mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::align_of::<AnonStructAeeb7f2cfe80f10>() == 8, "AnonStructAeeb7f2cfe80f10 alignment mismatch");
+const _: () = assert!(core::mem::align_of::<AnonStruct5544d9f4d7da9aed>() == 8, "AnonStruct5544d9f4d7da9aed alignment mismatch");
 
 /// Element type for __AnonStruct_3b01e35488cb00dc
 #[cfg(target_pointer_width = "32")]
@@ -1471,6 +1475,33 @@ const _: () = assert!(core::mem::align_of::<AnonStructFf6f93028827ced0>() == 8, 
 const _: () = assert!(core::mem::size_of::<AnonStructFf6f93028827ced0>() == 44, "AnonStructFf6f93028827ced0 size mismatch");
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(core::mem::align_of::<AnonStructFf6f93028827ced0>() == 4, "AnonStructFf6f93028827ced0 alignment mismatch");
+
+/// Element type for __AnonStruct_88f5430c7a4d7d9d
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AnonStruct88f5430c7a4d7d9d {
+    pub at: RocStr,
+    pub readiness: *mut u64,
+}
+
+/// Element type for __AnonStruct_88f5430c7a4d7d9d
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AnonStruct88f5430c7a4d7d9d {
+    pub at: RocStr,
+    pub readiness: *mut u64,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<AnonStruct88f5430c7a4d7d9d>() == 32, "AnonStruct88f5430c7a4d7d9d size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<AnonStruct88f5430c7a4d7d9d>() == 8, "AnonStruct88f5430c7a4d7d9d alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<AnonStruct88f5430c7a4d7d9d>() == 16, "AnonStruct88f5430c7a4d7d9d size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<AnonStruct88f5430c7a4d7d9d>() == 4, "AnonStruct88f5430c7a4d7d9d alignment mismatch");
 
 /// Element type for __AnonStruct_9bfbda88f35e6056
 #[cfg(target_pointer_width = "32")]
@@ -3798,6 +3829,154 @@ const _: () = assert!(core::mem::offset_of!(HostRequestBodyReadAllResult, tag) =
 /// Tag discriminant for Try.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostReadinessCreateResultTag {
+    Err = 0,
+    Ok = 1,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union HostReadinessCreateResultPayload {
+    pub err: [u8; 0],
+    pub ok: core::mem::ManuallyDrop<*mut u64>,
+}
+
+#[cfg(target_pointer_width = "32")]
+#[repr(align(4))]
+#[derive(Clone, Copy)]
+pub struct HostReadinessCreateResultPayloadAlignment;
+
+/// Tag union: Try
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostReadinessCreateResult {
+    pub _payload_alignment: [HostReadinessCreateResultPayloadAlignment; 0],
+    pub payload: [u8; 4],
+    pub tag: HostReadinessCreateResultTag,
+}
+
+/// Tag union: Try
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostReadinessCreateResult {
+    pub payload: HostReadinessCreateResultPayload,
+    pub tag: HostReadinessCreateResultTag,
+}
+
+impl HostReadinessCreateResult {
+    #[cfg(target_pointer_width = "32")]
+    pub fn payload_ok(&self) -> *mut u64 {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const *mut u64) }
+    }
+
+    #[cfg(not(target_pointer_width = "32"))]
+    pub fn payload_ok(&self) -> *mut u64 {
+        unsafe { core::mem::ManuallyDrop::into_inner(self.payload.ok) }
+    }
+
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<HostReadinessCreateResult>() == 16, "HostReadinessCreateResult size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<HostReadinessCreateResult>() == 8, "HostReadinessCreateResult alignment mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::offset_of!(HostReadinessCreateResult, tag) == 8, "HostReadinessCreateResult tag offset mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<HostReadinessCreateResult>() == 8, "HostReadinessCreateResult size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<HostReadinessCreateResult>() == 4, "HostReadinessCreateResult alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::offset_of!(HostReadinessCreateResult, tag) == 4, "HostReadinessCreateResult tag offset mismatch");
+
+/// Tag discriminant for Try.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostReadinessSetResultTag {
+    Err = 0,
+    Ok = 1,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union HostReadinessSetResultPayload {
+    pub err: core::mem::ManuallyDrop<InvalidReadinessOrServerStoppingOrStaleReadiness>,
+    pub ok: [u8; 0],
+}
+
+#[cfg(target_pointer_width = "32")]
+#[repr(align(1))]
+#[derive(Clone, Copy)]
+pub struct HostReadinessSetResultPayloadAlignment;
+
+/// Tag union: Try
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostReadinessSetResult {
+    pub _payload_alignment: [HostReadinessSetResultPayloadAlignment; 0],
+    pub payload: [u8; 1],
+    pub tag: HostReadinessSetResultTag,
+}
+
+/// Tag union: Try
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostReadinessSetResult {
+    pub payload: HostReadinessSetResultPayload,
+    pub tag: HostReadinessSetResultTag,
+}
+
+impl HostReadinessSetResult {
+    #[cfg(target_pointer_width = "32")]
+    pub fn payload_err(&self) -> InvalidReadinessOrServerStoppingOrStaleReadiness {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const InvalidReadinessOrServerStoppingOrStaleReadiness) }
+    }
+
+    #[cfg(not(target_pointer_width = "32"))]
+    pub fn payload_err(&self) -> InvalidReadinessOrServerStoppingOrStaleReadiness {
+        unsafe { core::mem::ManuallyDrop::into_inner(self.payload.err) }
+    }
+
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<HostReadinessSetResult>() == 2, "HostReadinessSetResult size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<HostReadinessSetResult>() == 1, "HostReadinessSetResult alignment mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::offset_of!(HostReadinessSetResult, tag) == 1, "HostReadinessSetResult tag offset mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<HostReadinessSetResult>() == 2, "HostReadinessSetResult size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<HostReadinessSetResult>() == 1, "HostReadinessSetResult alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::offset_of!(HostReadinessSetResult, tag) == 1, "HostReadinessSetResult tag offset mismatch");
+
+/// Tag union: InvalidReadinessOrServerStoppingOrStaleReadiness
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvalidReadinessOrServerStoppingOrStaleReadiness {
+    InvalidReadiness = 0,
+    ServerStopping = 1,
+    StaleReadiness = 2,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<InvalidReadinessOrServerStoppingOrStaleReadiness>() == 1, "InvalidReadinessOrServerStoppingOrStaleReadiness size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<InvalidReadinessOrServerStoppingOrStaleReadiness>() == 1, "InvalidReadinessOrServerStoppingOrStaleReadiness alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<InvalidReadinessOrServerStoppingOrStaleReadiness>() == 1, "InvalidReadinessOrServerStoppingOrStaleReadiness size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<InvalidReadinessOrServerStoppingOrStaleReadiness>() == 1, "InvalidReadinessOrServerStoppingOrStaleReadiness alignment mismatch");
+
+/// Tag discriminant for Try.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HostPathTypeResultTag {
     Err = 0,
     Ok = 1,
@@ -4912,7 +5091,7 @@ pub enum InitForHostResultTag {
 #[derive(Clone, Copy)]
 pub union InitForHostResultPayload {
     pub err: core::mem::ManuallyDrop<i64>,
-    pub ok: core::mem::ManuallyDrop<AnonStruct9d4feaaa75529fdc>,
+    pub ok: core::mem::ManuallyDrop<AnonStructC9d7cf274e6253>,
 }
 
 #[cfg(target_pointer_width = "32")]
@@ -4926,7 +5105,7 @@ pub struct InitForHostResultPayloadAlignment;
 #[derive(Clone, Copy)]
 pub struct InitForHostResult {
     pub _payload_alignment: [InitForHostResultPayloadAlignment; 0],
-    pub payload: [u8; 96],
+    pub payload: [u8; 120],
     pub tag: InitForHostResultTag,
 }
 
@@ -4951,29 +5130,29 @@ impl InitForHostResult {
     }
 
     #[cfg(target_pointer_width = "32")]
-    pub fn payload_ok(&self) -> AnonStruct9d4feaaa75529fdc {
-        unsafe { core::ptr::read(self.payload.as_ptr() as *const AnonStruct9d4feaaa75529fdc) }
+    pub fn payload_ok(&self) -> AnonStructC9d7cf274e6253 {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const AnonStructC9d7cf274e6253) }
     }
 
     #[cfg(not(target_pointer_width = "32"))]
-    pub fn payload_ok(&self) -> AnonStruct9d4feaaa75529fdc {
+    pub fn payload_ok(&self) -> AnonStructC9d7cf274e6253 {
         unsafe { core::mem::ManuallyDrop::into_inner(self.payload.ok) }
     }
 
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<InitForHostResult>() == 136, "InitForHostResult size mismatch");
+const _: () = assert!(core::mem::size_of::<InitForHostResult>() == 184, "InitForHostResult size mismatch");
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(core::mem::align_of::<InitForHostResult>() == 8, "InitForHostResult alignment mismatch");
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::offset_of!(InitForHostResult, tag) == 128, "InitForHostResult tag offset mismatch");
+const _: () = assert!(core::mem::offset_of!(InitForHostResult, tag) == 176, "InitForHostResult tag offset mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::size_of::<InitForHostResult>() == 104, "InitForHostResult size mismatch");
+const _: () = assert!(core::mem::size_of::<InitForHostResult>() == 128, "InitForHostResult size mismatch");
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(core::mem::align_of::<InitForHostResult>() == 8, "InitForHostResult alignment mismatch");
 #[cfg(target_pointer_width = "32")]
-const _: () = assert!(core::mem::offset_of!(InitForHostResult, tag) == 96, "InitForHostResult tag offset mismatch");
+const _: () = assert!(core::mem::offset_of!(InitForHostResult, tag) == 120, "InitForHostResult tag offset mismatch");
 
 /// Tag discriminant for Try.
 #[repr(u8)]
@@ -5820,6 +5999,25 @@ const _: () = assert!(core::mem::size_of::<HostPathTypeArgs>() == 28, "HostPathT
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(core::mem::align_of::<HostPathTypeArgs>() == 4, "HostPathTypeArgs alignment mismatch");
 
+/// Arguments for Host.readiness_create!
+/// Roc signature: Bool => Try(Host.Readiness, [ReadinessCapacityExhausted])
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostReadinessCreateArgs {
+    pub arg0: bool,
+}
+
+/// Arguments for Host.readiness_set!
+/// Roc signature: Host.Readiness, Bool => Try({}, [InvalidReadiness, ServerStopping, StaleReadiness])
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostReadinessSetArgs {
+    pub arg0: *mut u64,
+    pub arg1: bool,
+}
+
 /// Arguments for Host.request_body_read!
 /// Roc signature: Host.RequestBody, U64 => Try([Chunk(List(U8)), End], [Cancelled, ClientDisconnected, ConcurrentRead, InvalidBody(Str), RequestFinished, TooLarge({ limit_bytes : U64, received_at_least : U64 })])
 /// Refcounted fields are owned by the hosted function.
@@ -6174,6 +6372,7 @@ pub type CancelledOrConnectFailedOrConnectionClosedOrDnsFailedOrExchangeFailedOr
 pub type HostHttpSendRequestOkHeaders = AnonStruct82a96c5d55d63488;
 pub type HostPathTypeArg0 = AnonStruct2e21b53659f79626;
 pub type HostPathTypeOk = AnonStruct8dfa7f17f2083a52;
+pub type HostReadinessSetErr = InvalidReadinessOrServerStoppingOrStaleReadiness;
 pub type HostRequestBodyReadErr = CancelledOrClientDisconnectedOrConcurrentReadOrInvalidBodyOrRequestFinishedOrTooLarge;
 pub type HostRequestBodyReadErrPayload = CancelledOrClientDisconnectedOrConcurrentReadOrInvalidBodyOrRequestFinishedOrTooLargePayload;
 pub type HostRequestBodyReadErrTag = CancelledOrClientDisconnectedOrConcurrentReadOrInvalidBodyOrRequestFinishedOrTooLargeTag;
@@ -6225,10 +6424,11 @@ pub type HostTcpReadUntilResultTag = HostTcpReadExactlyResultTag;
 pub type HostTcpReadUpToResult = HostTcpReadExactlyResult;
 pub type HostTcpReadUpToResultPayload = HostTcpReadExactlyResultPayload;
 pub type HostTcpReadUpToResultTag = HostTcpReadExactlyResultTag;
-pub type InitForHostOk = AnonStruct9d4feaaa75529fdc;
-pub type InitForHostOkConfig = AnonStructAeeb7f2cfe80f10;
+pub type InitForHostOk = AnonStructC9d7cf274e6253;
+pub type InitForHostOkConfig = AnonStruct5544d9f4d7da9aed;
 pub type InitForHostOkConfigFileRoots = AnonStruct3b01e35488cb00dc;
-pub type InitForHostOkConfigNativeRoutes = AnonStructFf6f93028827ced0;
+pub type InitForHostOkConfigNativeFileRoutes = AnonStructFf6f93028827ced0;
+pub type InitForHostOkConfigReadinessRoutes = AnonStruct88f5430c7a4d7d9d;
 pub type RespondForHostArg0 = AnonStruct9bfbda88f35e6056;
 pub type RespondForHostArg0Headers = AnonStruct82a96c5d55d63488;
 pub type RespondForHost = AnonStructAeceb9ea017a78f4;
@@ -7787,6 +7987,97 @@ impl HostRequestBodyReadAllResult {
     }
 }
 
+impl HostReadinessCreateResult {
+    /// Recursively decrement Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted payload.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let value = self;
+        let _ = roc_host;
+        match value.tag {
+            HostReadinessCreateResultTag::Err => {},
+            HostReadinessCreateResultTag::Ok => {
+                let payload = value.payload_ok();
+                unsafe { decref_box_with(payload as RocBox, core::mem::align_of::<u64>(), false, None, roc_host); }
+            },
+        }
+    }
+
+    /// Increment Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        let _ = amount;
+        match value.tag {
+            HostReadinessCreateResultTag::Err => {},
+            HostReadinessCreateResultTag::Ok => {
+                let payload = value.payload_ok();
+                unsafe { incref_box(payload as RocBox, amount); }
+            },
+        }
+    }
+}
+
+impl HostReadinessSetResult {
+    /// Recursively decrement Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted payload.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let value = self;
+        let _ = roc_host;
+        match value.tag {
+            HostReadinessSetResultTag::Err => {
+                let payload = value.payload_err();
+                unsafe { payload.decref(roc_host); }
+            },
+            HostReadinessSetResultTag::Ok => {},
+        }
+    }
+
+    /// Increment Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        let _ = amount;
+        match value.tag {
+            HostReadinessSetResultTag::Err => {
+                let payload = value.payload_err();
+                unsafe { payload.incref(amount); }
+            },
+            HostReadinessSetResultTag::Ok => {},
+        }
+    }
+}
+
+impl InvalidReadinessOrServerStoppingOrStaleReadiness {
+    /// Recursively decrement Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted payload.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let _ = self;
+        let _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let _ = self;
+        let _ = amount;
+    }
+}
+
 impl HostPathTypeResult {
     /// Recursively decrement Roc-owned payloads.
     ///
@@ -8546,7 +8837,7 @@ impl InitForHostResult {
     }
 }
 
-impl AnonStruct9d4feaaa75529fdc {
+impl AnonStructC9d7cf274e6253 {
     /// Recursively decrement Roc-owned fields.
     ///
     /// # Safety
@@ -8569,7 +8860,7 @@ impl AnonStruct9d4feaaa75529fdc {
     }
 }
 
-impl AnonStructAeeb7f2cfe80f10 {
+impl AnonStruct5544d9f4d7da9aed {
     /// Recursively decrement Roc-owned fields.
     ///
     /// # Safety
@@ -8588,7 +8879,27 @@ impl AnonStructAeeb7f2cfe80f10 {
         }
         unsafe { value.host.decref(roc_host); }
         {
-            let list = value.native_routes;
+            let list = value.liveness_routes;
+            if list.has_one_ref() {
+                for item_ref in list.allocation_items() {
+                    let item = *item_ref;
+                        unsafe { item.decref(roc_host); }
+                }
+            }
+            unsafe { list.decref(roc_host); }
+        }
+        {
+            let list = value.native_file_routes;
+            if list.has_one_ref() {
+                for item_ref in list.allocation_items() {
+                    let item = *item_ref;
+                        unsafe { item.decref(roc_host); }
+                }
+            }
+            unsafe { list.decref(roc_host); }
+        }
+        {
+            let list = value.readiness_routes;
             if list.has_one_ref() {
                 for item_ref in list.allocation_items() {
                     let item = *item_ref;
@@ -8608,7 +8919,9 @@ impl AnonStructAeeb7f2cfe80f10 {
         let value = self;
         unsafe { value.file_roots.incref(amount); }
         unsafe { value.host.incref(amount); }
-        unsafe { value.native_routes.incref(amount); }
+        unsafe { value.liveness_routes.incref(amount); }
+        unsafe { value.native_file_routes.incref(amount); }
+        unsafe { value.readiness_routes.incref(amount); }
     }
 }
 
@@ -8661,6 +8974,29 @@ impl AnonStructFf6f93028827ced0 {
         unsafe { value.at.incref(amount); }
         unsafe { value.relative.incref(amount); }
         unsafe { value.root_id.incref(amount); }
+    }
+}
+
+impl AnonStruct88f5430c7a4d7d9d {
+    /// Recursively decrement Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted field.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let value = self;
+        unsafe { value.at.decref(roc_host); }
+        unsafe { decref_box_with(value.readiness as RocBox, core::mem::align_of::<u64>(), false, None, roc_host); }
+    }
+
+    /// Increment Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        unsafe { value.at.incref(amount); }
+        unsafe { incref_box(value.readiness as RocBox, amount); }
     }
 }
 
@@ -8945,6 +9281,14 @@ unsafe extern "C" {
     /// Hosted symbol for Host.path_type!
     /// Roc signature: { is_windows : Bool, unix_bytes : List(U8), windows_u16s : List(U16) } => Try({ is_dir : Bool, is_file : Bool, is_sym_link : Bool }, IOErr)
     pub fn hosted_path_type(arg0: HostPathTypeArgs) -> HostPathTypeResult;
+
+    /// Hosted symbol for Host.readiness_create!
+    /// Roc signature: Bool => Try(Host.Readiness, [ReadinessCapacityExhausted])
+    pub fn hosted_readiness_create(arg0: bool) -> HostReadinessCreateResult;
+
+    /// Hosted symbol for Host.readiness_set!
+    /// Roc signature: Host.Readiness, Bool => Try({}, [InvalidReadiness, ServerStopping, StaleReadiness])
+    pub fn hosted_readiness_set(arg0: *mut u64, arg1: bool) -> HostReadinessSetResult;
 
     /// Hosted symbol for Host.request_body_read!
     /// Roc signature: Host.RequestBody, U64 => Try([Chunk(List(U8)), End], [Cancelled, ClientDisconnected, ConcurrentRead, InvalidBody(Str), RequestFinished, TooLarge({ limit_bytes : U64, received_at_least : U64 })])


### PR DESCRIPTION
Closes #183

## Summary

- add startup-declared native liveness and readiness exact routes
- add a bounded, ARC-owned, concurrency-safe readiness capability with explicit `Ready`, `NotReady`, stale, invalid, and stopping semantics
- route probes through one immutable native router before Roc handler admission, with fixed responses, method handling, metrics labels, and drain integration
- validate file and operational route topology atomically before binding the listener
- add cross-platform real-listener specifications for transitions, saturation, shutdown, methods, and startup failures

## Architecture

`NativeRouter` is now the single source of truth for every host-native exact route and prefix. File serving retains ownership of roots and transfer execution, while route topology, precedence, conflicts, and path validation live in the router.

`Server.Readiness` wraps a bounded host resource whose state is atomic. Native readiness routes retain an ARC lease, graceful drain makes every gate terminally not ready before request draining, and the shutdown hook observes `ServerStopping` on later updates.

The Roc API deliberately replaces the old list of file-only `NativeRoute` values with a complete `NativeRoutes` startup record. No compatibility layer is included.

Local validation now builds the checkout host, creates a target-specific Roc bundle, serves it over loopback, and rewrites temporary app copies to that URL. Checked-in release URLs are not mutated. This exposed and fixes the SQLite row decoder use of the previous compiler record-parser protocol.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --locked` (114 passed)
- pinned `python3 scripts/regenerate_glue.py --check`
- `python3 -m unittest scripts.test_harness_test` (24 passed)
- `python3 scripts/test.py --operation validate` (24 applications)
- `python3 scripts/test.py --operation build` (24 x64musl applications from the hosted local bundle)
- `python3 scripts/test.py --operation run` (35 real-listener cases passed)