### PR TITLE
Expose standard Base64 encoding

### DIFF
--- a/.github/actions/setup-roc/action.yml
+++ b/.github/actions/setup-roc/action.yml
@@ -1,10 +1,33 @@
 name: Install the pinned Roc compiler
 description: Install the exact new-compiler nightly used to generate and test this platform
 
+outputs:
+  nightly-tag:
+    description: The immutable nightly release tag read from .roc-version
+    value: ${{ steps.roc_version.outputs.tag }}
+  revision:
+    description: The Roc source revision embedded in the nightly release tag
+    value: ${{ steps.roc_version.outputs.revision }}
+
 runs:
   using: composite
   steps:
+    - id: roc_version
+      name: Read the pinned Roc nightly
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        tag=$(<.roc-version)
+        if [[ ! "$tag" =~ ^nightly-[0-9]{4}-[A-Za-z]+-[0-9]{1,2}-[0-9a-f]{7}$ ]]; then
+          echo "Invalid .roc-version nightly tag: $tag" >&2
+          exit 1
+        fi
+
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        echo "revision=${tag##*-}" >> "$GITHUB_OUTPUT"
+
     - uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427 # ratchet:roc-lang/setup-roc@v0.3.0
       with:
         version: nightly-new-compiler
-        nightly-tag: nightly-2026-July-29-fe0ab22
+        nightly-tag: ${{ steps.roc_version.outputs.tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install the Zig-based Roc compiler
+        id: roc
         uses: ./.github/actions/setup-roc
 
       - name: Install Zig
@@ -48,13 +49,14 @@ jobs:
       - name: Check Rust formatting
         run: cargo fmt --all -- --check
 
-      - name: Checkout the matching Roc glue specification
-        uses: actions/checkout@v7
-        with:
-          repository: roc-lang/roc
-          ref: fe0ab22cf0a764249330342fa36363624fc8157d
-          path: target/roc-glue-source
-          sparse-checkout: src/glue/src/RustGlue.roc
+      - name: Download the matching Roc glue specification
+        env:
+          ROC_REVISION: ${{ steps.roc.outputs.revision }}
+        run: |
+          mkdir -p target/roc-glue-source/src/glue/src
+          curl --fail --location --silent --show-error \
+            --output target/roc-glue-source/src/glue/src/RustGlue.roc \
+            "https://raw.githubusercontent.com/roc-lang/roc/${ROC_REVISION}/src/glue/src/RustGlue.roc"
 
       - name: Check generated Rust glue
         env:

--- a/.roc-version
+++ b/.roc-version
@@ -1,0 +1,1 @@
+nightly-2026-July-30-05b6fa0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,8 @@ for a distinct reusable workflow.
 - Native build tools for your operating system. Windows host builds require
   MSVC and the Windows SDK.
 
-The CI action in [`.github/actions/setup-roc`](.github/actions/setup-roc/action.yml)
-records the exact Roc nightly used by the repository.
+The [`.roc-version`](.roc-version) file records the exact Roc nightly used by
+the repository. The shared CI setup action reads the same pin.
 
 ## Build and run locally
 
@@ -108,7 +108,7 @@ rejects platform-specific expected results.
 
 Changes to the `hosted` or `provides` blocks in `platform/main.roc` require
 regenerating `src/roc_platform_abi.rs`. The compiler and `RustGlue.roc` must
-come from the matching revision recorded in `scripts/regenerate_glue.py`.
+come from the matching nightly recorded in [`.roc-version`](.roc-version).
 
 ```sh
 ROC_SRC=/path/to/roc python scripts/regenerate_glue.py

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The platform exposes typed modules for:
 - pooled SQLite connections, transactions, and prepared statements;
 - finite command execution with time and output limits;
 - filesystem, environment, path, stdout/stderr, TCP, time, and sleep effects;
-- HTML construction, URL handling, and multipart form parsing.
+- Base64 encoding, HTML construction, URL handling, and multipart form parsing.
 
 `UnixTime` provides the POSIX wall-clock effect and normalized timestamps,
 including nanosecond precision and instants before the Unix epoch. Calendar

--- a/examples/form-file-upload.roc
+++ b/examples/form-file-upload.roc
@@ -4,6 +4,7 @@ app [Context, program] {
 	http: "https://github.com/roc-lang/http/releases/download/1.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
 }
 
+import pf.Base64
 import pf.Server
 import pf.MultipartFormData
 import http.Response
@@ -55,7 +56,7 @@ display_uploaded_image! = |req| {
 		Ok(parts) =>
 			match parts.find_first(is_png_upload) {
 				Ok(part) => {
-					img = base64_encode(part.data)
+					img = Base64.encode(part.data)
 					page =
 						Str.to_utf8(
 							\\<!DOCTYPE html>
@@ -123,51 +124,3 @@ text_response = |status, body|
 	Response.from_status(status)
 		.with_headers([{ name: "Content-Type", value: "text/plain; charset=utf-8" }])
 		.with_body(Str.to_utf8(body))
-
-base64_encode : List(U8) -> Str
-base64_encode = |bytes| Str.from_utf8(base64_bytes(bytes, [])) ?? ""
-
-base64_alphabet : List(U8)
-base64_alphabet = Str.to_utf8("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
-
-base64_bytes : List(U8), List(U8) -> List(U8)
-base64_bytes = |remaining, out|
-	match remaining {
-		[] => out
-
-		[a] =>
-			out.concat(base64_quad(a, 0, 0, 1))
-
-		[a, b] =>
-			out.concat(base64_quad(a, b, 0, 2))
-
-		[a, b, c, ..] =>
-			base64_bytes(remaining.drop_first(3), out.concat(base64_quad(a, b, c, 3)))
-		}
-
-base64_quad : U8, U8, U8, U64 -> List(U8)
-base64_quad = |a, b, c, byte_count| {
-	bits = a.to_u64() * 65_536 + b.to_u64() * 256 + c.to_u64()
-	first = base64_byte(bits // 262_144)
-	second = base64_byte((bits // 4_096) % 64)
-	third = base64_byte((bits // 64) % 64)
-	fourth = base64_byte(bits % 64)
-
-	match byte_count {
-		1 => [first, second, '=', '=']
-		2 => [first, second, third, '=']
-		_ => [first, second, third, fourth]
-	}
-}
-
-base64_byte : U64 -> U8
-base64_byte = |index| base64_alphabet.get(index) ?? 'A'
-
-# These expectations cover empty input and the one- and two-byte tails that
-# require Base64 padding.
-expect {
-	base64_encode(Str.to_utf8("")) == ""
-		and base64_encode(Str.to_utf8("f")) == "Zg=="
-			and base64_encode(Str.to_utf8("fo")) == "Zm8="
-				and base64_encode(Str.to_utf8("foo")) == "Zm9v"
-}

--- a/platform/Base64.roc
+++ b/platform/Base64.roc
@@ -1,0 +1,66 @@
+## Encode arbitrary bytes using standard padded Base64 from
+## [RFC 4648](https://www.rfc-editor.org/rfc/rfc4648.html#section-4).
+##
+## Output uses the standard `A-Z`, `a-z`, `0-9`, `+`, `/` alphabet, includes
+## `=` padding, and never contains line breaks. This is not URL-safe or
+## unpadded Base64.
+Base64 := [].{
+
+	## Encode arbitrary bytes as an ASCII string.
+	##
+	## Input does not need to be valid UTF-8. The output length is exactly four
+	## bytes for every three input bytes, rounded up to a complete group:
+	## `4 * ceil(input byte count / 3)`.
+	encode : List(U8) -> Str
+	encode = |bytes| Str.from_utf8_lossy(encode_bytes(bytes, []))
+}
+
+alphabet : List(U8)
+alphabet = Str.to_utf8("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
+
+encode_bytes : List(U8), List(U8) -> List(U8)
+encode_bytes = |remaining, out|
+	match remaining {
+		[] => out
+		[a] => append_quad(out, a, 0, 0, 1)
+		[a, b] => append_quad(out, a, b, 0, 2)
+		[a, b, c, .. as rest] => encode_bytes(rest, append_quad(out, a, b, c, 3))
+	}
+
+append_quad : List(U8), U8, U8, U8, U64 -> List(U8)
+append_quad = |out, a, b, c, byte_count| {
+	bits = a.to_u64() * 65_536 + b.to_u64() * 256 + c.to_u64()
+	first = alphabet_byte(bits // 262_144)
+	second = alphabet_byte((bits // 4_096) % 64)
+	third = alphabet_byte((bits // 64) % 64)
+	fourth = alphabet_byte(bits % 64)
+
+	match byte_count {
+		1 => out.append(first).append(second).append('=').append('=')
+		2 => out.append(first).append(second).append(third).append('=')
+		_ => out.append(first).append(second).append(third).append(fourth)
+	}
+}
+
+alphabet_byte : U64 -> U8
+alphabet_byte = |index| alphabet.get(index) ?? 'A'
+
+## Encoding matches the RFC 4648 section 10 test vectors.
+expect {
+	Base64.encode(Str.to_utf8("")) == ""
+		and Base64.encode(Str.to_utf8("f")) == "Zg=="
+			and Base64.encode(Str.to_utf8("fo")) == "Zm8="
+				and Base64.encode(Str.to_utf8("foo")) == "Zm9v"
+					and Base64.encode(Str.to_utf8("foob")) == "Zm9vYg=="
+						and Base64.encode(Str.to_utf8("fooba")) == "Zm9vYmE="
+							and Base64.encode(Str.to_utf8("foobar")) == "Zm9vYmFy"
+}
+
+## Encoding accepts arbitrary non-UTF-8 bytes.
+expect Base64.encode([0x00, 0xFF, 0x80, 0xFE]) == "AP+A/g=="
+
+## One- and two-byte binary tails receive standard padding.
+expect {
+	Base64.encode([0xFF]) == "/w=="
+		and Base64.encode([0xFF, 0xEE]) == "/+4="
+}

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -16,6 +16,7 @@ platform "webserver"
 	}
 	exposes [
 		Attribute,
+		Base64,
 		Cmd,
 		Env,
 		File,
@@ -121,6 +122,7 @@ import Env
 import File
 import Host
 import Attribute
+import Base64
 import Html
 import Http
 import IOErr

--- a/scripts/regenerate_glue.py
+++ b/scripts/regenerate_glue.py
@@ -6,17 +6,34 @@ from __future__ import annotations
 import argparse
 import difflib
 import os
+import re
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 
 
-# Glue provenance: the committed Rust glue is generated with the compiler and
-# RustGlue.roc shipped together in nightly-2026-July-29-fe0ab22. Compiler and
-# glue-spec revisions must match.
 ROOT = Path(__file__).resolve().parents[1]
-KNOWN_GOOD_REVISION = "fe0ab22cf0a764249330342fa36363624fc8157d"
+ROC_VERSION_PATH = ROOT / ".roc-version"
+NIGHTLY_TAG_PATTERN = re.compile(
+    r"^nightly-[0-9]{4}-[A-Za-z]+-[0-9]{1,2}-([0-9a-f]{7})$"
+)
+
+
+def pinned_roc_version() -> tuple[str, str]:
+    try:
+        nightly_tag = ROC_VERSION_PATH.read_text(encoding="utf-8").strip()
+    except OSError as error:
+        raise SystemExit(f"Could not read {ROC_VERSION_PATH}: {error}") from error
+    match = NIGHTLY_TAG_PATTERN.fullmatch(nightly_tag)
+    if match is None:
+        raise SystemExit(
+            f"{ROC_VERSION_PATH} must contain exactly one immutable Roc nightly tag"
+        )
+    return nightly_tag, match.group(1)
+
+
+PINNED_NIGHTLY, PINNED_ROC_REVISION = pinned_roc_version()
 
 
 def rooted_path(value: str) -> Path:
@@ -44,10 +61,10 @@ def require_known_roc(roc: str) -> None:
         text=True,
     )
     version = f"{result.stdout}\n{result.stderr}"
-    if KNOWN_GOOD_REVISION[:7] not in version:
+    if PINNED_ROC_REVISION not in version:
         raise SystemExit(
             "Rust glue must be generated with the pinned Roc compiler "
-            f"{KNOWN_GOOD_REVISION[:7]}, but `roc version` reported:\n"
+            f"{PINNED_NIGHTLY}, but `roc version` reported:\n"
             f"{version.strip()}"
         )
 
@@ -108,7 +125,7 @@ def run_glue(roc: str, glue_spec: Path, platform_file: Path, out_dir: Path) -> N
         raise SystemExit(
             "Glue generation failed.\n"
             "Use matching Roc and RustGlue.roc revisions; "
-            f"{KNOWN_GOOD_REVISION} is the known-good pair."
+            f"{PINNED_NIGHTLY} is the pinned pair."
         )
 
 


### PR DESCRIPTION
## Summary

- expose pure standard padded Base64 encoding as pf.Base64
- replace the form upload example private encoder with the shared module
- pin nightly-2026-July-30-05b6fa0 in .roc-version and use it for CI setup and glue validation
- document the encoding contract and include it in generated platform docs

## Testing

- python3 scripts/test.py with the pinned Roc nightly: 26 applications built and all 52 runtime cases passed
- cargo test --locked: 169 tests passed
- matching-revision generated glue check passed
- generated API docs include Base64.encode
- Roc formatting passes for platform and examples

Closes #197