### PR TITLE
Bump nightly to 2026-08-10 and regenerate ABI glue

### DIFF
--- a/.github/actions/setup-roc/action.yml
+++ b/.github/actions/setup-roc/action.yml
@@ -34,7 +34,7 @@ runs:
               exit 1
             fi
             nightly_tag="$(sed 's/\r$//' "$version_file")"
-            if [[ ! "$nightly_tag" =~ ^nightly-[0-9]{4}-[A-Za-z]+-[0-9]{2}-[0-9a-f]{7}$ ]]; then
+            if [[ ! "$nightly_tag" =~ ^nightly-[0-9]{4}-([A-Za-z]+|[0-9]{2})-[0-9]{2}-[0-9a-f]{7}$ ]]; then
               echo "Invalid Roc nightly tag in $version_file: $nightly_tag"
               exit 1
             fi

--- a/.roc-version
+++ b/.roc-version
@@ -1,1 +1,1 @@
-nightly-2026-August-05-24f0b47
+nightly-2026-08-10-7df8509

--- a/scripts/regenerate_glue.py
+++ b/scripts/regenerate_glue.py
@@ -21,7 +21,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 ROC_VERSION_FILE = ROOT / ".roc-version"
 NIGHTLY_TAG = re.compile(
-    r"^nightly-[0-9]{4}-[A-Za-z]+-[0-9]{2}-([0-9a-f]{7})$"
+    r"^nightly-[0-9]{4}-(?:[A-Za-z]+|[0-9]{2})-[0-9]{2}-([0-9a-f]{7})$"
 )
 
 

--- a/src/roc_platform_abi.rs
+++ b/src/roc_platform_abi.rs
@@ -183,7 +183,7 @@ fn shifted_capacity(capacity: usize) -> usize {
 /// reference to the callee. The caller must not use or decref that ownership
 /// unit after the call. The callee consumes it exactly once, whether or not the
 /// result can reuse the allocation.
-pub type RocErasedCallableFn = extern "C" fn(*mut RocHost, *mut u8, *const u8, *mut u8, *mut u8);
+pub type RocErasedCallableFn = extern "C" fn(*mut RocHost, *mut u8, *const u8, *mut u8, *mut u8, *mut *const c_void);
 
 /// Final-drop callback for inline erased-callable captures.
 pub type RocErasedCallableOnDrop = extern "C" fn(*mut u8, *mut RocHost);
@@ -598,7 +598,7 @@ impl RocStr {
         }
         let rc = unsafe { (alloc_ptr as *mut AtomicIsize).sub(1) };
         if unsafe { (*rc).load(Ordering::Relaxed) } == 0 {
-            return; // REFCOUNT_STATIC_DATA — bytes are in read-only memory
+            return; // REFCOUNT_STATIC_DATA—bytes are in read-only memory
         }
         let prev = unsafe { (*rc).fetch_sub(1, Ordering::Release) };
         if prev == 1 {
@@ -839,7 +839,7 @@ impl<T, const ELEMENTS_REFCOUNTED: bool> RocListWith<T, ELEMENTS_REFCOUNTED> {
         let header_bytes = Self::header_bytes();
         let rc = unsafe { (alloc_ptr as *mut AtomicIsize).sub(1) };
         if unsafe { (*rc).load(Ordering::Relaxed) } == 0 {
-            return; // REFCOUNT_STATIC_DATA — elements are in read-only memory
+            return; // REFCOUNT_STATIC_DATA—elements are in read-only memory
         }
         let prev = unsafe { (*rc).fetch_sub(1, Ordering::Release) };
         if prev == 1 {


### PR DESCRIPTION
## Summary
- Pin `.roc-version` to the latest nightly, `nightly-2026-08-10-7df8509`
- Accept the new numeric-month nightly tag format (`nightly-YYYY-MM-DD-hash`) in the two tag-validation regexes (`.github/actions/setup-roc/action.yml`, `scripts/regenerate_glue.py`) — `roc-lang/nightlies` switched away from the spelled-out month name (`nightly-YYYY-MonthName-DD-hash`) starting 2026-08-06
- Regenerate `src/roc_platform_abi.rs` against the pinned compiler and its matching `RustGlue.roc`
