### PR TITLE
Expose bounded cryptographic random bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
  "cap-primitives",
  "flate2",
  "futures",
+ "getrandom 0.4.3",
  "h2",
  "http-body-util",
  "httpdate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ cap-primitives = "=4.0.2"
 flate2 = "=1.1.9"
 zstd = { version = "=0.13.3", default-features = false }
 futures = "=0.3.31"
+getrandom = { version = "=0.4.3", features = ["std"] }
 h2 = "=0.4.15"
 hyper = { version = "=1.6.0", features = ["http1", "http2", "client", "server"] }
 http-body-util = "=0.1.3"

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ The platform exposes typed modules for:
 - pooled outbound HTTP and HTTPS requests;
 - pooled SQLite connections, transactions, and prepared statements;
 - finite command execution with time and output limits;
-- filesystem, environment, path, stdout/stderr, TCP, time, and sleep effects;
+- filesystem, environment, path, cryptographic random bytes, stdout/stderr,
+  TCP, time, and sleep effects;
 - Base64 encoding, HTML construction, URL handling, and multipart form parsing.
 
 `UnixTime` provides the POSIX wall-clock effect and normalized timestamps,

--- a/examples/hello-web.roc
+++ b/examples/hello-web.roc
@@ -5,6 +5,8 @@ app [Context, program] {
 	gregorian: "https://cdn.jasperwoudenberg.com/roc-gregorian-v1.0.0-rc.2/Ce3xuHN92F5oGRuzjUTmm65jULAEj8pvvrTBmZJzE1M4.tar.zst",
 }
 
+import pf.Base64
+import pf.Random
 import pf.Server
 import pf.Stdout
 import pf.UnixTime
@@ -38,7 +40,17 @@ respond! = |request, _context| {
 	Stdout.line!("${datetime} ${Str.inspect(request.method())} ${Str.inspect(request.target())}")
 		? |err| ServerErr("Failed to log request: ${Str.inspect(err)}")
 
-	Ok(Server.respond(Response.from_status(200).with_body(Str.to_utf8("<b>Hello from server</b><br>"))))
+	body =
+		match request.target() {
+			Resource({ raw_path: "/random", .. }) => {
+				bytes = Random.bytes!(32)
+					? |err| ServerErr("Failed to obtain random bytes: ${Str.inspect(err)}")
+				Base64.encode(bytes)
+			}
+			_ => "<b>Hello from server</b><br>"
+		}
+
+	Ok(Server.respond(Response.from_status(200).with_body(Str.to_utf8(body))))
 }
 
 shutdown! : Server.ShutdownReason, Context => Try({}, [Exit(I64), ..])

--- a/platform/Host.roc
+++ b/platform/Host.roc
@@ -103,6 +103,11 @@ Host := [].{
 
 	ReadinessSetErr : [InvalidReadiness, StaleReadiness, ServerStopping]
 
+	RandomErr : [
+		EntropyUnavailable(IOErr),
+		TooManyBytes({ requested : U64, max : U64 }),
+	]
+
 	CmdExecErr : [FailedToGetExitCode(IOErr), Timeout, Saturated]
 
 	CmdOutputErr : [
@@ -158,6 +163,8 @@ Host := [].{
 
 	readiness_create! : Bool => Try(Readiness, [ReadinessCapacityExhausted])
 	readiness_set! : Readiness, Bool => Try({}, ReadinessSetErr)
+
+	random_bytes! : U64 => Try(List(U8), RandomErr)
 
 	path_type! : RawPath => Try(PathType, IOErr)
 

--- a/platform/Random.roc
+++ b/platform/Random.roc
@@ -1,0 +1,24 @@
+import Host
+import IOErr exposing [IOErr]
+
+## Obtain cryptographically secure random bytes from the operating system.
+##
+## The host returns exactly the requested number of bytes or a typed error.
+## Requests are limited to 65,536 bytes so the effect has a fixed allocation
+## bound. Call the effect again when an application needs more independent
+## random data.
+Random := [].{
+
+	## Obtain `count` cryptographically secure random bytes.
+	##
+	## A zero-byte request succeeds with an empty list. Requests above 65,536
+	## bytes fail before allocation.
+	bytes! : U64 => Try(
+		List(U8),
+		[
+			EntropyUnavailable(IOErr),
+			TooManyBytes({ requested : U64, max : U64 }),
+		],
+	)
+	bytes! = |count| Host.random_bytes!(count)
+}

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -26,6 +26,7 @@ platform "webserver"
 		MultipartFormData,
 		OsStr,
 		Path,
+		Random,
 		Server,
 		Sleep,
 		Sqlite,
@@ -78,6 +79,7 @@ platform "webserver"
 		"hosted_file_write_bytes": Host.file_write_bytes!,
 		"hosted_file_write_utf8": Host.file_write_utf8!,
 		"hosted_path_type": Host.path_type!,
+		"hosted_random_bytes": Host.random_bytes!,
 		"hosted_stdout_line": Host.stdout_line!,
 		"hosted_stdout_write": Host.stdout_write!,
 		"hosted_stdout_write_bytes": Host.stdout_write_bytes!,
@@ -128,6 +130,7 @@ import Http
 import IOErr
 import OsStr
 import Path
+import Random
 import Server
 import Sleep
 import Sqlite

--- a/scripts/test_spec.json
+++ b/scripts/test_spec.json
@@ -686,9 +686,14 @@
             },
             {
               "method": "GET",
+              "target": "/random",
+              "body_regex": ["^[A-Za-z0-9+/]{43}=$"]
+            },
+            {
+              "method": "GET",
               "target": "/metrics",
               "body_contains": [
-                "basic_webserver_http_requests_total{method=\"GET\",destination=\"roc\",completion=\"end_of_stream\"} 1",
+                "basic_webserver_http_requests_total{method=\"GET\",destination=\"roc\",completion=\"end_of_stream\"} 2",
                 "basic_webserver_http_requests_active 1",
                 "# EOF"
               ],

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -74,6 +74,14 @@ pub(crate) type PathTypeResultPayload = HostPathTypeResultPayload;
 pub(crate) type PathTypeResultTag = HostPathTypeResultTag;
 pub(crate) type PathInfo = HostPathTypeOk;
 
+pub(crate) type RandomBytesResult = HostRandomBytesResult;
+pub(crate) type RandomBytesResultPayload = HostRandomBytesResultPayload;
+pub(crate) type RandomBytesResultTag = HostRandomBytesResultTag;
+pub(crate) type RandomBytesError = HostRandomBytesErr;
+pub(crate) type RandomBytesErrorPayload = HostRandomBytesErrPayload;
+pub(crate) type RandomBytesErrorTag = HostRandomBytesErrTag;
+pub(crate) type RandomBytesTooMany = HostRandomBytesErrTooManyBytes;
+
 pub(crate) type SqliteHostOpenResult = HostSqliteOpenResult;
 pub(crate) type SqliteHostOpenResultPayload = HostSqliteOpenResultPayload;
 pub(crate) type SqliteHostOpenResultTag = HostSqliteOpenResultTag;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod http_server;
 mod native_router;
 mod os_str;
 mod path;
+mod random;
 mod readiness;
 mod request_body;
 mod request_limits;

--- a/src/random.rs
+++ b/src/random.rs
@@ -1,0 +1,272 @@
+use core::mem::ManuallyDrop;
+use std::io;
+
+use crate::abi::{
+    io_err_from_io, roc_host, RandomBytesError, RandomBytesErrorPayload, RandomBytesErrorTag,
+    RandomBytesResult, RandomBytesResultPayload, RandomBytesResultTag, RandomBytesTooMany,
+};
+use crate::roc_platform_abi::{RocHost, RocListWith};
+
+const MAX_RANDOM_BYTES: u64 = 64 * 1024;
+
+enum RandomFailure {
+    EntropyUnavailable(io::Error),
+    TooManyBytes,
+}
+
+fn random_bytes_with(
+    requested: u64,
+    roc_host: &RocHost,
+    fill: impl FnOnce(&mut [u8]) -> io::Result<()>,
+) -> Result<RocListWith<u8, false>, RandomFailure> {
+    if requested > MAX_RANDOM_BYTES {
+        return Err(RandomFailure::TooManyBytes);
+    }
+    if requested == 0 {
+        return Ok(RocListWith::empty());
+    }
+
+    let length = requested as usize;
+    // SAFETY: the limit above fits usize on every supported target. The
+    // allocation is initialized before a slice is formed, and it is either
+    // returned as an owned Roc list or released on failure.
+    let bytes = unsafe {
+        let bytes = RocListWith::<u8, false>::allocate(length, roc_host);
+        core::ptr::write_bytes(bytes.elements, 0, length);
+        bytes
+    };
+    let destination = unsafe { core::slice::from_raw_parts_mut(bytes.elements, length) };
+
+    match fill(destination) {
+        Ok(()) => Ok(bytes),
+        Err(error) => {
+            // Do not expose or log a partially filled destination.
+            unsafe { bytes.decref(roc_host) };
+            Err(RandomFailure::EntropyUnavailable(error))
+        }
+    }
+}
+
+fn random_error(failure: RandomFailure, requested: u64, roc_host: &RocHost) -> RandomBytesError {
+    let (tag, entropy, too_many) = match failure {
+        RandomFailure::EntropyUnavailable(error) => (
+            RandomBytesErrorTag::EntropyUnavailable,
+            Some(io_err_from_io(&error, roc_host)),
+            None,
+        ),
+        RandomFailure::TooManyBytes => (
+            RandomBytesErrorTag::TooManyBytes,
+            None,
+            Some(RandomBytesTooMany {
+                max: MAX_RANDOM_BYTES,
+                requested,
+            }),
+        ),
+    };
+
+    #[cfg(target_pointer_width = "32")]
+    unsafe {
+        let mut value: RandomBytesError = core::mem::zeroed();
+        match (entropy, too_many) {
+            (Some(error), None) => {
+                core::ptr::write(value.payload.as_mut_ptr().cast(), error);
+            }
+            (None, Some(limit)) => {
+                core::ptr::write(value.payload.as_mut_ptr().cast(), limit);
+            }
+            _ => unreachable!("random error payload does not match its tag"),
+        }
+        value.tag = tag;
+        value
+    }
+    #[cfg(not(target_pointer_width = "32"))]
+    {
+        let payload = match (entropy, too_many) {
+            (Some(error), None) => RandomBytesErrorPayload {
+                entropy_unavailable: ManuallyDrop::new(error),
+            },
+            (None, Some(limit)) => RandomBytesErrorPayload {
+                too_many_bytes: ManuallyDrop::new(limit),
+            },
+            _ => unreachable!("random error payload does not match its tag"),
+        };
+        RandomBytesError { payload, tag }
+    }
+}
+
+fn random_ok(bytes: RocListWith<u8, false>) -> RandomBytesResult {
+    #[cfg(target_pointer_width = "32")]
+    unsafe {
+        let mut result: RandomBytesResult = core::mem::zeroed();
+        core::ptr::write(result.payload.as_mut_ptr().cast(), bytes);
+        result.tag = RandomBytesResultTag::Ok;
+        result
+    }
+    #[cfg(not(target_pointer_width = "32"))]
+    {
+        RandomBytesResult {
+            payload: RandomBytesResultPayload {
+                ok: ManuallyDrop::new(bytes),
+            },
+            tag: RandomBytesResultTag::Ok,
+        }
+    }
+}
+
+fn random_err(error: RandomBytesError) -> RandomBytesResult {
+    #[cfg(target_pointer_width = "32")]
+    unsafe {
+        let mut result: RandomBytesResult = core::mem::zeroed();
+        core::ptr::write(result.payload.as_mut_ptr().cast(), error);
+        result.tag = RandomBytesResultTag::Err;
+        result
+    }
+    #[cfg(not(target_pointer_width = "32"))]
+    {
+        RandomBytesResult {
+            payload: RandomBytesResultPayload {
+                err: ManuallyDrop::new(error),
+            },
+            tag: RandomBytesResultTag::Err,
+        }
+    }
+}
+
+fn hosted_random_bytes_with(
+    requested: u64,
+    fill: impl FnOnce(&mut [u8]) -> io::Result<()>,
+) -> RandomBytesResult {
+    let roc_host = roc_host();
+    match random_bytes_with(requested, roc_host, fill) {
+        Ok(bytes) => random_ok(bytes),
+        Err(failure) => random_err(random_error(failure, requested, roc_host)),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn hosted_random_bytes(requested: u64) -> RandomBytesResult {
+    hosted_random_bytes_with(requested, |destination| {
+        getrandom::fill(destination).map_err(io::Error::from)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::*;
+    use crate::roc_platform_abi::IOErrTag;
+
+    fn initialize() {
+        crate::abi::initialize_test_roc_host();
+    }
+
+    fn take_ok(result: RandomBytesResult) -> Vec<u8> {
+        assert_eq!(result.tag, RandomBytesResultTag::Ok);
+        let bytes = result.payload_ok();
+        let owned = bytes.as_slice().to_vec();
+        unsafe { result.decref(roc_host()) };
+        owned
+    }
+
+    #[test]
+    fn zero_bytes_succeeds_without_calling_the_os_source() {
+        initialize();
+        let called = AtomicBool::new(false);
+        let result = hosted_random_bytes_with(0, |_| {
+            called.store(true, Ordering::Relaxed);
+            Ok(())
+        });
+
+        assert!(take_ok(result).is_empty());
+        assert!(!called.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn injected_source_fills_representative_lengths_exactly() {
+        initialize();
+        for length in [1, 31, 32, 33, MAX_RANDOM_BYTES] {
+            let result = hosted_random_bytes_with(length, |destination| {
+                for (index, byte) in destination.iter_mut().enumerate() {
+                    *byte = (index % 251) as u8;
+                }
+                Ok(())
+            });
+            let bytes = take_ok(result);
+
+            assert_eq!(bytes.len(), length as usize);
+            assert!(bytes
+                .iter()
+                .enumerate()
+                .all(|(index, byte)| *byte == (index % 251) as u8));
+        }
+    }
+
+    #[test]
+    fn oversized_request_fails_before_source_or_allocation() {
+        initialize();
+        let called = AtomicBool::new(false);
+        let requested = MAX_RANDOM_BYTES + 1;
+        let result = hosted_random_bytes_with(requested, |_| {
+            called.store(true, Ordering::Relaxed);
+            Ok(())
+        });
+
+        assert_eq!(result.tag, RandomBytesResultTag::Err);
+        let error = result.payload_err();
+        assert_eq!(error.tag, RandomBytesErrorTag::TooManyBytes);
+        let limit = error.payload_too_many_bytes();
+        assert_eq!(limit.requested, requested);
+        assert_eq!(limit.max, MAX_RANDOM_BYTES);
+        assert!(!called.load(Ordering::Relaxed));
+        unsafe { result.decref(roc_host()) };
+    }
+
+    #[test]
+    fn injected_entropy_failure_is_typed_and_does_not_return_bytes() {
+        initialize();
+        let result = hosted_random_bytes_with(32, |destination| {
+            destination.fill(0xA5);
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "injected entropy failure",
+            ))
+        });
+
+        assert_eq!(result.tag, RandomBytesResultTag::Err);
+        let error = result.payload_err();
+        assert_eq!(error.tag, RandomBytesErrorTag::EntropyUnavailable);
+        assert_eq!(
+            error.payload_entropy_unavailable().tag,
+            IOErrTag::PermissionDenied
+        );
+        unsafe { result.decref(roc_host()) };
+    }
+
+    #[test]
+    fn native_source_returns_exact_length() {
+        initialize();
+        assert_eq!(take_ok(hosted_random_bytes(32)).len(), 32);
+    }
+
+    #[test]
+    fn native_source_is_safe_under_concurrent_calls() {
+        initialize();
+        let threads: Vec<_> = (0..16)
+            .map(|_| {
+                std::thread::spawn(|| {
+                    for _ in 0..100 {
+                        if take_ok(hosted_random_bytes(32)).len() != 32 {
+                            return false;
+                        }
+                    }
+                    true
+                })
+            })
+            .collect();
+
+        assert!(threads
+            .into_iter()
+            .all(|thread| thread.join().expect("random worker panicked")));
+    }
+}

--- a/src/roc_platform_abi.rs
+++ b/src/roc_platform_abi.rs
@@ -1280,6 +1280,33 @@ const _: () = assert!(core::mem::size_of::<AnonStruct247809673488181b>() == 24, 
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(core::mem::align_of::<AnonStruct247809673488181b>() == 8, "AnonStruct247809673488181b alignment mismatch");
 
+/// Element type for __AnonStruct_fc642424773bfbcb
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AnonStructFc642424773bfbcb {
+    pub max: u64,
+    pub requested: u64,
+}
+
+/// Element type for __AnonStruct_fc642424773bfbcb
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AnonStructFc642424773bfbcb {
+    pub max: u64,
+    pub requested: u64,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<AnonStructFc642424773bfbcb>() == 16, "AnonStructFc642424773bfbcb size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<AnonStructFc642424773bfbcb>() == 8, "AnonStructFc642424773bfbcb alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<AnonStructFc642424773bfbcb>() == 16, "AnonStructFc642424773bfbcb size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<AnonStructFc642424773bfbcb>() == 8, "AnonStructFc642424773bfbcb alignment mismatch");
+
 /// Element type for __AnonStruct_8dfa7f17f2083a52
 #[cfg(target_pointer_width = "32")]
 #[repr(C)]
@@ -4440,6 +4467,156 @@ const _: () = assert!(core::mem::align_of::<InvalidReadinessOrServerStoppingOrSt
 /// Tag discriminant for Try.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostRandomBytesResultTag {
+    Err = 0,
+    Ok = 1,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union HostRandomBytesResultPayload {
+    pub err: core::mem::ManuallyDrop<EntropyUnavailableOrTooManyBytes>,
+    pub ok: core::mem::ManuallyDrop<RocListWith<u8, false>>,
+}
+
+#[cfg(target_pointer_width = "32")]
+#[repr(align(8))]
+#[derive(Clone, Copy)]
+pub struct HostRandomBytesResultPayloadAlignment;
+
+/// Tag union: Try
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostRandomBytesResult {
+    pub _payload_alignment: [HostRandomBytesResultPayloadAlignment; 0],
+    pub payload: [u8; 24],
+    pub tag: HostRandomBytesResultTag,
+}
+
+/// Tag union: Try
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostRandomBytesResult {
+    pub payload: HostRandomBytesResultPayload,
+    pub tag: HostRandomBytesResultTag,
+}
+
+impl HostRandomBytesResult {
+    #[cfg(target_pointer_width = "32")]
+    pub fn payload_err(&self) -> EntropyUnavailableOrTooManyBytes {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const EntropyUnavailableOrTooManyBytes) }
+    }
+
+    #[cfg(not(target_pointer_width = "32"))]
+    pub fn payload_err(&self) -> EntropyUnavailableOrTooManyBytes {
+        unsafe { core::mem::ManuallyDrop::into_inner(self.payload.err) }
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    pub fn payload_ok(&self) -> RocListWith<u8, false> {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const RocListWith<u8, false>) }
+    }
+
+    #[cfg(not(target_pointer_width = "32"))]
+    pub fn payload_ok(&self) -> RocListWith<u8, false> {
+        unsafe { core::mem::ManuallyDrop::into_inner(self.payload.ok) }
+    }
+
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<HostRandomBytesResult>() == 48, "HostRandomBytesResult size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<HostRandomBytesResult>() == 8, "HostRandomBytesResult alignment mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::offset_of!(HostRandomBytesResult, tag) == 40, "HostRandomBytesResult tag offset mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<HostRandomBytesResult>() == 32, "HostRandomBytesResult size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<HostRandomBytesResult>() == 8, "HostRandomBytesResult alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::offset_of!(HostRandomBytesResult, tag) == 24, "HostRandomBytesResult tag offset mismatch");
+
+/// Tag discriminant for EntropyUnavailableOrTooManyBytes.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntropyUnavailableOrTooManyBytesTag {
+    EntropyUnavailable = 0,
+    TooManyBytes = 1,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union EntropyUnavailableOrTooManyBytesPayload {
+    pub entropy_unavailable: core::mem::ManuallyDrop<IOErr>,
+    pub too_many_bytes: core::mem::ManuallyDrop<AnonStructFc642424773bfbcb>,
+}
+
+#[cfg(target_pointer_width = "32")]
+#[repr(align(8))]
+#[derive(Clone, Copy)]
+pub struct EntropyUnavailableOrTooManyBytesPayloadAlignment;
+
+/// Tag union: EntropyUnavailableOrTooManyBytes
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct EntropyUnavailableOrTooManyBytes {
+    pub _payload_alignment: [EntropyUnavailableOrTooManyBytesPayloadAlignment; 0],
+    pub payload: [u8; 16],
+    pub tag: EntropyUnavailableOrTooManyBytesTag,
+}
+
+/// Tag union: EntropyUnavailableOrTooManyBytes
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct EntropyUnavailableOrTooManyBytes {
+    pub payload: EntropyUnavailableOrTooManyBytesPayload,
+    pub tag: EntropyUnavailableOrTooManyBytesTag,
+}
+
+impl EntropyUnavailableOrTooManyBytes {
+    #[cfg(target_pointer_width = "32")]
+    pub fn payload_entropy_unavailable(&self) -> IOErr {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const IOErr) }
+    }
+
+    #[cfg(not(target_pointer_width = "32"))]
+    pub fn payload_entropy_unavailable(&self) -> IOErr {
+        unsafe { core::mem::ManuallyDrop::into_inner(self.payload.entropy_unavailable) }
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    pub fn payload_too_many_bytes(&self) -> AnonStructFc642424773bfbcb {
+        unsafe { core::ptr::read(self.payload.as_ptr() as *const AnonStructFc642424773bfbcb) }
+    }
+
+    #[cfg(not(target_pointer_width = "32"))]
+    pub fn payload_too_many_bytes(&self) -> AnonStructFc642424773bfbcb {
+        unsafe { core::mem::ManuallyDrop::into_inner(self.payload.too_many_bytes) }
+    }
+
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::size_of::<EntropyUnavailableOrTooManyBytes>() == 40, "EntropyUnavailableOrTooManyBytes size mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::align_of::<EntropyUnavailableOrTooManyBytes>() == 8, "EntropyUnavailableOrTooManyBytes alignment mismatch");
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(core::mem::offset_of!(EntropyUnavailableOrTooManyBytes, tag) == 32, "EntropyUnavailableOrTooManyBytes tag offset mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<EntropyUnavailableOrTooManyBytes>() == 24, "EntropyUnavailableOrTooManyBytes size mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::align_of::<EntropyUnavailableOrTooManyBytes>() == 8, "EntropyUnavailableOrTooManyBytes alignment mismatch");
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::offset_of!(EntropyUnavailableOrTooManyBytes, tag) == 16, "EntropyUnavailableOrTooManyBytes tag offset mismatch");
+
+/// Tag discriminant for Try.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HostPathTypeResultTag {
     Err = 0,
     Ok = 1,
@@ -6462,6 +6639,15 @@ const _: () = assert!(core::mem::size_of::<HostPathTypeArgs>() == 28, "HostPathT
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(core::mem::align_of::<HostPathTypeArgs>() == 4, "HostPathTypeArgs alignment mismatch");
 
+/// Arguments for Host.random_bytes!
+/// Roc signature: U64 => Try(List(U8), [EntropyUnavailable(IOErr), TooManyBytes({ max : U64, requested : U64 })])
+/// Refcounted fields are owned by the hosted function.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostRandomBytesArgs {
+    pub arg0: u64,
+}
+
 /// Arguments for Host.readiness_create!
 /// Roc signature: Bool => Try(Host.Readiness, [ReadinessCapacityExhausted])
 /// Refcounted fields are owned by the hosted function.
@@ -6848,6 +7034,11 @@ pub type CancelledOrConnectFailedOrConnectionClosedOrDnsFailedOrExchangeFailedOr
 pub type HostHttpSendRequestOkHeaders = AnonStruct82a96c5d55d63488;
 pub type HostPathTypeArg0 = AnonStruct2e21b53659f79626;
 pub type HostPathTypeOk = AnonStruct8dfa7f17f2083a52;
+pub type HostRandomBytesErr = EntropyUnavailableOrTooManyBytes;
+pub type HostRandomBytesErrPayload = EntropyUnavailableOrTooManyBytesPayload;
+pub type HostRandomBytesErrTag = EntropyUnavailableOrTooManyBytesTag;
+pub type HostRandomBytesErrTooManyBytes = AnonStructFc642424773bfbcb;
+pub type EntropyUnavailableOrTooManyBytesTooManyBytes = AnonStructFc642424773bfbcb;
 pub type HostReadinessSetErr = InvalidReadinessOrServerStoppingOrStaleReadiness;
 pub type HostRequestBodyReadErr = CancelledOrClientDisconnectedOrConcurrentReadOrInvalidBodyOrRequestFinishedOrStoppingOrTimeoutOrTooLarge;
 pub type HostRequestBodyReadErrPayload = CancelledOrClientDisconnectedOrConcurrentReadOrInvalidBodyOrRequestFinishedOrStoppingOrTimeoutOrTooLargePayload;
@@ -8751,6 +8942,111 @@ impl InvalidReadinessOrServerStoppingOrStaleReadiness {
     }
 }
 
+impl HostRandomBytesResult {
+    /// Recursively decrement Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted payload.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let value = self;
+        let _ = roc_host;
+        match value.tag {
+            HostRandomBytesResultTag::Err => {
+                let payload = value.payload_err();
+                unsafe { payload.decref(roc_host); }
+            },
+            HostRandomBytesResultTag::Ok => {
+                let payload = value.payload_ok();
+                unsafe { payload.decref(roc_host); }
+            },
+        }
+    }
+
+    /// Increment Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        let _ = amount;
+        match value.tag {
+            HostRandomBytesResultTag::Err => {
+                let payload = value.payload_err();
+                unsafe { payload.incref(amount); }
+            },
+            HostRandomBytesResultTag::Ok => {
+                let payload = value.payload_ok();
+                unsafe { payload.incref(amount); }
+            },
+        }
+    }
+}
+
+impl EntropyUnavailableOrTooManyBytes {
+    /// Recursively decrement Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted payload.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let value = self;
+        let _ = roc_host;
+        match value.tag {
+            EntropyUnavailableOrTooManyBytesTag::EntropyUnavailable => {
+                let payload = value.payload_entropy_unavailable();
+                unsafe { payload.decref(roc_host); }
+            },
+            EntropyUnavailableOrTooManyBytesTag::TooManyBytes => {
+                let payload = value.payload_too_many_bytes();
+                unsafe { payload.decref(roc_host); }
+            },
+        }
+    }
+
+    /// Increment Roc-owned payloads.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        let _ = amount;
+        match value.tag {
+            EntropyUnavailableOrTooManyBytesTag::EntropyUnavailable => {
+                let payload = value.payload_entropy_unavailable();
+                unsafe { payload.incref(amount); }
+            },
+            EntropyUnavailableOrTooManyBytesTag::TooManyBytes => {
+                let payload = value.payload_too_many_bytes();
+                unsafe { payload.incref(amount); }
+            },
+        }
+    }
+}
+
+impl AnonStructFc642424773bfbcb {
+    /// Recursively decrement Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must own one live Roc reference for each refcounted field.
+    pub unsafe fn decref(self, roc_host: &RocHost) {
+        let value = self;
+        let _ = value;
+        let _ = roc_host;
+    }
+
+    /// Increment Roc-owned fields.
+    ///
+    /// # Safety
+    /// `self` must point at live Roc allocations. The retained references must
+    /// be balanced by later decrefs.
+    pub unsafe fn incref(self, amount: isize) {
+        let value = self;
+        let _ = value;
+        let _ = amount;
+    }
+}
+
 impl HostPathTypeResult {
     /// Recursively decrement Roc-owned payloads.
     ///
@@ -10000,6 +10296,10 @@ unsafe extern "C" {
     /// Hosted symbol for Host.path_type!
     /// Roc signature: { is_windows : Bool, unix_bytes : List(U8), windows_u16s : List(U16) } => Try({ is_dir : Bool, is_file : Bool, is_sym_link : Bool }, IOErr)
     pub fn hosted_path_type(arg0: HostPathTypeArgs) -> HostPathTypeResult;
+
+    /// Hosted symbol for Host.random_bytes!
+    /// Roc signature: U64 => Try(List(U8), [EntropyUnavailable(IOErr), TooManyBytes({ max : U64, requested : U64 })])
+    pub fn hosted_random_bytes(arg0: u64) -> HostRandomBytesResult;
 
     /// Hosted symbol for Host.readiness_create!
     /// Roc signature: Bool => Try(Host.Readiness, [ReadinessCapacityExhausted])


### PR DESCRIPTION
Stacked on #205; review this PR after or on top of that Base64/nightly pin change.

## Summary

- expose `Random.bytes!` with exact-length OS cryptographic randomness
- enforce a 65,536-byte limit before allocation and return typed entropy/size failures
- release partially filled storage on failure without logging generated bytes
- cover zero, maximum, over-limit, representative lengths, injected failure, native entropy, and concurrent calls
- exercise the effect through the cross-platform HTTP runtime specification

## Verification

- `cargo test --locked` (175 passed)
- `python3 scripts/test.py --operation validate --roc <pinned-nightly>` (26 applications)
- `python3 scripts/test.py --roc <pinned-nightly>` (52 runtime cases)
- `python3 scripts/build.py --all` (`x64musl`, `arm64musl`)
- `scripts/regenerate_glue.py --check`

Closes #198